### PR TITLE
Go 1.18: rewrite `interface{}` to `any`

### DIFF
--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -98,10 +98,10 @@ type FullCachingSource struct {
 
 	prepareDirs sync.Once
 
-	usersMissBatch  func(interface{})
-	teamsMissBatch  func(interface{})
-	usersStaleBatch func(interface{})
-	teamsStaleBatch func(interface{})
+	usersMissBatch  func(any)
+	teamsMissBatch  func(any)
+	usersStaleBatch func(any)
+	teamsStaleBatch func(any)
 
 	// testing
 	populateSuccessCh chan struct{}
@@ -117,16 +117,16 @@ func NewFullCachingSource(g *libkb.GlobalContext, staleThreshold time.Duration, 
 		staleThreshold: staleThreshold,
 		simpleSource:   NewSimpleSource(),
 	}
-	batcher := func(intBatched interface{}, intSingle interface{}) interface{} {
+	batcher := func(intBatched any, intSingle any) any {
 		reqs, _ := intBatched.([]remoteFetchArg)
 		single, _ := intSingle.(remoteFetchArg)
 		return append(reqs, single)
 	}
-	reset := func() interface{} {
+	reset := func() any {
 		return []remoteFetchArg{}
 	}
-	actor := func(loadFn func(libkb.MetaContext, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)) func(interface{}) {
-		return func(intBatched interface{}) {
+	actor := func(loadFn func(libkb.MetaContext, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)) func(any) {
+		return func(intBatched any) {
 			reqs, _ := intBatched.([]remoteFetchArg)
 			s.makeRemoteFetchRequests(reqs, loadFn)
 		}
@@ -238,7 +238,7 @@ func (c *FullCachingSource) StopBackgroundTasks(mctx libkb.MetaContext) {
 	}
 }
 
-func (c *FullCachingSource) debug(m libkb.MetaContext, msg string, args ...interface{}) {
+func (c *FullCachingSource) debug(m libkb.MetaContext, msg string, args ...any) {
 	m.Debug("Avatars.FullCachingSource: %s", fmt.Sprintf(msg, args...))
 }
 
@@ -266,7 +266,7 @@ func (c *FullCachingSource) monitorAppState(m libkb.MetaContext) {
 
 func (c *FullCachingSource) processLRUHit(entry lru.DiskLRUEntry) (res lruEntry) {
 	var ok bool
-	if _, ok = entry.Value.(map[string]interface{}); ok {
+	if _, ok = entry.Value.(map[string]any); ok {
 		jstr, _ := json.Marshal(entry.Value)
 		_ = json.Unmarshal(jstr, &res)
 		return res

--- a/go/avatars/simple.go
+++ b/go/avatars/simple.go
@@ -69,7 +69,7 @@ func (s *SimpleSource) makeRes(res *keybase1.LoadAvatarsRes, apiRes apiAvatarRes
 	return nil
 }
 
-func (s *SimpleSource) debug(m libkb.MetaContext, msg string, args ...interface{}) {
+func (s *SimpleSource) debug(m libkb.MetaContext, msg string, args ...any) {
 	m.Debug("Avatars.SimpleSource: %s", fmt.Sprintf(msg, args...))
 }
 

--- a/go/avatars/srv.go
+++ b/go/avatars/srv.go
@@ -65,12 +65,12 @@ func (s *Srv) GetUserAvatar(username string) (string, error) {
 	return fmt.Sprintf("http://%v/av?typ=user&name=%v&format=square_192&token=%v", addr, username, token), nil
 }
 
-func (s *Srv) debug(msg string, args ...interface{}) {
+func (s *Srv) debug(msg string, args ...any) {
 	s.G().GetLog().Debug("Avatars.Srv: %s", fmt.Sprintf(msg, args...))
 }
 
 func (s *Srv) makeError(w http.ResponseWriter, code int, msg string,
-	args ...interface{}) {
+	args ...any) {
 	s.debug("serve: error code: %d msg %s", code, fmt.Sprintf(msg, args...))
 	w.WriteHeader(code)
 }

--- a/go/avatars/urlcaching.go
+++ b/go/avatars/urlcaching.go
@@ -36,7 +36,7 @@ func (c *URLCachingSource) StopBackgroundTasks(m libkb.MetaContext) {
 	c.diskLRU.Flush(m.Ctx(), m.G())
 }
 
-func (c *URLCachingSource) debug(m libkb.MetaContext, msg string, args ...interface{}) {
+func (c *URLCachingSource) debug(m libkb.MetaContext, msg string, args ...any) {
 	m.Debug("Avatars.URLCachingSource: %s", fmt.Sprintf(msg, args...))
 }
 

--- a/go/blindtree/defaults.go
+++ b/go/blindtree/defaults.go
@@ -12,7 +12,7 @@ const maxValuesPerLeaf = 1
 const keysByteLength = 16
 
 func GetCurrentBlindTreeConfig() (cfg merkletree2.Config) {
-	valueConstructor := func() interface{} { return BlindMerkleValue{} }
+	valueConstructor := func() any { return BlindMerkleValue{} }
 
 	cfg, err := merkletree2.NewConfig(
 		encodingType.GetEncoder(),
@@ -29,7 +29,7 @@ func GetCurrentBlindTreeConfig() (cfg merkletree2.Config) {
 
 // This config uses the non thread safe encoder.
 func GetCurrentBlindTreeConfigUnsafe() (cfg merkletree2.Config) {
-	valueConstructor := func() interface{} { return BlindMerkleValue{} }
+	valueConstructor := func() any { return BlindMerkleValue{} }
 
 	cfg, err := merkletree2.NewConfig(
 		encodingType.GetUnsafeEncoder(),

--- a/go/blindtree/values.go
+++ b/go/blindtree/values.go
@@ -12,7 +12,7 @@ import (
 // appropriate.
 type BlindMerkleValue struct {
 	ValueType  BlindMerkleValueType
-	InnerValue interface{}
+	InnerValue any
 }
 
 // Note: values up to 127 are preferred as they are encoded in a single byte

--- a/go/blindtree/values_test.go
+++ b/go/blindtree/values_test.go
@@ -18,7 +18,7 @@ func TestEncodeMerkleValues(t *testing.T) {
 	}
 
 	encodingTests := []struct {
-		Value        interface{}
+		Value        any
 		EncodedValue BlindMerkleValue
 		Type         BlindMerkleValueType
 	}{

--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -86,7 +86,7 @@ func NewAttachmentHTTPSrv(g *globals.Context, httpSrv *manager.Srv, fetcher type
 		fetcher:            fetcher,
 		httpSrv:            httpSrv,
 		hmacPool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				return hmac.New(sha256.New, token)
 			},
 		},
@@ -104,7 +104,7 @@ func (r *AttachmentHTTPSrv) GetAttachmentFetcher() types.AttachmentFetcher {
 	return r.fetcher
 }
 
-func (r *AttachmentHTTPSrv) genURLKey(prefix string, payload interface{}) (string, error) {
+func (r *AttachmentHTTPSrv) genURLKey(prefix string, payload any) (string, error) {
 	h := r.hmacPool.Get().(hash.Hash)
 	defer r.hmacPool.Put(h)
 	h.Reset()
@@ -118,7 +118,7 @@ func (r *AttachmentHTTPSrv) genURLKey(prefix string, payload interface{}) (strin
 	return prefix + hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func (r *AttachmentHTTPSrv) getURL(ctx context.Context, prefix string, payload interface{}) string {
+func (r *AttachmentHTTPSrv) getURL(ctx context.Context, prefix string, payload any) string {
 	if !r.httpSrv.Active() {
 		r.Debug(ctx, "getURL: http server failed to start earlier")
 		return ""
@@ -391,7 +391,7 @@ func (r *AttachmentHTTPSrv) serveGiphyLink(ctx context.Context, w http.ResponseW
 }
 
 func (r *AttachmentHTTPSrv) makeError(ctx context.Context, w http.ResponseWriter, code int, msg string,
-	args ...interface{}) {
+	args ...any) {
 	r.Debug(ctx, "serve: error code: %d msg %s", code, fmt.Sprintf(msg, args...))
 	w.WriteHeader(code)
 }

--- a/go/chat/attachments/utils.go
+++ b/go/chat/attachments/utils.go
@@ -269,7 +269,7 @@ func (fi kbfsFileInfo) ModTime() time.Time {
 func (fi kbfsFileInfo) IsDir() bool {
 	return fi.dirent.DirentType == keybase1.DirentType_DIR
 }
-func (fi kbfsFileInfo) Sys() interface{} { return fi.dirent }
+func (fi kbfsFileInfo) Sys() any { return fi.dirent }
 
 // StatOSOrKbfsFile stats the file located at p, using SimpleFSStat if it's a
 // KBFS path, or os.Stat if not.

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -1627,7 +1627,7 @@ func (b *Boxer) preBoxCheck(ctx context.Context, messagePlaintext chat1.MessageP
 	if err != nil {
 		return err
 	}
-	e := func(format string, args ...interface{}) error {
+	e := func(format string, args ...any) error {
 		return errors.New(fmt.Sprintf("malformed %v message: ", typ) + fmt.Sprintf(format, args...))
 	}
 	switch typ {
@@ -1876,7 +1876,7 @@ func (b *Boxer) boxV2orV3orV4(ctx context.Context, messagePlaintext chat1.Messag
 }
 
 // seal encrypts data into chat1.EncryptedData.
-func (b *Boxer) seal(data interface{}, key libkb.NaclSecretBoxKey) (*chat1.EncryptedData, error) {
+func (b *Boxer) seal(data any, key libkb.NaclSecretBoxKey) (*chat1.EncryptedData, error) {
 	s, err := b.marshal(data)
 	if err != nil {
 		return nil, err
@@ -1916,7 +1916,7 @@ func (b *Boxer) open(data chat1.EncryptedData, key libkb.NaclSecretBoxKey) ([]by
 
 // signMarshal signs data with a NaclSigningKeyPair, returning a chat1.SignatureInfo.
 // It marshals data before signing.
-func (b *Boxer) signMarshal(data interface{}, kp libkb.NaclSigningKeyPair, prefix kbcrypto.SignaturePrefix) (chat1.SignatureInfo, error) {
+func (b *Boxer) signMarshal(data any, kp libkb.NaclSigningKeyPair, prefix kbcrypto.SignaturePrefix) (chat1.SignatureInfo, error) {
 	encoded, err := b.marshal(data)
 	if err != nil {
 		return chat1.SignatureInfo{}, err
@@ -1927,7 +1927,7 @@ func (b *Boxer) signMarshal(data interface{}, kp libkb.NaclSigningKeyPair, prefi
 
 // signEncryptMarshal signencrypts data given an encryption and signing key, returning a chat1.SignEncryptedData.
 // It marshals data before signing.
-func (b *Boxer) signEncryptMarshal(data interface{}, encryptionKey libkb.NaclSecretBoxKey,
+func (b *Boxer) signEncryptMarshal(data any, encryptionKey libkb.NaclSecretBoxKey,
 	signingKeyPair libkb.NaclSigningKeyPair, prefix kbcrypto.SignaturePrefix) (chat1.SignEncryptedData, error) {
 	encoded, err := b.marshal(data)
 	if err != nil {
@@ -2164,7 +2164,7 @@ func (b *Boxer) keybase1KeybaseTimeToTime(t1 keybase1.KeybaseTime) time.Time {
 	return t2
 }
 
-func (b *Boxer) marshal(v interface{}) ([]byte, error) {
+func (b *Boxer) marshal(v any) ([]byte, error) {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	var data []byte
 	enc := codec.NewEncoderBytes(&data, &mh)
@@ -2174,7 +2174,7 @@ func (b *Boxer) marshal(v interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func (b *Boxer) unmarshal(data []byte, v interface{}) error {
+func (b *Boxer) unmarshal(data []byte, v any) error {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	dec := codec.NewDecoderBytes(data, &mh)
 	return dec.Decode(&v)

--- a/go/chat/boxer_canned_test.go
+++ b/go/chat/boxer_canned_test.go
@@ -162,7 +162,7 @@ func (cm cannedMessage) SenderDeviceID(t *testing.T) gregor1.DeviceID {
 	return did
 }
 
-func (cm cannedMessage) unhex(t *testing.T, out interface{}, inHex string) {
+func (cm cannedMessage) unhex(t *testing.T, out any, inHex string) {
 	bytes, err := hex.DecodeString(inHex)
 	require.NoError(t, err)
 	mh := codec.MsgpackHandle{WriteExt: true}

--- a/go/chat/convdevstorage.go
+++ b/go/chat/convdevstorage.go
@@ -49,7 +49,7 @@ func (s *ConvDevConversationBackedStorage) getMembersType(conv chat1.Conversatio
 }
 
 func (s *ConvDevConversationBackedStorage) PutToKnownConv(ctx context.Context, uid gregor1.UID,
-	conv chat1.ConversationLocal, src interface{}) (err error) {
+	conv chat1.ConversationLocal, src any) (err error) {
 	if s.adminOnly && !conv.ReaderInfo.UntrustedTeamRole.IsAdminOrAbove() {
 		return NewDevStoragePermissionDeniedError(conv.ReaderInfo.UntrustedTeamRole)
 	}
@@ -91,7 +91,7 @@ func (s *ConvDevConversationBackedStorage) PutToKnownConv(ctx context.Context, u
 }
 
 func (s *ConvDevConversationBackedStorage) Put(ctx context.Context, uid gregor1.UID,
-	convID chat1.ConversationID, name string, src interface{}) (err error) {
+	convID chat1.ConversationID, name string, src any) (err error) {
 	defer s.Trace(ctx, &err, "Put(%s)", name)()
 
 	var conv chat1.ConversationLocal
@@ -109,7 +109,7 @@ func (s *ConvDevConversationBackedStorage) Put(ctx context.Context, uid gregor1.
 }
 
 func (s *ConvDevConversationBackedStorage) GetFromKnownConv(ctx context.Context, uid gregor1.UID,
-	conv chat1.ConversationLocal, dest interface{}) (found bool, err error) {
+	conv chat1.ConversationLocal, dest any) (found bool, err error) {
 	defer s.Trace(ctx, &err, "GetFromKnownConv(%s)", conv.GetConvID())()
 	tv, err := s.G().ConvSource.Pull(ctx, conv.GetConvID(), uid, chat1.GetThreadReason_GENERAL, nil,
 		&chat1.GetThreadQuery{
@@ -148,7 +148,7 @@ func (s *ConvDevConversationBackedStorage) GetFromKnownConv(ctx context.Context,
 }
 
 func (s *ConvDevConversationBackedStorage) Get(ctx context.Context, uid gregor1.UID,
-	convID chat1.ConversationID, name string, dest interface{}, createConvIfMissing bool) (found bool, conv *chat1.ConversationLocal, err error) {
+	convID chat1.ConversationID, name string, dest any, createConvIfMissing bool) (found bool, conv *chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, &err, "Get(%s)", name)()
 
 	baseConv, err := utils.GetVerifiedConv(ctx, s.G(), uid, convID, types.InboxSourceDataSourceAll)

--- a/go/chat/devstorage.go
+++ b/go/chat/devstorage.go
@@ -29,7 +29,7 @@ func NewDevConversationBackedStorage(g *globals.Context, ri func() chat1.RemoteI
 	}
 }
 
-func (s *DevConversationBackedStorage) Put(ctx context.Context, uid gregor1.UID, name string, src interface{}) (err error) {
+func (s *DevConversationBackedStorage) Put(ctx context.Context, uid gregor1.UID, name string, src any) (err error) {
 	defer s.Trace(ctx, &err, "Put(%s)", name)()
 	un, err := s.G().GetUPAKLoader().LookupUsername(ctx, keybase1.UID(uid.String()))
 	if err != nil {
@@ -63,7 +63,7 @@ func (s *DevConversationBackedStorage) Put(ctx context.Context, uid gregor1.UID,
 }
 
 func (s *DevConversationBackedStorage) Get(ctx context.Context, uid gregor1.UID, name string,
-	dest interface{}) (found bool, err error) {
+	dest any) (found bool, err error) {
 	defer s.Trace(ctx, &err, "Get(%s)", name)()
 	un, err := s.G().GetUPAKLoader().LookupUsername(ctx, keybase1.UID(uid.String()))
 	if err != nil {

--- a/go/chat/ephemeral_purge_tracker.go
+++ b/go/chat/ephemeral_purge_tracker.go
@@ -363,14 +363,14 @@ func (t *EphemeralTracker) OnLogout(mctx libkb.MetaContext) error {
 	return nil
 }
 
-func decode(data []byte, res interface{}) error {
+func decode(data []byte, res any) error {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	dec := codec.NewDecoderBytes(data, &mh)
 	err := dec.Decode(res)
 	return err
 }
 
-func encode(input interface{}) ([]byte, error) {
+func encode(input any) ([]byte, error) {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	var data []byte
 	enc := codec.NewEncoderBytes(&data, &mh)

--- a/go/chat/ephemeral_purger.go
+++ b/go/chat/ephemeral_purger.go
@@ -74,7 +74,7 @@ func (pq *priorityQueue) Swap(i, j int) {
 // conversation to appear once in the heap. Use
 // `BackgroundEphemeralPurger.update` instead since it handles this as
 // intended.
-func (pq *priorityQueue) Push(x interface{}) {
+func (pq *priorityQueue) Push(x any) {
 	pq.Lock()
 	defer pq.Unlock()
 
@@ -84,7 +84,7 @@ func (pq *priorityQueue) Push(x interface{}) {
 	pq.itemMap[item.purgeInfo.ConvID.ConvIDStr()] = item
 }
 
-func (pq *priorityQueue) Pop() interface{} {
+func (pq *priorityQueue) Pop() any {
 	pq.Lock()
 	defer pq.Unlock()
 

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -263,7 +263,7 @@ func (e chatThreadConsistencyErrorImpl) Code() ConsistencyErrorCode {
 	return e.code
 }
 
-func NewChatThreadConsistencyError(code ConsistencyErrorCode, msg string, formatArgs ...interface{}) ChatThreadConsistencyError {
+func NewChatThreadConsistencyError(code ConsistencyErrorCode, msg string, formatArgs ...any) ChatThreadConsistencyError {
 	return &chatThreadConsistencyErrorImpl{
 		code: code,
 		msg:  fmt.Sprintf(msg, formatArgs...),
@@ -435,17 +435,17 @@ func (e OfflineError) Error() string {
 type OfflineClient struct {
 }
 
-func (e OfflineClient) Call(ctx context.Context, method string, arg interface{},
-	res interface{}, timeout time.Duration) error {
+func (e OfflineClient) Call(ctx context.Context, method string, arg any,
+	res any, timeout time.Duration) error {
 	return OfflineError{}
 }
 
-func (e OfflineClient) CallCompressed(ctx context.Context, method string, arg interface{},
-	res interface{}, ctype rpc.CompressionType, timeout time.Duration) error {
+func (e OfflineClient) CallCompressed(ctx context.Context, method string, arg any,
+	res any, ctype rpc.CompressionType, timeout time.Duration) error {
 	return OfflineError{}
 }
 
-func (e OfflineClient) Notify(ctx context.Context, method string, arg interface{}, timeout time.Duration) error {
+func (e OfflineClient) Notify(ctx context.Context, method string, arg any, timeout time.Duration) error {
 	return OfflineError{}
 }
 

--- a/go/chat/flip/chat_test.go
+++ b/go/chat/flip/chat_test.go
@@ -48,13 +48,13 @@ func (c *chatClient) ServerTime(context.Context) (time.Time, error) {
 	return c.Clock().Now(), nil
 }
 
-func testPrintf(fmtString string, args ...interface{}) {
+func testPrintf(fmtString string, args ...any) {
 	if testing.Verbose() {
 		fmt.Printf(fmtString, args...)
 	}
 }
 
-func (c *chatClient) CLogf(ctx context.Context, fmtString string, args ...interface{}) {
+func (c *chatClient) CLogf(ctx context.Context, fmtString string, args ...any) {
 	testPrintf(fmtString+"\n", args...)
 }
 

--- a/go/chat/flip/dealer.go
+++ b/go/chat/flip/dealer.go
@@ -92,7 +92,7 @@ type Game struct {
 	me                     *playerControl
 	commitmentCompleteHash Hash
 	clock                  func() clockwork.Clock
-	clogf                  func(ctx context.Context, fmt string, args ...interface{})
+	clogf                  func(ctx context.Context, fmt string, args ...any)
 
 	// To handle reorderings between CommitmentComplete and commitements,
 	// wee need some extra bookkeeping.

--- a/go/chat/flip/dealer_test.go
+++ b/go/chat/flip/dealer_test.go
@@ -35,7 +35,7 @@ func (t *testDealersHelper) ServerTime(context.Context) (time.Time, error) {
 	return t.clock.Now(), nil
 }
 
-func (t *testDealersHelper) CLogf(ctx context.Context, fmtString string, args ...interface{}) {
+func (t *testDealersHelper) CLogf(ctx context.Context, fmtString string, args ...any) {
 	testPrintf(fmtString+"\n", args...)
 }
 

--- a/go/chat/flip/flip.go
+++ b/go/chat/flip/flip.go
@@ -63,7 +63,7 @@ type Dealer struct {
 
 // ReplayHelper contains hooks needed to replay a flip.
 type ReplayHelper interface {
-	CLogf(ctx context.Context, fmt string, args ...interface{})
+	CLogf(ctx context.Context, fmt string, args ...any)
 }
 
 // DealersHelper is an interface that calling chat clients need to implement.

--- a/go/chat/flip/msgpack.go
+++ b/go/chat/flip/msgpack.go
@@ -10,12 +10,12 @@ func codecHandle() *codec.MsgpackHandle {
 	return &mh
 }
 
-func msgpackDecode(dst interface{}, src []byte) error {
+func msgpackDecode(dst any, src []byte) error {
 	h := codecHandle()
 	return codec.NewDecoderBytes(src, h).Decode(dst)
 }
 
-func msgpackEncode(src interface{}) ([]byte, error) {
+func msgpackEncode(src any) ([]byte, error) {
 	h := codecHandle()
 	var ret []byte
 	err := codec.NewEncoderBytes(&ret, h).Encode(src)

--- a/go/chat/flipmanager.go
+++ b/go/chat/flipmanager.go
@@ -1433,7 +1433,7 @@ func (m *FlipManager) IsFlipConversationCreated(ctx context.Context, outboxID ch
 }
 
 // CLogf implements the flip.DealersHelper interface
-func (m *FlipManager) CLogf(ctx context.Context, fmt string, args ...interface{}) {
+func (m *FlipManager) CLogf(ctx context.Context, fmt string, args ...any) {
 	m.Debug(ctx, fmt, args...)
 }
 

--- a/go/chat/globals/context.go
+++ b/go/chat/globals/context.go
@@ -176,7 +176,7 @@ func CtxAddLogTags(ctx context.Context, g *Context) context.Context {
 	// Add log tags
 	ctx = libkb.WithLogTagWithValue(ctx, "chat-trace", trace)
 
-	rpcTags := make(map[string]interface{})
+	rpcTags := make(map[string]any)
 	rpcTags["user-agent"] = libkb.UserAgent
 	rpcTags["platform"] = libkb.GetPlatformString()
 	rpcTags["apptype"] = g.GetAppType()

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -92,7 +92,7 @@ func TestInboxSourceSkipAhead(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	fatal := func(msg string, args ...interface{}) error {
+	fatal := func(msg string, args ...any) error {
 		t.Fatalf(msg, args...)
 		return fmt.Errorf(msg, args...)
 	}

--- a/go/chat/journey_card_manager.go
+++ b/go/chat/journey_card_manager.go
@@ -164,7 +164,7 @@ type JourneyCardManagerSingleUser struct {
 	encryptedDB *encrypteddb.EncryptedDB
 }
 
-type logFn func(ctx context.Context, format string, args ...interface{})
+type logFn func(ctx context.Context, format string, args ...any)
 
 func NewJourneyCardManagerSingleUser(g *globals.Context, ri func() chat1.RemoteInterface, uid gregor1.UID) *JourneyCardManagerSingleUser {
 	lru, err := lru.New(200)
@@ -237,7 +237,7 @@ func (cc *JourneyCardManagerSingleUser) PickCard(ctx context.Context,
 		// Journey cards are gated by either client-side flag KEYBASE_DEBUG_JOURNEYCARD or server-driven flag 'journeycard'.
 		return nil, nil
 	}
-	debugDebug := func(ctx context.Context, format string, args ...interface{}) {
+	debugDebug := func(ctx context.Context, format string, args ...any) {
 		if debug {
 			cc.Debug(ctx, format, args...)
 		}

--- a/go/chat/maps/srv.go
+++ b/go/chat/maps/srv.go
@@ -28,11 +28,11 @@ func NewSrv(g *globals.Context, httpSrv *manager.Srv) *Srv {
 	return s
 }
 
-func (s *Srv) debug(msg string, args ...interface{}) {
+func (s *Srv) debug(msg string, args ...any) {
 	s.G().GetLog().Debug("Maps.Srv: %s", fmt.Sprintf(msg, args...))
 }
 
-func (s *Srv) makeError(w http.ResponseWriter, code int, msg string, args ...interface{}) {
+func (s *Srv) makeError(w http.ResponseWriter, code int, msg string, args ...any) {
 	s.debug("serve: error code: %d msg %s", code, fmt.Sprintf(msg, args...))
 	w.WriteHeader(code)
 }

--- a/go/chat/pager/pager.go
+++ b/go/chat/pager/pager.go
@@ -33,7 +33,7 @@ func NewPager() Pager {
 	}
 }
 
-func (p Pager) encode(input interface{}) ([]byte, error) {
+func (p Pager) encode(input any) ([]byte, error) {
 	var data []byte
 	enc := codec.NewEncoderBytes(&data, p.codec)
 	if err := enc.Encode(input); err != nil {
@@ -42,14 +42,14 @@ func (p Pager) encode(input interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func (p Pager) decode(data []byte, res interface{}) error {
+func (p Pager) decode(data []byte, res any) error {
 	dec := codec.NewDecoderBytes(data, p.codec)
 	err := dec.Decode(res)
 	return err
 }
 
 func (p Pager) GetPage(getcond func(bool) string, page *chat1.Pagination,
-	pivot interface{}) (string, bool, error) {
+	pivot any) (string, bool, error) {
 
 	var dat []byte
 	var cond string
@@ -74,7 +74,7 @@ func (p Pager) GetPage(getcond func(bool) string, page *chat1.Pagination,
 	return cond, prev, nil
 }
 
-func (p Pager) MakePage(length, reqed int, next interface{}, prev interface{}) (*chat1.Pagination, error) {
+func (p Pager) MakePage(length, reqed int, next any, prev any) (*chat1.Pagination, error) {
 	prevEncoded, err := p.encode(prev)
 	if err != nil {
 		return nil, err

--- a/go/chat/participantsource.go
+++ b/go/chat/participantsource.go
@@ -29,7 +29,7 @@ type CachingParticipantSource struct {
 	encryptedDB *encrypteddb.EncryptedDB
 	sema        *semaphore.Weighted
 	locktab     *libkb.LockTable
-	notify      func(interface{})
+	notify      func(any)
 }
 
 var _ types.ParticipantSource = (*CachingParticipantSource)(nil)
@@ -41,17 +41,17 @@ func NewCachingParticipantSource(g *globals.Context, ri func() chat1.RemoteInter
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalChatDb
 	}
-	notify, notifyCancel := libkb.ThrottleBatch(func(batchedInt interface{}) {
+	notify, notifyCancel := libkb.ThrottleBatch(func(batchedInt any) {
 		batched, _ := batchedInt.(map[chat1.ConvIDStr][]chat1.UIParticipant)
 		g.NotifyRouter.HandleChatParticipantsInfo(context.Background(), batched)
-	}, func(batchedInt, singleInt interface{}) interface{} {
+	}, func(batchedInt, singleInt any) any {
 		batched, _ := batchedInt.(map[chat1.ConvIDStr][]chat1.UIParticipant)
 		single, _ := singleInt.(map[chat1.ConvIDStr][]chat1.UIParticipant)
 		for convIDStr, parts := range single {
 			batched[convIDStr] = parts
 		}
 		return batched
-	}, func() interface{} {
+	}, func() any {
 		return make(map[chat1.ConvIDStr][]chat1.UIParticipant)
 	},
 		200*time.Millisecond, true)

--- a/go/chat/remoteclient.go
+++ b/go/chat/remoteclient.go
@@ -23,8 +23,8 @@ func NewRemoteClient(g *globals.Context, cli rpc.GenericClient) *RemoteClient {
 	}
 }
 
-func (c *RemoteClient) Call(ctx context.Context, method string, arg interface{},
-	res interface{}, timeout time.Duration) (err error) {
+func (c *RemoteClient) Call(ctx context.Context, method string, arg any,
+	res any, timeout time.Duration) (err error) {
 	defer c.Trace(ctx, &err, method)()
 	err = c.cli.Call(ctx, method, arg, res, timeout)
 	if err == nil {
@@ -35,8 +35,8 @@ func (c *RemoteClient) Call(ctx context.Context, method string, arg interface{},
 	return err
 }
 
-func (c *RemoteClient) CallCompressed(ctx context.Context, method string, arg interface{},
-	res interface{}, ctype rpc.CompressionType, timeout time.Duration) (err error) {
+func (c *RemoteClient) CallCompressed(ctx context.Context, method string, arg any,
+	res any, ctype rpc.CompressionType, timeout time.Duration) (err error) {
 	defer c.Trace(ctx, &err, method)()
 	err = c.cli.CallCompressed(ctx, method, arg, res, ctype, timeout)
 	if err == nil {
@@ -47,7 +47,7 @@ func (c *RemoteClient) CallCompressed(ctx context.Context, method string, arg in
 	return err
 }
 
-func (c *RemoteClient) Notify(ctx context.Context, method string, arg interface{}, timeout time.Duration) (err error) {
+func (c *RemoteClient) Notify(ctx context.Context, method string, arg any, timeout time.Duration) (err error) {
 	defer c.Trace(ctx, &err, method)()
 	return c.cli.Notify(ctx, method, arg, timeout)
 }

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -18,17 +18,17 @@ import (
 
 type errorClient struct{}
 
-func (e errorClient) Call(ctx context.Context, method string, arg interface{},
-	res interface{}, timeout time.Duration) error {
+func (e errorClient) Call(ctx context.Context, method string, arg any,
+	res any, timeout time.Duration) error {
 	return fmt.Errorf("errorClient: Call %s", method)
 }
 
-func (e errorClient) CallCompressed(ctx context.Context, method string, arg interface{},
-	res interface{}, ctype rpc.CompressionType, timeout time.Duration) error {
+func (e errorClient) CallCompressed(ctx context.Context, method string, arg any,
+	res any, ctype rpc.CompressionType, timeout time.Duration) error {
 	return fmt.Errorf("errorClient: Call %s", method)
 }
 
-func (e errorClient) Notify(ctx context.Context, method string, arg interface{}, timeout time.Duration) error {
+func (e errorClient) Notify(ctx context.Context, method string, arg any, timeout time.Duration) error {
 	return fmt.Errorf("errorClient: Notify %s", method)
 }
 

--- a/go/chat/s3/s3.go
+++ b/go/chat/s3/s3.go
@@ -99,7 +99,6 @@ type Owner struct {
 }
 
 // Fold options into an Options struct
-//
 type Options struct {
 	SSE              bool
 	Meta             map[string][]string
@@ -639,41 +638,41 @@ type Key struct {
 //
 // For example, given these keys in a bucket:
 //
-//     index.html
-//     index2.html
-//     photos/2006/January/sample.jpg
-//     photos/2006/February/sample2.jpg
-//     photos/2006/February/sample3.jpg
-//     photos/2006/February/sample4.jpg
+//	index.html
+//	index2.html
+//	photos/2006/January/sample.jpg
+//	photos/2006/February/sample2.jpg
+//	photos/2006/February/sample3.jpg
+//	photos/2006/February/sample4.jpg
 //
 // Listing this bucket with delimiter set to "/" would yield the
 // following result:
 //
-//     &ListResp{
-//         Name:      "sample-bucket",
-//         MaxKeys:   1000,
-//         Delimiter: "/",
-//         Contents:  []Key{
-//             {Key: "index.html", "index2.html"},
-//         },
-//         CommonPrefixes: []string{
-//             "photos/",
-//         },
-//     }
+//	&ListResp{
+//	    Name:      "sample-bucket",
+//	    MaxKeys:   1000,
+//	    Delimiter: "/",
+//	    Contents:  []Key{
+//	        {Key: "index.html", "index2.html"},
+//	    },
+//	    CommonPrefixes: []string{
+//	        "photos/",
+//	    },
+//	}
 //
 // Listing the same bucket with delimiter set to "/" and prefix set to
 // "photos/2006/" would yield the following result:
 //
-//     &ListResp{
-//         Name:      "sample-bucket",
-//         MaxKeys:   1000,
-//         Delimiter: "/",
-//         Prefix:    "photos/2006/",
-//         CommonPrefixes: []string{
-//             "photos/2006/February/",
-//             "photos/2006/January/",
-//         },
-//     }
+//	&ListResp{
+//	    Name:      "sample-bucket",
+//	    MaxKeys:   1000,
+//	    Delimiter: "/",
+//	    Prefix:    "photos/2006/",
+//	    CommonPrefixes: []string{
+//	        "photos/2006/February/",
+//	        "photos/2006/January/",
+//	    },
+//	}
 //
 // See http://goo.gl/YjQTc for details.
 func (b *Bucket) List(prefix, delim, marker string, max int) (result *ListResp, err error) {
@@ -850,7 +849,7 @@ func (req *request) url() (*url.URL, error) {
 // query prepares and runs the req request.
 // If resp is not nil, the XML data contained in the response
 // body will be unmarshalled on it.
-func (s3 *S3) query(ctx context.Context, req *request, resp interface{}) error {
+func (s3 *S3) query(ctx context.Context, req *request, resp any) error {
 	err := s3.prepare(req)
 	if err == nil {
 		var httpResponse *http.Response
@@ -918,7 +917,7 @@ func (s3 *S3) prepare(req *request) error {
 // run sends req and returns the http response from the server.
 // If resp is not nil, the XML data contained in the response
 // body will be unmarshalled on it.
-func (s3 *S3) run(ctx context.Context, req *request, resp interface{}) (*http.Response, error) {
+func (s3 *S3) run(ctx context.Context, req *request, resp any) (*http.Response, error) {
 	if debug {
 		log.Printf("Running S3 request: %#v", req)
 	}

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -54,7 +54,7 @@ type Indexer struct {
 	clock        clockwork.Clock
 	eg           errgroup.Group
 	uid          gregor1.UID
-	storageCh    chan interface{}
+	storageCh    chan any
 
 	maxSyncConvs          int
 	startSyncDelay        time.Duration
@@ -81,7 +81,7 @@ func NewIndexer(g *globals.Context) *Indexer {
 		pokeSyncCh:   make(chan struct{}, 100),
 		clock:        clockwork.NewRealClock(),
 		flushDelay:   15 * time.Second,
-		storageCh:    make(chan interface{}, 100),
+		storageCh:    make(chan any, 100),
 	}
 	switch idx.G().GetAppType() {
 	case libkb.MobileAppType:
@@ -370,7 +370,7 @@ func (idx *Indexer) consumeResultsForTest(convID chat1.ConversationID, err error
 	}
 }
 
-func (idx *Indexer) storageDispatch(op interface{}) {
+func (idx *Indexer) storageDispatch(op any) {
 	select {
 	case idx.storageCh <- op:
 	default:

--- a/go/chat/signencrypt/codec.go
+++ b/go/chat/signencrypt/codec.go
@@ -579,7 +579,7 @@ type AEADMessage struct {
 // SealWithAssociatedData is a wrapper around SealWhole which adds an associatedData object
 // (see AEAD ciphers) which must be message-packable into bytes. This exact object is required
 // to call OpenWithAssociatedData on the ciphertext.
-func SealWithAssociatedData(msg []byte, associatedData interface{}, encKey SecretboxKey, signKey SignKey, signaturePrefix kbcrypto.SignaturePrefix, nonce Nonce) (ret []byte, err error) {
+func SealWithAssociatedData(msg []byte, associatedData any, encKey SecretboxKey, signKey SignKey, signaturePrefix kbcrypto.SignaturePrefix, nonce Nonce) (ret []byte, err error) {
 	adEncoded, err := msgpack.Encode(associatedData)
 	if err != nil {
 		return ret, err
@@ -597,7 +597,7 @@ func SealWithAssociatedData(msg []byte, associatedData interface{}, encKey Secre
 	return SealWhole(clearBytes, encKey, signKey, signaturePrefix, nonce), nil
 }
 
-func OpenWithAssociatedData(sealed []byte, associatedData interface{}, encKey SecretboxKey, verifyKey VerifyKey, signaturePrefix kbcrypto.SignaturePrefix, nonce Nonce) (ret []byte, err error) {
+func OpenWithAssociatedData(sealed []byte, associatedData any, encKey SecretboxKey, verifyKey VerifyKey, signaturePrefix kbcrypto.SignaturePrefix, nonce Nonce) (ret []byte, err error) {
 	clearBytes, err := OpenWhole(sealed, encKey, verifyKey, signaturePrefix, nonce)
 	if err != nil {
 		return ret, err
@@ -642,7 +642,7 @@ type Error struct {
 	Message string
 }
 
-func NewError(errorType ErrorType, message string, args ...interface{}) error {
+func NewError(errorType ErrorType, message string, args ...any) error {
 	return Error{
 		Type:    errorType,
 		Message: fmt.Sprintf(message, args...),

--- a/go/chat/signencrypt/codec_test.go
+++ b/go/chat/signencrypt/codec_test.go
@@ -31,7 +31,7 @@ type arbitraryNested struct {
 	Boring arbitraryMsg `codec:"b" json:"b"`
 }
 
-var associatedDataInputs = []interface{}{
+var associatedDataInputs = []any{
 	"",
 	nil,
 	map[string]map[float64]map[string]string{"first": {2.22000222: {"third": "fourth"}}},
@@ -90,7 +90,7 @@ func zeroOpenWhole(plaintext []byte) ([]byte, error) {
 	return OpenWhole(plaintext, zeroSecretboxKey(), zeroVerifyKey(), testingPrefix(), zeroNonce())
 }
 
-func zeroSealWithAssociatedData(plaintext []byte, associatedData interface{}) []byte {
+func zeroSealWithAssociatedData(plaintext []byte, associatedData any) []byte {
 	res, err := SealWithAssociatedData(plaintext, associatedData, zeroSecretboxKey(), zeroSignKey(), testingPrefix(), zeroNonce())
 	if err != nil {
 		// this should never actually error
@@ -99,7 +99,7 @@ func zeroSealWithAssociatedData(plaintext []byte, associatedData interface{}) []
 	return res
 }
 
-func zeroOpenWithAssociatedData(plaintext []byte, associatedData interface{}) ([]byte, error) {
+func zeroOpenWithAssociatedData(plaintext []byte, associatedData any) ([]byte, error) {
 	return OpenWithAssociatedData(plaintext, associatedData, zeroSecretboxKey(), zeroVerifyKey(), testingPrefix(), zeroNonce())
 }
 

--- a/go/chat/signencrypt/example/main.go
+++ b/go/chat/signencrypt/example/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/keybase/go-crypto/ed25519"
 )
 
-func failf(format string, args ...interface{}) {
+func failf(format string, args ...any) {
 	log.Print(fmt.Sprintf(format, args...))
 	os.Exit(1)
 }

--- a/go/chat/storage/basebox.go
+++ b/go/chat/storage/basebox.go
@@ -35,11 +35,11 @@ func newBaseBox(g *globals.Context) *baseBox {
 	}
 }
 
-func (i *baseBox) readDiskBox(ctx context.Context, key libkb.DbKey, res interface{}) (bool, error) {
+func (i *baseBox) readDiskBox(ctx context.Context, key libkb.DbKey, res any) (bool, error) {
 	return i.encryptedDB.Get(ctx, key, res)
 }
 
-func (i *baseBox) writeDiskBox(ctx context.Context, key libkb.DbKey, data interface{}) error {
+func (i *baseBox) writeDiskBox(ctx context.Context, key libkb.DbKey, data any) error {
 	return i.encryptedDB.Put(ctx, key, data)
 }
 

--- a/go/chat/storage/errors.go
+++ b/go/chat/storage/errors.go
@@ -30,7 +30,7 @@ func (e InternalError) Message() string {
 	return e.Msg
 }
 
-func NewInternalError(ctx context.Context, d utils.DebugLabeler, msg string, args ...interface{}) InternalError {
+func NewInternalError(ctx context.Context, d utils.DebugLabeler, msg string, args ...any) InternalError {
 	d.Debug(ctx, "internal chat storage error: "+msg, args...)
 	return InternalError{Msg: fmt.Sprintf(msg, args...)}
 }

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -98,7 +98,7 @@ func makeBlockIndexKey(convID chat1.ConversationID, uid gregor1.UID) libkb.DbKey
 	}
 }
 
-func encode(input interface{}) ([]byte, error) {
+func encode(input any) ([]byte, error) {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	var data []byte
 	enc := codec.NewEncoderBytes(&data, &mh)
@@ -108,7 +108,7 @@ func encode(input interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func decode(data []byte, res interface{}) error {
+func decode(data []byte, res any) error {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	dec := codec.NewDecoderBytes(data, &mh)
 	err := dec.Decode(res)
@@ -686,7 +686,7 @@ func (s *Storage) flatten(m map[chat1.MessageID]chat1.MessageUnboxed) (res []cha
 func (s *Storage) updateMinDeletableMessage(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, msgs []chat1.MessageUnboxed) Error {
 
-	de := func(format string, args ...interface{}) {
+	de := func(format string, args ...any) {
 		s.Debug(ctx, "updateMinDeletableMessage: "+fmt.Sprintf(format, args...))
 	}
 
@@ -736,11 +736,12 @@ func (s *Storage) updateMinDeletableMessage(ctx context.Context, convID chat1.Co
 // Returns a non-nil expunge if deletes happened.
 // Shortcircuits so it's ok to call a lot.
 // The actual effect will be to delete upto the max of `expungeExplicit` (which can be nil)
-//   and the DeleteHistory-type messages.
+//
+//	and the DeleteHistory-type messages.
 func (s *Storage) handleDeleteHistory(ctx context.Context, conv types.UnboxConversationInfo,
 	uid gregor1.UID, msgs []chat1.MessageUnboxed, expungeExplicit *chat1.Expunge) (*chat1.Expunge, Error) {
 
-	de := func(format string, args ...interface{}) {
+	de := func(format string, args ...any) {
 		s.Debug(ctx, "handleDeleteHistory: "+fmt.Sprintf(format, args...))
 	}
 
@@ -824,7 +825,7 @@ func (s *Storage) applyExpunge(ctx context.Context, conv types.UnboxConversation
 	convID := conv.GetConvID()
 	s.Debug(ctx, "applyExpunge(%v, %v, %v)", convID, uid, expunge.Upto)
 
-	de := func(format string, args ...interface{}) {
+	de := func(format string, args ...any) {
 		s.Debug(ctx, "applyExpunge: "+fmt.Sprintf(format, args...))
 	}
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -461,16 +461,16 @@ type StellarSender interface {
 }
 
 type ConvConversationBackedStorage interface {
-	Put(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, name string, data interface{}) error
-	PutToKnownConv(ctx context.Context, uid gregor1.UID, conv chat1.ConversationLocal, data interface{}) error
-	Get(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, name string, res interface{},
+	Put(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, name string, data any) error
+	PutToKnownConv(ctx context.Context, uid gregor1.UID, conv chat1.ConversationLocal, data any) error
+	Get(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, name string, res any,
 		createConvIfMissing bool) (bool, *chat1.ConversationLocal, error)
-	GetFromKnownConv(ctx context.Context, uid gregor1.UID, conv chat1.ConversationLocal, dest interface{}) (bool, error)
+	GetFromKnownConv(ctx context.Context, uid gregor1.UID, conv chat1.ConversationLocal, dest any) (bool, error)
 }
 
 type UserConversationBackedStorage interface {
-	Put(ctx context.Context, uid gregor1.UID, name string, data interface{}) error
-	Get(ctx context.Context, uid gregor1.UID, name string, res interface{}) (bool, error)
+	Put(ctx context.Context, uid gregor1.UID, name string, data any) error
+	Get(ctx context.Context, uid gregor1.UID, name string, res any) (bool, error)
 }
 
 type WhitelistExemption interface {

--- a/go/chat/uiinboxloader.go
+++ b/go/chat/uiinboxloader.go
@@ -32,7 +32,7 @@ type UIInboxLoader struct {
 	eg      errgroup.Group
 
 	clock                 clockwork.Clock
-	transmitCh            chan interface{}
+	transmitCh            chan any
 	layoutCh              chan chat1.InboxLayoutReselectMode
 	bigTeamUnboxCh        chan []chat1.ConversationID
 	convTransmitBatch     map[chat1.ConvIDStr]chat1.ConversationLocal
@@ -73,7 +73,7 @@ func (h *UIInboxLoader) Start(ctx context.Context, uid gregor1.UID) {
 	if h.started {
 		return
 	}
-	h.transmitCh = make(chan interface{}, 1000)
+	h.transmitCh = make(chan any, 1000)
 	h.layoutCh = make(chan chat1.InboxLayoutReselectMode, 1000)
 	h.bigTeamUnboxCh = make(chan []chat1.ConversationID, 1000)
 	h.stopCh = make(chan struct{})
@@ -249,7 +249,7 @@ func (h *UIInboxLoader) flushFailed(r failedResponse) {
 	}
 }
 
-func (h *UIInboxLoader) transmitOnce(imsg interface{}) {
+func (h *UIInboxLoader) transmitOnce(imsg any) {
 	switch msg := imsg.(type) {
 	case unverifiedResponse:
 		_ = h.flushConvBatch()

--- a/go/chat/unfurl/cache.go
+++ b/go/chat/unfurl/cache.go
@@ -13,7 +13,7 @@ const defaultCacheLifetime = 10 * time.Minute
 const defaultCacheSize = 1000
 
 type cacheItem struct {
-	data  interface{}
+	data  any
 	ctime gregor1.Time
 }
 
@@ -60,7 +60,7 @@ func (c *unfurlCache) get(key string) (res cacheItem, ok bool) {
 	return cacheItem, valid
 }
 
-func (c *unfurlCache) put(key string, data interface{}) {
+func (c *unfurlCache) put(key string, data any) {
 	c.Lock()
 	defer c.Unlock()
 	c.cache.Add(key, cacheItem{

--- a/go/chat/unfurl/settings_test.go
+++ b/go/chat/unfurl/settings_test.go
@@ -24,7 +24,7 @@ func newMemConversationBackedStorage() *memConversationBackedStorage {
 	}
 }
 
-func (s *memConversationBackedStorage) Get(ctx context.Context, uid gregor1.UID, name string, res interface{}) (bool, error) {
+func (s *memConversationBackedStorage) Get(ctx context.Context, uid gregor1.UID, name string, res any) (bool, error) {
 	s.Lock()
 	defer s.Unlock()
 	dat, ok := s.storage[name]
@@ -35,7 +35,7 @@ func (s *memConversationBackedStorage) Get(ctx context.Context, uid gregor1.UID,
 	return true, err
 }
 
-func (s *memConversationBackedStorage) Put(ctx context.Context, uid gregor1.UID, name string, src interface{}) error {
+func (s *memConversationBackedStorage) Put(ctx context.Context, uid gregor1.UID, name string, src any) error {
 	s.Lock()
 	defer s.Unlock()
 	dat, err := json.Marshal(src)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -533,21 +533,21 @@ func (d DebugLabeler) showLog() bool {
 	return true
 }
 
-func (d DebugLabeler) Debug(ctx context.Context, msg string, args ...interface{}) {
+func (d DebugLabeler) Debug(ctx context.Context, msg string, args ...any) {
 	if d.showLog() {
 		d.G().GetLog().CDebugf(ctx, "++Chat: | "+d.label+": "+msg, args...)
 	}
 }
 
-func (d DebugLabeler) Trace(ctx context.Context, err *error, format string, args ...interface{}) func() {
+func (d DebugLabeler) Trace(ctx context.Context, err *error, format string, args ...any) func() {
 	return d.trace(ctx, d.G().GetLog(), err, format, args...)
 }
 
-func (d DebugLabeler) PerfTrace(ctx context.Context, err *error, format string, args ...interface{}) func() {
+func (d DebugLabeler) PerfTrace(ctx context.Context, err *error, format string, args ...any) func() {
 	return d.trace(ctx, d.G().GetPerfLog(), err, format, args...)
 }
 
-func (d DebugLabeler) trace(ctx context.Context, log logger.Logger, err *error, format string, args ...interface{}) func() {
+func (d DebugLabeler) trace(ctx context.Context, log logger.Logger, err *error, format string, args ...any) func() {
 	if d.showLog() {
 		msg := fmt.Sprintf(format, args...)
 		start := time.Now()
@@ -2555,7 +2555,7 @@ func EscapeForDecorate(ctx context.Context, body string) string {
 	})
 }
 
-func DecorateBody(ctx context.Context, body string, offset, length int, decoration interface{}) (res string, added int) {
+func DecorateBody(ctx context.Context, body string, offset, length int, decoration any) (res string, added int) {
 	out, err := json.Marshal(decoration)
 	if err != nil {
 		return res, 0

--- a/go/citogo/main.go
+++ b/go/citogo/main.go
@@ -36,7 +36,7 @@ type opts struct {
 	Pause                time.Duration
 }
 
-func logError(f string, args ...interface{}) {
+func logError(f string, args ...any) {
 	s := fmt.Sprintf(f, args...)
 	if s[len(s)-1] != '\n' {
 		s += "\n"

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -266,7 +266,7 @@ func (c *chatServiceHandler) GetUnfurlSettingsV1(ctx context.Context) Reply {
 		return c.errReply(err)
 	}
 	return Reply{
-		Result: map[string]interface{}{
+		Result: map[string]any{
 			"mode":      strings.ToLower(chat1.UnfurlModeRevMap[res.Mode]),
 			"whitelist": res.Whitelist,
 		},

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -142,7 +142,7 @@ func sendPing(cli keybase1.SessionClient) error {
 	return cli.SessionPing(ctx)
 }
 
-func (c *CmdChatAPIListen) ErrWriteLn(format string, obj ...interface{}) {
+func (c *CmdChatAPIListen) ErrWriteLn(format string, obj ...any) {
 	_, _ = c.G().UI.GetTerminalUI().ErrorWriter().Write([]byte(fmt.Sprintf(format, obj...) + "\n"))
 }
 
@@ -222,17 +222,17 @@ func newBaseNotificationDisplay(g *libkb.GlobalContext) *baseNotificationDisplay
 	}
 }
 
-func (d *baseNotificationDisplay) printf(fmt string, args ...interface{}) error {
+func (d *baseNotificationDisplay) printf(fmt string, args ...any) error {
 	_, err := d.G().UI.GetTerminalUI().Printf(fmt, args...)
 	return err
 }
 
-func (d *baseNotificationDisplay) errorf(format string, args ...interface{}) error {
+func (d *baseNotificationDisplay) errorf(format string, args ...any) error {
 	_, err := d.G().UI.GetTerminalUI().ErrorWriter().Write([]byte(fmt.Sprintf(format, args...)))
 	return err
 }
 
-func (d *baseNotificationDisplay) printJSON(data interface{}) {
+func (d *baseNotificationDisplay) printJSON(data any) {
 	if jsonStr, err := json.Marshal(data); err != nil {
 		_ = d.errorf("Error while marshaling JSON: %s\n", err)
 	} else {

--- a/go/client/cmd_chat_retention.go
+++ b/go/client/cmd_chat_retention.go
@@ -315,6 +315,6 @@ func (c *CmdChatSetRetention) parseExpireAgeLimited(s string) (gregor1.DurationS
 	return gregor1.DurationSec(d.Seconds()), nil
 }
 
-func (c *CmdChatSetRetention) println(dui libkb.DumbOutputUI, format string, args ...interface{}) {
+func (c *CmdChatSetRetention) println(dui libkb.DumbOutputUI, format string, args ...any) {
 	dui.Printf(fmt.Sprintf(format, args...) + "\n")
 }

--- a/go/client/cmd_ctl_watchdog.go
+++ b/go/client/cmd_ctl_watchdog.go
@@ -128,22 +128,22 @@ func (c *CmdWatchdog) GetUsage() libkb.Usage {
 }
 
 // Debugf (for watchdog.Log interface)
-func (c *CmdWatchdog) Debugf(s string, args ...interface{}) {
+func (c *CmdWatchdog) Debugf(s string, args ...any) {
 	c.G().Log.Debug(s, args...)
 }
 
 // Infof (for watchdog.Log interface)
-func (c *CmdWatchdog) Infof(s string, args ...interface{}) {
+func (c *CmdWatchdog) Infof(s string, args ...any) {
 	c.G().Log.Info(s, args...)
 }
 
 // Warningf (for watchdog Log interface)
-func (c *CmdWatchdog) Warningf(s string, args ...interface{}) {
+func (c *CmdWatchdog) Warningf(s string, args ...any) {
 	c.G().Log.Warning(s, args...)
 }
 
 // Errorf (for watchdog Log interface)
-func (c *CmdWatchdog) Errorf(s string, args ...interface{}) {
+func (c *CmdWatchdog) Errorf(s string, args ...any) {
 	c.G().Log.Errorf(s, args...)
 }
 

--- a/go/client/cmd_decrypt.go
+++ b/go/client/cmd_decrypt.go
@@ -74,7 +74,7 @@ func (c *CmdDecrypt) explainDecryptionFailure(info *keybase1.SaltpackEncryptedMe
 		return
 	}
 	out := c.G().UI.GetTerminalUI().ErrorWriter()
-	prnt := func(s string, args ...interface{}) {
+	prnt := func(s string, args ...any) {
 		fmt.Fprintf(out, s, args...)
 	}
 	if len(info.Devices) > 0 {

--- a/go/client/cmd_show_notifications.go
+++ b/go/client/cmd_show_notifications.go
@@ -95,7 +95,7 @@ func newNotificationDisplay(g *libkb.GlobalContext) *notificationDisplay {
 	return &notificationDisplay{Contextified: libkb.NewContextified(g)}
 }
 
-func (d *notificationDisplay) printf(fmt string, args ...interface{}) error {
+func (d *notificationDisplay) printf(fmt string, args ...any) error {
 	_, err := d.G().UI.GetTerminalUI().Printf(fmt, args...)
 	return err
 }

--- a/go/client/cmd_wallet_history.go
+++ b/go/client/cmd_wallet_history.go
@@ -70,7 +70,7 @@ func (c *cmdWalletHistory) Run() (err error) {
 		return err
 	}
 	dui := c.G().UI.GetDumbOutputUI()
-	lineUnescaped := func(format string, args ...interface{}) {
+	lineUnescaped := func(format string, args ...any) {
 		_, _ = dui.PrintfUnescaped(format+"\n", args...)
 	}
 	// `payments` is sorted most recent first.

--- a/go/client/cmd_wot_list.go
+++ b/go/client/cmd_wot_list.go
@@ -76,7 +76,7 @@ func (c *cmdWotList) Run() error {
 		return err
 	}
 	dui := c.G().UI.GetDumbOutputUI()
-	line := func(format string, args ...interface{}) {
+	line := func(format string, args ...any) {
 		dui.Printf(format+"\n", args...)
 	}
 

--- a/go/client/color.go
+++ b/go/client/color.go
@@ -146,6 +146,6 @@ func ColorBytes(g *libkb.GlobalContext, which string, text []byte) []byte {
 	}
 }
 
-func ColorString(g *libkb.GlobalContext, which, format string, args ...interface{}) string {
+func ColorString(g *libkb.GlobalContext, which, format string, args ...any) string {
 	return string(ColorBytes(g, which, []byte(fmt.Sprintf(format, args...))))
 }

--- a/go/client/contact_settings_api_handler.go
+++ b/go/client/contact_settings_api_handler.go
@@ -142,7 +142,7 @@ func (t *contactSettingsAPIHandler) set(ctx context.Context, c Call, w io.Writer
 	return t.get(ctx, c, w)
 }
 
-func (t *contactSettingsAPIHandler) encodeResult(call Call, result interface{}, w io.Writer) error {
+func (t *contactSettingsAPIHandler) encodeResult(call Call, result any, w io.Writer) error {
 	return encodeResult(call, result, w, t.indent)
 }
 

--- a/go/client/json_api_common.go
+++ b/go/client/json_api_common.go
@@ -67,17 +67,17 @@ type Params struct {
 
 // CallError is the result when there is an error.
 type CallError struct {
-	Code    int         `json:"code"`
-	Message string      `json:"message"`
-	Data    interface{} `json:"data,omitempty"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
 }
 
 // Reply is returned with the results of processing a Call.
 type Reply struct {
-	Jsonrpc string      `json:"jsonrpc,omitempty"`
-	ID      int         `json:"id,omitempty"`
-	Error   *CallError  `json:"error,omitempty"`
-	Result  interface{} `json:"result,omitempty"`
+	Jsonrpc string     `json:"jsonrpc,omitempty"`
+	ID      int        `json:"id,omitempty"`
+	Error   *CallError `json:"error,omitempty"`
+	Result  any        `json:"result,omitempty"`
 }
 
 // Checker implementations can check their options for errors.
@@ -219,7 +219,7 @@ func (c *cmdAPI) decode(ctx context.Context, r io.Reader, w io.Writer, h handler
 }
 
 // encodeResult JSON encodes a successful result to the wr writer.
-func encodeResult(call Call, result interface{}, wr io.Writer, indent bool) error {
+func encodeResult(call Call, result any, wr io.Writer, indent bool) error {
 	reply := Reply{
 		Result: result,
 	}

--- a/go/client/kvstore_api_handler.go
+++ b/go/client/kvstore_api_handler.go
@@ -259,7 +259,7 @@ func (t *kvStoreAPIHandler) list(ctx context.Context, c Call, w io.Writer) error
 	return t.encodeResult(c, res, w)
 }
 
-func (t *kvStoreAPIHandler) encodeResult(call Call, result interface{}, w io.Writer) error {
+func (t *kvStoreAPIHandler) encodeResult(call Call, result any, w io.Writer) error {
 	return encodeResult(call, result, w, t.indent)
 }
 

--- a/go/client/pgp_ui.go
+++ b/go/client/pgp_ui.go
@@ -31,7 +31,7 @@ func (p PgpUI) OutputPGPWarning(_ context.Context, arg keybase1.OutputPGPWarning
 func (p PgpUI) OutputSignatureSuccess(ctx context.Context, arg keybase1.OutputSignatureSuccessArg) error {
 	signedAt := keybase1.FromTime(arg.SignedAt)
 	un := ColorString(p.G(), "bold", arg.Username)
-	output := func(fmtString string, args ...interface{}) {
+	output := func(fmtString string, args ...any) {
 		s := fmt.Sprintf(fmtString, args...)
 		s = ColorString(p.G(), "green", s)
 		_, _ = p.w.Write([]byte(s))
@@ -57,7 +57,7 @@ func (p PgpUI) OutputSignatureSuccess(ctx context.Context, arg keybase1.OutputSi
 
 func (p PgpUI) OutputSignatureNonKeybase(ctx context.Context, arg keybase1.OutputSignatureNonKeybaseArg) error {
 	signedAt := keybase1.FromTime(arg.SignedAt)
-	output := func(fmtString string, args ...interface{}) {
+	output := func(fmtString string, args ...any) {
 		s := fmt.Sprintf(fmtString, args...)
 		s = ColorString(p.G(), "red", s)
 		_, _ = p.w.Write([]byte(s))

--- a/go/client/simplefs_ls.go
+++ b/go/client/simplefs_ls.go
@@ -91,7 +91,7 @@ func (d DirentFileInfo) IsDir() bool {
 }
 
 // Sys - underlying data source (can return nil)
-func (d DirentFileInfo) Sys() interface{} {
+func (d DirentFileInfo) Sys() any {
 	return nil
 }
 

--- a/go/client/stellar_common.go
+++ b/go/client/stellar_common.go
@@ -15,10 +15,10 @@ import (
 )
 
 func printPayment(g *libkb.GlobalContext, p stellar1.PaymentCLILocal, verbose, details bool, dui libkb.DumbOutputUI) {
-	lineUnescaped := func(format string, args ...interface{}) {
+	lineUnescaped := func(format string, args ...any) {
 		_, _ = dui.PrintfUnescaped(format+"\n", args...)
 	}
-	line := func(format string, args ...interface{}) {
+	line := func(format string, args ...any) {
 		dui.Printf(format+"\n", args...)
 	}
 	timeStr := p.Time.Time().Format("2006/01/02 15:04")

--- a/go/client/team_api_handler.go
+++ b/go/client/team_api_handler.go
@@ -475,7 +475,7 @@ func (t *teamAPIHandler) requireOptionsV1(c Call) error {
 
 }
 
-func (t *teamAPIHandler) encodeResult(call Call, result interface{}, w io.Writer) error {
+func (t *teamAPIHandler) encodeResult(call Call, result any, w io.Writer) error {
 	return encodeResult(call, result, w, t.indent)
 }
 

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -1246,19 +1246,19 @@ func (ui *UI) ErrorWriter() io.Writer {
 	return logger.ErrorWriter()
 }
 
-func (ui *UI) Printf(format string, a ...interface{}) (n int, err error) {
+func (ui *UI) Printf(format string, a ...any) (n int, err error) {
 	return fmt.Fprintf(ui.OutputWriter(), format, a...)
 }
 
-func (ui *UI) PrintfUnescaped(format string, a ...interface{}) (n int, err error) {
+func (ui *UI) PrintfUnescaped(format string, a ...any) (n int, err error) {
 	return fmt.Fprintf(ui.UnescapedOutputWriter(), format, a...)
 }
 
-func (ui *UI) Println(a ...interface{}) (int, error) {
+func (ui *UI) Println(a ...any) (int, error) {
 	return fmt.Fprintln(ui.OutputWriter(), a...)
 }
 
-func (ui *UI) PrintfStderr(format string, a ...interface{}) (n int, err error) {
+func (ui *UI) PrintfStderr(format string, a ...any) (n int, err error) {
 	return fmt.Fprintf(os.Stderr, format, a...)
 }
 

--- a/go/client/wallet_api_handler.go
+++ b/go/client/wallet_api_handler.go
@@ -432,7 +432,7 @@ func (w *walletAPIHandler) sendPathPayment(ctx context.Context, c Call, wr io.Wr
 }
 
 // encodeResult JSON encodes a successful result to the wr writer.
-func (w *walletAPIHandler) encodeResult(call Call, result interface{}, wr io.Writer) error {
+func (w *walletAPIHandler) encodeResult(call Call, result any, wr io.Writer) error {
 	return encodeResult(call, result, wr, w.indent)
 }
 

--- a/go/client/wallet_api_listen_display.go
+++ b/go/client/wallet_api_listen_display.go
@@ -19,9 +19,9 @@ type walletNotification struct {
 	// wallet
 	Type string `json:"type"`
 	// payment, request, etc
-	Source       string      `json:"source"`
-	Notification interface{} `json:"notification,omitempty"`
-	Error        *string     `json:"error,omitempty"`
+	Source       string  `json:"source"`
+	Notification any     `json:"notification,omitempty"`
+	Error        *string `json:"error,omitempty"`
 }
 
 func newWalletNotification(source string) *walletNotification {

--- a/go/encrypteddb/db.go
+++ b/go/encrypteddb/db.go
@@ -46,7 +46,7 @@ func New(g *libkb.GlobalContext, getDB DbFn, getSecretBoxKey KeyFn) *EncryptedDB
 }
 
 func DecodeBox(ctx context.Context, b []byte, getSecretBoxKey KeyFn,
-	res interface{}) error {
+	res any) error {
 	// Decode encrypted box
 	var boxed boxedData
 	if err := libkb.MPackDecode(b, &boxed); err != nil {
@@ -74,7 +74,7 @@ func DecodeBox(ctx context.Context, b []byte, getSecretBoxKey KeyFn,
 // Get a value
 // Decodes into res
 // Returns (found, err). Res is valid only if (found && err == nil)
-func (i *EncryptedDB) Get(ctx context.Context, key libkb.DbKey, res interface{}) (bool, error) {
+func (i *EncryptedDB) Get(ctx context.Context, key libkb.DbKey, res any) (bool, error) {
 	var err error
 	db := i.getDB(i.G())
 	b, found, err := db.GetRaw(key)
@@ -90,7 +90,7 @@ func (i *EncryptedDB) Get(ctx context.Context, key libkb.DbKey, res interface{})
 	return true, nil
 }
 
-func EncodeBox(ctx context.Context, data interface{}, getSecretBoxKey KeyFn) ([]byte, error) {
+func EncodeBox(ctx context.Context, data any, getSecretBoxKey KeyFn) ([]byte, error) {
 	dat, err := libkb.MPackEncode(data)
 	if err != nil {
 		return nil, err
@@ -121,7 +121,7 @@ func EncodeBox(ctx context.Context, data interface{}, getSecretBoxKey KeyFn) ([]
 	return dat, nil
 }
 
-func (i *EncryptedDB) Put(ctx context.Context, key libkb.DbKey, data interface{}) error {
+func (i *EncryptedDB) Put(ctx context.Context, key libkb.DbKey, data any) error {
 	db := i.getDB(i.G())
 	dat, err := EncodeBox(ctx, data, i.getSecretBoxKey)
 	if err != nil {

--- a/go/encrypteddb/file.go
+++ b/go/encrypteddb/file.go
@@ -23,7 +23,7 @@ func NewFile(g *libkb.GlobalContext, path string, getSecretBoxKey KeyFn) *Encryp
 	}
 }
 
-func (f *EncryptedFile) Get(ctx context.Context, res interface{}) error {
+func (f *EncryptedFile) Get(ctx context.Context, res any) error {
 	enc, err := ioutil.ReadFile(f.path)
 	if err != nil {
 		return err
@@ -34,7 +34,7 @@ func (f *EncryptedFile) Get(ctx context.Context, res interface{}) error {
 	return nil
 }
 
-func (f *EncryptedFile) Put(ctx context.Context, data interface{}) error {
+func (f *EncryptedFile) Put(ctx context.Context, data any) error {
 	b, err := EncodeBox(ctx, data, f.getSecretBoxKey)
 	if err != nil {
 		return err

--- a/go/engine/background_task.go
+++ b/go/engine/background_task.go
@@ -200,7 +200,7 @@ func (e *BackgroundTask) meta(s string) {
 	}
 }
 
-func (e *BackgroundTask) log(m libkb.MetaContext, format string, args ...interface{}) {
+func (e *BackgroundTask) log(m libkb.MetaContext, format string, args ...any) {
 	content := fmt.Sprintf(format, args...)
 	m.Debug("%s %s", e.Name(), content)
 }

--- a/go/engine/bug_3964_repairman_test.go
+++ b/go/engine/bug_3964_repairman_test.go
@@ -30,56 +30,56 @@ func (a *auditLog) ClearLines() {
 	a.lines = &[]string{}
 }
 
-func (a *auditLog) Debug(format string, args ...interface{}) {
+func (a *auditLog) Debug(format string, args ...any) {
 	s := fmt.Sprintf(format, args...)
 	a.l.CloneWithAddedDepth(1).Debug(s)
 	*a.lines = append(*a.lines, s)
 }
-func (a *auditLog) CDebugf(ctx context.Context, format string, args ...interface{}) {
+func (a *auditLog) CDebugf(ctx context.Context, format string, args ...any) {
 	s := fmt.Sprintf(format, args...)
 	a.l.CloneWithAddedDepth(1).CDebugf(ctx, s)
 	*a.lines = append(*a.lines, s)
 }
-func (a *auditLog) Info(format string, args ...interface{}) {
+func (a *auditLog) Info(format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).Info(format, args...)
 }
-func (a *auditLog) CInfof(ctx context.Context, format string, args ...interface{}) {
+func (a *auditLog) CInfof(ctx context.Context, format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).CInfof(ctx, format, args...)
 }
-func (a *auditLog) Notice(format string, args ...interface{}) {
+func (a *auditLog) Notice(format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).Notice(format, args...)
 }
-func (a *auditLog) CNoticef(ctx context.Context, format string, args ...interface{}) {
+func (a *auditLog) CNoticef(ctx context.Context, format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).CNoticef(ctx, format, args...)
 }
-func (a *auditLog) Warning(format string, args ...interface{}) {
+func (a *auditLog) Warning(format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).Warning(format, args...)
 }
-func (a *auditLog) CWarningf(ctx context.Context, format string, args ...interface{}) {
+func (a *auditLog) CWarningf(ctx context.Context, format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).CWarningf(ctx, format, args...)
 }
-func (a *auditLog) Error(format string, args ...interface{}) {
+func (a *auditLog) Error(format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).Errorf(format, args...)
 }
-func (a *auditLog) Errorf(format string, args ...interface{}) {
+func (a *auditLog) Errorf(format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).Errorf(format, args...)
 }
-func (a *auditLog) CErrorf(ctx context.Context, format string, args ...interface{}) {
+func (a *auditLog) CErrorf(ctx context.Context, format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).CErrorf(ctx, format, args...)
 }
-func (a *auditLog) Critical(format string, args ...interface{}) {
+func (a *auditLog) Critical(format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).Critical(format, args...)
 }
-func (a *auditLog) CCriticalf(ctx context.Context, format string, args ...interface{}) {
+func (a *auditLog) CCriticalf(ctx context.Context, format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).CCriticalf(ctx, format, args...)
 }
-func (a *auditLog) Fatalf(format string, args ...interface{}) {
+func (a *auditLog) Fatalf(format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).Fatalf(format, args...)
 }
-func (a *auditLog) CFatalf(ctx context.Context, format string, args ...interface{}) {
+func (a *auditLog) CFatalf(ctx context.Context, format string, args ...any) {
 	a.l.CloneWithAddedDepth(1).CFatalf(ctx, format, args...)
 }
-func (a *auditLog) Profile(fmts string, args ...interface{}) {
+func (a *auditLog) Profile(fmts string, args ...any) {
 	a.l.CloneWithAddedDepth(1).Profile(fmts, args...)
 }
 func (a *auditLog) Configure(style string, debug bool, filename string) {

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -91,7 +91,7 @@ type kex2LogContext struct {
 	log logger.Logger
 }
 
-func (k kex2LogContext) Debug(format string, args ...interface{}) {
+func (k kex2LogContext) Debug(format string, args ...any) {
 	k.log.Debug(format, args...)
 }
 

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -4003,7 +4003,7 @@ func newTestProvisionUIGPGSign() *testProvisionUI {
 	return ui
 }
 
-func (u *testProvisionUI) printf(format string, a ...interface{}) {
+func (u *testProvisionUI) printf(format string, a ...any) {
 	if !u.verbose {
 		return
 	}

--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -455,7 +455,7 @@ func (e *ScanProofsEngine) GetRemoteProofChainLink(m libkb.MetaContext, uid keyb
 }
 
 func (e *ScanProofsEngine) ParseIndices(indices string) (start int, end int, reterr error) {
-	wrap := func(format string, arg ...interface{}) error {
+	wrap := func(format string, arg ...any) error {
 		f2 := fmt.Sprintf("Invalid indices: %s", format)
 		return fmt.Errorf(f2, arg...)
 	}

--- a/go/engine/wot_react.go
+++ b/go/engine/wot_react.go
@@ -128,7 +128,7 @@ func (e *WotReact) Run(mctx libkb.MetaContext) error {
 	}
 
 	payload := make(libkb.JSONPayload)
-	payload["sigs"] = []interface{}{item}
+	payload["sigs"] = []any{item}
 
 	if _, err := e.G().API.PostJSON(mctx, libkb.APIArg{
 		Endpoint:    "sig/multi",

--- a/go/engine/wot_vouch.go
+++ b/go/engine/wot_vouch.go
@@ -198,7 +198,7 @@ func (e *WotVouch) Run(mctx libkb.MetaContext) error {
 	}
 
 	payload := make(libkb.JSONPayload)
-	payload["sigs"] = []interface{}{item}
+	payload["sigs"] = []any{item}
 	if lease != nil {
 		payload["downgrade_lease_id"] = lease.LeaseID
 	}

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -106,7 +106,7 @@ func (s *DeviceEKStorage) SetLogPrefix(mctx libkb.MetaContext) {
 
 // Log sensitive deletion actions to a separate log file so we don't lose the
 // logs during normal rotation.
-func (s *DeviceEKStorage) ekLogf(mctx libkb.MetaContext, format string, args ...interface{}) {
+func (s *DeviceEKStorage) ekLogf(mctx libkb.MetaContext, format string, args ...any) {
 	mctx.Debug(format, args...)
 	if s.logger != nil {
 		s.logger.Printf(format, args...)
@@ -283,14 +283,14 @@ func (s *DeviceEKStorage) get(mctx libkb.MetaContext, generation keybase1.EkGene
 }
 
 func (s *DeviceEKStorage) Delete(mctx libkb.MetaContext, generation keybase1.EkGeneration,
-	reason string, args ...interface{}) (err error) {
+	reason string, args ...any) (err error) {
 	s.Lock()
 	defer s.Unlock()
 	return s.delete(mctx, generation, reason, args...)
 }
 
 func (s *DeviceEKStorage) delete(mctx libkb.MetaContext, generation keybase1.EkGeneration,
-	reason string, args ...interface{}) (err error) {
+	reason string, args ...any) (err error) {
 	defer s.ekLogCTrace(mctx, fmt.Sprintf("DeviceEKStorage#delete: generation:%v reason: %s", generation, fmt.Sprintf(reason, args...)), &err)()
 
 	// clear the cache

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -429,7 +429,7 @@ func (e *EKLib) teambotCacheKey(teamID keybase1.TeamID, botUID keybase1.UID, gen
 	return fmt.Sprintf("%s-%s-%d", teamID, botUID, generation)
 }
 
-func (e *EKLib) isEntryExpired(val interface{}) (*teamEKGenCacheEntry, bool) {
+func (e *EKLib) isEntryExpired(val any) (*teamEKGenCacheEntry, bool) {
 	cacheEntry, ok := val.(*teamEKGenCacheEntry)
 	if !ok || cacheEntry == nil {
 		return nil, false

--- a/go/install/install.go
+++ b/go/install/install.go
@@ -21,10 +21,10 @@ import (
 
 // Log is the logging interface for this package
 type Log interface {
-	Debug(s string, args ...interface{})
-	Info(s string, args ...interface{})
-	Warning(s string, args ...interface{})
-	Errorf(s string, args ...interface{})
+	Debug(s string, args ...any)
+	Info(s string, args ...any)
+	Warning(s string, args ...any)
+	Errorf(s string, args ...any)
 }
 
 // Context is the environment for this package

--- a/go/install/libnativeinstaller/app.go
+++ b/go/install/libnativeinstaller/app.go
@@ -16,10 +16,10 @@ import (
 
 // Log is the logging interface for this package
 type Log interface {
-	Debug(s string, args ...interface{})
-	Info(s string, args ...interface{})
-	Warning(s string, args ...interface{})
-	Errorf(s string, args ...interface{})
+	Debug(s string, args ...any)
+	Info(s string, args ...any)
+	Warning(s string, args ...any)
+	Errorf(s string, args ...any)
 }
 
 // Context is the environment for install package.

--- a/go/jsonhelpers/json_helpers.go
+++ b/go/jsonhelpers/json_helpers.go
@@ -93,7 +93,7 @@ func JSONGetChildren(w *jsonw.Wrapper) ([]*jsonw.Wrapper, error) {
 // ([], nil) will be returned.  This is because a selector may descend into
 // many subtrees and fail in all but one.
 func AtSelectorPath(selectedObject *jsonw.Wrapper, selectors []keybase1.SelectorEntry,
-	logger func(format string, arg ...interface{}), mkErr func(selector keybase1.SelectorEntry) error) ([]*jsonw.Wrapper, error) {
+	logger func(format string, arg ...any), mkErr func(selector keybase1.SelectorEntry) error) ([]*jsonw.Wrapper, error) {
 	// The terminating condition is when we've consumed all the selectors.
 	if len(selectors) == 0 {
 		return []*jsonw.Wrapper{selectedObject}, nil

--- a/go/kbfs/cache/cache.go
+++ b/go/kbfs/cache/cache.go
@@ -123,7 +123,7 @@ func NewLRUEvictedCache(maxBytes int) Cache {
 		maxBytes: maxBytes,
 	}
 	c.data = &lru.Cache{
-		OnEvicted: func(key lru.Key, value interface{}) {
+		OnEvicted: func(key lru.Key, value any) {
 			// No locking is needed in this function because we do them in
 			// public methods Get/Add, and RemoveOldest() is only called in the
 			// Add method.

--- a/go/kbfs/cache/size_utils.go
+++ b/go/kbfs/cache/size_utils.go
@@ -98,7 +98,7 @@ func mapKeyOrValueSizeWithIndirectPointerOverhead(rawSize int) int {
 // itself, etc.). If needed, dynamic sized stuff (slice/map content, pointer
 // content should be calculated separately by caller.
 func StaticSizeOfMap(
-	zeroValueKey, zeroValueValue interface{}, count int) (bytes int) {
+	zeroValueKey, zeroValueValue any, count int) (bytes int) {
 	return StaticSizeOfMapWithSize(int(reflect.TypeOf(zeroValueKey).Size()),
 		int(reflect.TypeOf(zeroValueValue).Size()), count)
 }

--- a/go/kbfs/data/bcache.go
+++ b/go/kbfs/data/bcache.go
@@ -127,7 +127,7 @@ func (b *BlockCacheStandard) subtractBlockBytes(block Block) {
 	}
 }
 
-func (b *BlockCacheStandard) onEvict(key interface{}, value interface{}) {
+func (b *BlockCacheStandard) onEvict(key any, value any) {
 	block, ok := value.(Block)
 	if !ok {
 		return

--- a/go/kbfs/data/data_mocks_test.go
+++ b/go/kbfs/data/data_mocks_test.go
@@ -40,7 +40,7 @@ func (m *MockBlockWithPtrs) AppendNewIndirectPtr(arg0 BlockPointer, arg1 Offset)
 }
 
 // AppendNewIndirectPtr indicates an expected call of AppendNewIndirectPtr.
-func (mr *MockBlockWithPtrsMockRecorder) AppendNewIndirectPtr(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) AppendNewIndirectPtr(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendNewIndirectPtr", reflect.TypeOf((*MockBlockWithPtrs)(nil).AppendNewIndirectPtr), arg0, arg1)
 }
@@ -66,7 +66,7 @@ func (m *MockBlockWithPtrs) ClearIndirectPtrSize(arg0 int) {
 }
 
 // ClearIndirectPtrSize indicates an expected call of ClearIndirectPtrSize.
-func (mr *MockBlockWithPtrsMockRecorder) ClearIndirectPtrSize(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) ClearIndirectPtrSize(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearIndirectPtrSize", reflect.TypeOf((*MockBlockWithPtrs)(nil).ClearIndirectPtrSize), arg0)
 }
@@ -123,7 +123,7 @@ func (m *MockBlockWithPtrs) IndirectPtr(arg0 int) (BlockInfo, Offset) {
 }
 
 // IndirectPtr indicates an expected call of IndirectPtr.
-func (mr *MockBlockWithPtrsMockRecorder) IndirectPtr(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) IndirectPtr(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndirectPtr", reflect.TypeOf((*MockBlockWithPtrs)(nil).IndirectPtr), arg0)
 }
@@ -207,7 +207,7 @@ func (m *MockBlockWithPtrs) OffsetExceedsData(arg0, arg1 Offset) bool {
 }
 
 // OffsetExceedsData indicates an expected call of OffsetExceedsData.
-func (mr *MockBlockWithPtrsMockRecorder) OffsetExceedsData(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) OffsetExceedsData(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OffsetExceedsData", reflect.TypeOf((*MockBlockWithPtrs)(nil).OffsetExceedsData), arg0, arg1)
 }
@@ -219,7 +219,7 @@ func (m *MockBlockWithPtrs) Set(arg0 Block) {
 }
 
 // Set indicates an expected call of Set.
-func (mr *MockBlockWithPtrsMockRecorder) Set(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) Set(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockBlockWithPtrs)(nil).Set), arg0)
 }
@@ -231,7 +231,7 @@ func (m *MockBlockWithPtrs) SetEncodedSize(arg0 uint32) {
 }
 
 // SetEncodedSize indicates an expected call of SetEncodedSize.
-func (mr *MockBlockWithPtrsMockRecorder) SetEncodedSize(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) SetEncodedSize(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEncodedSize", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetEncodedSize), arg0)
 }
@@ -243,7 +243,7 @@ func (m *MockBlockWithPtrs) SetIndirectPtrInfo(arg0 int, arg1 BlockInfo) {
 }
 
 // SetIndirectPtrInfo indicates an expected call of SetIndirectPtrInfo.
-func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrInfo(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrInfo(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIndirectPtrInfo", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetIndirectPtrInfo), arg0, arg1)
 }
@@ -255,7 +255,7 @@ func (m *MockBlockWithPtrs) SetIndirectPtrOff(arg0 int, arg1 Offset) {
 }
 
 // SetIndirectPtrOff indicates an expected call of SetIndirectPtrOff.
-func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrOff(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrOff(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIndirectPtrOff", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetIndirectPtrOff), arg0, arg1)
 }
@@ -267,7 +267,7 @@ func (m *MockBlockWithPtrs) SetIndirectPtrType(arg0 int, arg1 BlockDirectType) {
 }
 
 // SetIndirectPtrType indicates an expected call of SetIndirectPtrType.
-func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrType(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrType(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIndirectPtrType", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetIndirectPtrType), arg0, arg1)
 }
@@ -279,7 +279,7 @@ func (m *MockBlockWithPtrs) SwapIndirectPtrs(arg0 int, arg1 BlockWithPtrs, arg2 
 }
 
 // SwapIndirectPtrs indicates an expected call of SwapIndirectPtrs.
-func (mr *MockBlockWithPtrsMockRecorder) SwapIndirectPtrs(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) SwapIndirectPtrs(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SwapIndirectPtrs", reflect.TypeOf((*MockBlockWithPtrs)(nil).SwapIndirectPtrs), arg0, arg1, arg2)
 }

--- a/go/kbfs/dokan/debug_none.go
+++ b/go/kbfs/dokan/debug_none.go
@@ -9,5 +9,5 @@ package dokan
 
 const isDebug = false //nolint
 
-func debug(...interface{})          {} // nolint
-func debugf(string, ...interface{}) {} // nolint
+func debug(...any)          {} // nolint
+func debugf(string, ...any) {} // nolint

--- a/go/kbfs/dokan/debug_stderr.go
+++ b/go/kbfs/dokan/debug_stderr.go
@@ -13,10 +13,10 @@ import (
 
 const isDebug = true
 
-func debug(args ...interface{}) {
+func debug(args ...any) {
 	log.Println(args...)
 }
 
-func debugf(s string, args ...interface{}) {
+func debugf(s string, args ...any) {
 	log.Printf(s, args...)
 }

--- a/go/kbfs/dokan/filesystem.go
+++ b/go/kbfs/dokan/filesystem.go
@@ -54,7 +54,7 @@ type FileSystem interface {
 	ErrorPrint(error)
 
 	// Printf is for information level messages.
-	Printf(format string, v ...interface{})
+	Printf(format string, v ...any)
 }
 
 // CreateStatus marks status of successfull create/open operations.

--- a/go/kbfs/dokan/loaddll.go
+++ b/go/kbfs/dokan/loaddll.go
@@ -31,7 +31,7 @@ type errorPrinter struct {
 	buf bytes.Buffer
 }
 
-func (ep *errorPrinter) Printf(s string, os ...interface{}) {
+func (ep *errorPrinter) Printf(s string, os ...any) {
 	fmt.Fprintf(&ep.buf, s, os...)
 }
 

--- a/go/kbfs/dokan/testfs_test.go
+++ b/go/kbfs/dokan/testfs_test.go
@@ -265,7 +265,7 @@ func (t emptyFS) ErrorPrint(err error) {
 	debug(err)
 }
 
-func (t emptyFS) Printf(string, ...interface{}) {
+func (t emptyFS) Printf(string, ...any) {
 }
 
 func (t emptyFS) CreateFile(ctx context.Context, fi *FileInfo, cd *CreateData) (File, CreateStatus, error) {

--- a/go/kbfs/ioutil/json.go
+++ b/go/kbfs/ioutil/json.go
@@ -17,7 +17,7 @@ import (
 // SerializeToJSONFile serializes the given object as JSON and writes
 // it to the given file, making its parent directory first if
 // necessary.
-func SerializeToJSONFile(obj interface{}, path string) error {
+func SerializeToJSONFile(obj any, path string) error {
 	err := MkdirAll(filepath.Dir(path), 0700)
 	if err != nil {
 		return err
@@ -34,7 +34,7 @@ func SerializeToJSONFile(obj interface{}, path string) error {
 // DeserializeFromJSONFile deserializes the given JSON file into the
 // object pointed to by objPtr. It may return an error for which
 // ioutil.IsNotExist() returns true.
-func DeserializeFromJSONFile(path string, objPtr interface{}) error {
+func DeserializeFromJSONFile(path string, objPtr any) error {
 	data, err := ReadFile(path)
 	if err != nil {
 		return err

--- a/go/kbfs/kbfsblock/server_errors.go
+++ b/go/kbfs/kbfsblock/server_errors.go
@@ -287,12 +287,12 @@ type ServerErrorUnwrapper struct{}
 var _ rpc.ErrorUnwrapper = ServerErrorUnwrapper{}
 
 // MakeArg implements rpc.ErrorUnwrapper.
-func (eu ServerErrorUnwrapper) MakeArg() interface{} {
+func (eu ServerErrorUnwrapper) MakeArg() any {
 	return &keybase1.Status{}
 }
 
 // UnwrapError implements rpc.ErrorUnwrapper.
-func (eu ServerErrorUnwrapper) UnwrapError(arg interface{}) (appError error, dispatchError error) {
+func (eu ServerErrorUnwrapper) UnwrapError(arg any) (appError error, dispatchError error) {
 	s, ok := arg.(*keybase1.Status)
 	if !ok {
 		return nil, errors.New("Error converting arg to keybase1.Status object in ServerErrorUnwrapper.UnwrapError")

--- a/go/kbfs/kbfscodec/codec.go
+++ b/go/kbfs/kbfscodec/codec.go
@@ -25,9 +25,9 @@ const (
 // Codec encodes and decodes arbitrary data
 type Codec interface {
 	// Decode unmarshals the given buffer into the given object, if possible.
-	Decode(buf []byte, obj interface{}) error
+	Decode(buf []byte, obj any) error
 	// Encode marshals the given object into a returned buffer.
-	Encode(obj interface{}) ([]byte, error)
+	Encode(obj any) ([]byte, error)
 	// RegisterType should be called for all types that are stored
 	// under ambiguous types (like interface{} or nil interface) in a
 	// struct that will be encoded/decoded by the codec.  Each must
@@ -45,12 +45,12 @@ type Codec interface {
 	// codec cannot decode interface types to their desired pointer
 	// form.
 	RegisterIfaceSliceType(rt reflect.Type, code ExtCode,
-		typer func(interface{}) reflect.Value)
+		typer func(any) reflect.Value)
 }
 
 // Equal returns whether or not the given objects serialize to the
 // same byte string. x or y (or both) can be nil.
-func Equal(c Codec, x, y interface{}) (bool, error) {
+func Equal(c Codec, x, y any) (bool, error) {
 	xBuf, err := c.Encode(x)
 	if err != nil {
 		return false, err
@@ -64,7 +64,7 @@ func Equal(c Codec, x, y interface{}) (bool, error) {
 
 // Update encodes src into a byte string, and then decode it into the
 // object pointed to by dstPtr.
-func Update(c Codec, dstPtr interface{}, src interface{}) error {
+func Update(c Codec, dstPtr any, src any) error {
 	buf, err := c.Encode(src)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func Update(c Codec, dstPtr interface{}, src interface{}) error {
 
 // SerializeToFile serializes the given object and writes it to the
 // given file, making its parent directory first if necessary.
-func SerializeToFile(c Codec, obj interface{}, path string) error {
+func SerializeToFile(c Codec, obj any, path string) error {
 	err := ioutil.MkdirAll(filepath.Dir(path), 0700)
 	if err != nil {
 		return err
@@ -94,7 +94,7 @@ func SerializeToFile(c Codec, obj interface{}, path string) error {
 
 // SerializeToFileIfNotExist is like SerializeToFile, but does nothing
 // if the file already exists.
-func SerializeToFileIfNotExist(c Codec, obj interface{}, path string) error {
+func SerializeToFileIfNotExist(c Codec, obj any, path string) error {
 	_, err := ioutil.Stat(path)
 	switch {
 	case ioutil.IsExist(err):
@@ -111,7 +111,7 @@ func SerializeToFileIfNotExist(c Codec, obj interface{}, path string) error {
 // DeserializeFromFile deserializes the given file into the object
 // pointed to by objPtr. It may return an error for which
 // ioutil.IsNotExist() returns true.
-func DeserializeFromFile(c Codec, path string, objPtr interface{}) error {
+func DeserializeFromFile(c Codec, path string, objPtr any) error {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/go/kbfs/kbfscodec/codec_msgpack.go
+++ b/go/kbfs/kbfscodec/codec_msgpack.go
@@ -21,17 +21,17 @@ type ext struct {
 }
 
 // ConvertExt implements the codec.Ext interface for ext.
-func (e ext) ConvertExt(v interface{}) interface{} {
+func (e ext) ConvertExt(v any) any {
 	panic("ConvertExt not supported")
 }
 
 // UpdateExt implements the codec.Ext interface for ext.
-func (e ext) UpdateExt(dest interface{}, v interface{}) {
+func (e ext) UpdateExt(dest any, v any) {
 	panic("UpdateExt not supported")
 }
 
 // WriteExt implements the codec.Ext interface for ext.
-func (e ext) WriteExt(v interface{}) (buf []byte) {
+func (e ext) WriteExt(v any) (buf []byte) {
 	buf, err := e.codec.Encode(v)
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't encode data in %v", v))
@@ -40,7 +40,7 @@ func (e ext) WriteExt(v interface{}) (buf []byte) {
 }
 
 // ReadExt implements the codec.Ext interface for ext.
-func (e ext) ReadExt(v interface{}, buf []byte) {
+func (e ext) ReadExt(v any, buf []byte) {
 	err := e.codec.Decode(buf, v)
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't decode data into %v", v))
@@ -53,28 +53,28 @@ func (e ext) ReadExt(v interface{}, buf []byte) {
 type extSlice struct {
 	// codec SHOULD encode extension types
 	codec Codec
-	typer func(interface{}) reflect.Value
+	typer func(any) reflect.Value
 }
 
 // ConvertExt implements the codec.Ext interface for extSlice.
-func (es extSlice) ConvertExt(v interface{}) interface{} {
+func (es extSlice) ConvertExt(v any) any {
 	panic("ConvertExt not supported")
 }
 
 // UpdateExt implements the codec.Ext interface for extSlice.
-func (es extSlice) UpdateExt(dest interface{}, v interface{}) {
+func (es extSlice) UpdateExt(dest any, v any) {
 	panic("UpdateExt not supported")
 }
 
 // WriteExt implements the codec.Ext interface for extSlice.
-func (es extSlice) WriteExt(v interface{}) (buf []byte) {
+func (es extSlice) WriteExt(v any) (buf []byte) {
 	val := reflect.ValueOf(v)
 	if val.Kind() != reflect.Slice {
 		panic(fmt.Sprintf("Non-slice passed to extSlice.WriteExt %v",
 			val.Kind()))
 	}
 
-	ifaceArray := make([]interface{}, val.Len())
+	ifaceArray := make([]any, val.Len())
 	for i := 0; i < val.Len(); i++ {
 		ifaceArray[i] = val.Index(i).Interface()
 	}
@@ -87,7 +87,7 @@ func (es extSlice) WriteExt(v interface{}) (buf []byte) {
 }
 
 // ReadExt implements the codec.Ext interface for extSlice.
-func (es extSlice) ReadExt(v interface{}, buf []byte) {
+func (es extSlice) ReadExt(v any, buf []byte) {
 	// ReadExt actually receives a pointer to the list
 	val := reflect.ValueOf(v)
 	if val.Kind() != reflect.Ptr {
@@ -101,7 +101,7 @@ func (es extSlice) ReadExt(v interface{}, buf []byte) {
 			val.Kind()))
 	}
 
-	var ifaceArray []interface{}
+	var ifaceArray []any
 	err := es.codec.Decode(buf, &ifaceArray)
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't decode data into %v", v))
@@ -158,7 +158,7 @@ func NewMsgpackNoUnknownFields() *CodecMsgpack {
 }
 
 // Decode implements the Codec interface for CodecMsgpack
-func (c *CodecMsgpack) Decode(buf []byte, obj interface{}) error {
+func (c *CodecMsgpack) Decode(buf []byte, obj any) error {
 	err := codec.NewDecoderBytes(buf, c.h).Decode(obj)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode")
@@ -167,7 +167,7 @@ func (c *CodecMsgpack) Decode(buf []byte, obj interface{}) error {
 }
 
 // Encode implements the Codec interface for CodecMsgpack
-func (c *CodecMsgpack) Encode(obj interface{}) (buf []byte, err error) {
+func (c *CodecMsgpack) Encode(obj any) (buf []byte, err error) {
 	err = codec.NewEncoderBytes(&buf, c.h).Encode(obj)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to encode")
@@ -186,7 +186,7 @@ func (c *CodecMsgpack) RegisterType(rt reflect.Type, code ExtCode) {
 
 // RegisterIfaceSliceType implements the Codec interface for CodecMsgpack
 func (c *CodecMsgpack) RegisterIfaceSliceType(
-	rt reflect.Type, code ExtCode, typer func(interface{}) reflect.Value) {
+	rt reflect.Type, code ExtCode, typer func(any) reflect.Value) {
 	err := c.h.(*codec.MsgpackHandle).SetBytesExt(
 		rt, uint64(code), extSlice{c, typer})
 	if err != nil {

--- a/go/kbfs/kbfscodec/mock_codec.go
+++ b/go/kbfs/kbfscodec/mock_codec.go
@@ -29,24 +29,24 @@ func (_m *MockCodec) EXPECT() *_MockCodecRecorder {
 	return _m.recorder
 }
 
-func (_m *MockCodec) Decode(buf []byte, obj interface{}) error {
+func (_m *MockCodec) Decode(buf []byte, obj any) error {
 	ret := _m.ctrl.Call(_m, "Decode", buf, obj)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockCodecRecorder) Decode(arg0, arg1 interface{}) *gomock.Call {
+func (_mr *_MockCodecRecorder) Decode(arg0, arg1 any) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Decode", arg0, arg1)
 }
 
-func (_m *MockCodec) Encode(obj interface{}) ([]byte, error) {
+func (_m *MockCodec) Encode(obj any) ([]byte, error) {
 	ret := _m.ctrl.Call(_m, "Encode", obj)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockCodecRecorder) Encode(arg0 interface{}) *gomock.Call {
+func (_mr *_MockCodecRecorder) Encode(arg0 any) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Encode", arg0)
 }
 
@@ -54,14 +54,14 @@ func (_m *MockCodec) RegisterType(rt reflect.Type, code ExtCode) {
 	_m.ctrl.Call(_m, "RegisterType", rt, code)
 }
 
-func (_mr *_MockCodecRecorder) RegisterType(arg0, arg1 interface{}) *gomock.Call {
+func (_mr *_MockCodecRecorder) RegisterType(arg0, arg1 any) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterType", arg0, arg1)
 }
 
-func (_m *MockCodec) RegisterIfaceSliceType(rt reflect.Type, code ExtCode, typer func(interface{}) reflect.Value) {
+func (_m *MockCodec) RegisterIfaceSliceType(rt reflect.Type, code ExtCode, typer func(any) reflect.Value) {
 	_m.ctrl.Call(_m, "RegisterIfaceSliceType", rt, code, typer)
 }
 
-func (_mr *_MockCodecRecorder) RegisterIfaceSliceType(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (_mr *_MockCodecRecorder) RegisterIfaceSliceType(arg0, arg1, arg2 any) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterIfaceSliceType", arg0, arg1, arg2)
 }

--- a/go/kbfs/kbfscodec/unknown_fields_test_util.go
+++ b/go/kbfs/kbfscodec/unknown_fields_test_util.go
@@ -94,7 +94,7 @@ func MakeExtraOrBust(prefix string, t require.TestingT) Extra {
 
 // CurrentStruct is an interface for the current version of a struct
 // type.
-type CurrentStruct interface{}
+type CurrentStruct any
 
 // FutureStruct is an interface for a hypothetical future version of a
 // struct type.

--- a/go/kbfs/kbfscrypto/crypto_key_types_test.go
+++ b/go/kbfs/kbfscrypto/crypto_key_types_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 type kidContainerType interface {
-	makeZero() interface{}
-	makeFromKID(kid keybase1.KID) interface{}
-	decode(codec *kbfscodec.CodecMsgpack, data []byte) (interface{}, error)
+	makeZero() any
+	makeFromKID(kid keybase1.KID) any
+	decode(codec *kbfscodec.CodecMsgpack, data []byte) (any, error)
 }
 
 // Make sure the kid container type encodes and decodes properly with
@@ -59,16 +59,16 @@ func testKidContainerTypeEncodeDecodeZero(t *testing.T, kt kidContainerType) {
 
 type verifyingKeyType struct{}
 
-func (verifyingKeyType) makeZero() interface{} {
+func (verifyingKeyType) makeZero() any {
 	return VerifyingKey{}
 }
 
-func (verifyingKeyType) makeFromKID(kid keybase1.KID) interface{} {
+func (verifyingKeyType) makeFromKID(kid keybase1.KID) any {
 	return MakeVerifyingKey(kid)
 }
 
 func (verifyingKeyType) decode(
-	codec *kbfscodec.CodecMsgpack, data []byte) (interface{}, error) {
+	codec *kbfscodec.CodecMsgpack, data []byte) (any, error) {
 	k := VerifyingKey{}
 	err := codec.Decode(data, &k)
 	return k, err
@@ -85,8 +85,8 @@ func TestVerifyingKeyEncodeDecodeZero(t *testing.T) {
 }
 
 type byte32ContainerType interface {
-	makeZero() interface{}
-	makeFromData(data [32]byte) interface{}
+	makeZero() any
+	makeFromData(data [32]byte) any
 }
 
 func testByte32ContainerEncodeDecode(t *testing.T, bt byte32ContainerType) {
@@ -111,11 +111,11 @@ func testByte32ContainerEncodeDecode(t *testing.T, bt byte32ContainerType) {
 
 type tlfPrivateKeyType struct{}
 
-func (tlfPrivateKeyType) makeZero() interface{} {
+func (tlfPrivateKeyType) makeZero() any {
 	return TLFPrivateKey{}
 }
 
-func (tlfPrivateKeyType) makeFromData(data [32]byte) interface{} {
+func (tlfPrivateKeyType) makeFromData(data [32]byte) any {
 	return MakeTLFPrivateKey(data)
 }
 
@@ -127,11 +127,11 @@ func TestTLFPrivateKeyEncodeDecode(t *testing.T) {
 
 type tlfPublicKeyType struct{}
 
-func (tlfPublicKeyType) makeZero() interface{} {
+func (tlfPublicKeyType) makeZero() any {
 	return TLFPublicKey{}
 }
 
-func (tlfPublicKeyType) makeFromData(data [32]byte) interface{} {
+func (tlfPublicKeyType) makeFromData(data [32]byte) any {
 	return MakeTLFPublicKey(data)
 }
 
@@ -143,11 +143,11 @@ func TestTLFPublicKeyEncodeDecode(t *testing.T) {
 
 type tlfEphemeralPrivateKeyType struct{}
 
-func (tlfEphemeralPrivateKeyType) makeZero() interface{} {
+func (tlfEphemeralPrivateKeyType) makeZero() any {
 	return TLFEphemeralPrivateKey{}
 }
 
-func (tlfEphemeralPrivateKeyType) makeFromData(data [32]byte) interface{} {
+func (tlfEphemeralPrivateKeyType) makeFromData(data [32]byte) any {
 	return MakeTLFEphemeralPrivateKey(data)
 }
 
@@ -159,16 +159,16 @@ func TestTLFEphemeralPrivateKeyEncodeDecode(t *testing.T) {
 
 type cryptPublicKeyType struct{}
 
-func (cryptPublicKeyType) makeZero() interface{} {
+func (cryptPublicKeyType) makeZero() any {
 	return CryptPublicKey{}
 }
 
-func (cryptPublicKeyType) makeFromKID(kid keybase1.KID) interface{} {
+func (cryptPublicKeyType) makeFromKID(kid keybase1.KID) any {
 	return MakeCryptPublicKey(kid)
 }
 
 func (cryptPublicKeyType) decode(
-	codec *kbfscodec.CodecMsgpack, data []byte) (interface{}, error) {
+	codec *kbfscodec.CodecMsgpack, data []byte) (any, error) {
 	k := CryptPublicKey{}
 	err := codec.Decode(data, &k)
 	return k, err
@@ -188,11 +188,11 @@ func TestCryptPublicKeyEncodeDecodeZero(t *testing.T) {
 
 type tlfEphemeralPublicKeyType struct{}
 
-func (tlfEphemeralPublicKeyType) makeZero() interface{} {
+func (tlfEphemeralPublicKeyType) makeZero() any {
 	return TLFEphemeralPublicKey{}
 }
 
-func (tlfEphemeralPublicKeyType) makeFromData(data [32]byte) interface{} {
+func (tlfEphemeralPublicKeyType) makeFromData(data [32]byte) any {
 	return MakeTLFEphemeralPublicKey(data)
 }
 
@@ -204,11 +204,11 @@ func TestTLFEphemeralPublicKeyEncodeDecode(t *testing.T) {
 
 type tlfCryptKeyServerHalfType struct{}
 
-func (tlfCryptKeyServerHalfType) makeZero() interface{} {
+func (tlfCryptKeyServerHalfType) makeZero() any {
 	return TLFCryptKeyServerHalf{}
 }
 
-func (tlfCryptKeyServerHalfType) makeFromData(data [32]byte) interface{} {
+func (tlfCryptKeyServerHalfType) makeFromData(data [32]byte) any {
 	return MakeTLFCryptKeyServerHalf(data)
 }
 
@@ -220,11 +220,11 @@ func TestTLFCryptKeyServerHalfEncodeDecode(t *testing.T) {
 
 type tlfCryptKeyClientHalfType struct{}
 
-func (tlfCryptKeyClientHalfType) makeZero() interface{} {
+func (tlfCryptKeyClientHalfType) makeZero() any {
 	return TLFCryptKeyClientHalf{}
 }
 
-func (tlfCryptKeyClientHalfType) makeFromData(data [32]byte) interface{} {
+func (tlfCryptKeyClientHalfType) makeFromData(data [32]byte) any {
 	return MakeTLFCryptKeyClientHalf(data)
 }
 
@@ -236,11 +236,11 @@ func TestTLFCryptKeyClientHalfEncodeDecode(t *testing.T) {
 
 type tlfCryptKeyType struct{}
 
-func (tlfCryptKeyType) makeZero() interface{} {
+func (tlfCryptKeyType) makeZero() any {
 	return TLFCryptKey{}
 }
 
-func (tlfCryptKeyType) makeFromData(data [32]byte) interface{} {
+func (tlfCryptKeyType) makeFromData(data [32]byte) any {
 	return MakeTLFCryptKey(data)
 }
 
@@ -266,11 +266,11 @@ func TestRandomTLFCryptKeyServerHalf(t *testing.T) {
 
 type blockCryptKeyServerHalfType struct{}
 
-func (blockCryptKeyServerHalfType) makeZero() interface{} {
+func (blockCryptKeyServerHalfType) makeZero() any {
 	return TLFCryptKey{}
 }
 
-func (blockCryptKeyServerHalfType) makeFromData(data [32]byte) interface{} {
+func (blockCryptKeyServerHalfType) makeFromData(data [32]byte) any {
 	return MakeTLFCryptKey(data)
 }
 
@@ -282,11 +282,11 @@ func TestBlockCryptKeyServerHalfEncodeDecode(t *testing.T) {
 
 type blockCryptKeyType struct{}
 
-func (blockCryptKeyType) makeZero() interface{} {
+func (blockCryptKeyType) makeZero() any {
 	return TLFCryptKey{}
 }
 
-func (blockCryptKeyType) makeFromData(data [32]byte) interface{} {
+func (blockCryptKeyType) makeFromData(data [32]byte) any {
 	return MakeTLFCryptKey(data)
 }
 

--- a/go/kbfs/kbfsedits/tlf_history.go
+++ b/go/kbfs/kbfsedits/tlf_history.go
@@ -70,12 +70,12 @@ func (wbr writersByRevision) Swap(i, j int) {
 	wbr[i], wbr[j] = wbr[j], wbr[i]
 }
 
-func (wbr *writersByRevision) Push(x interface{}) {
+func (wbr *writersByRevision) Push(x any) {
 	wn := x.(*writerNotifications)
 	*wbr = append(*wbr, wn)
 }
 
-func (wbr *writersByRevision) Pop() interface{} {
+func (wbr *writersByRevision) Pop() any {
 	// The item to remove is the last item; heap has already swapped
 	// it to the end.
 	old := *wbr
@@ -90,7 +90,7 @@ func (wbr *writersByRevision) Pop() interface{} {
 //
 // There will be two users of a TlfHistory instance:
 //
-//   * One user (likely something outside of the kbfsedits package,
+//   - One user (likely something outside of the kbfsedits package,
 //     e.g. libkbfs.folderBranchOps) will read notifications from the
 //     corresponding TLF and add them to this history.  After adding a
 //     batch or several batches of messages, it should call
@@ -98,7 +98,7 @@ func (wbr *writersByRevision) Pop() interface{} {
 //     it should fetch more notifications for the indicated writer and
 //     repeat.
 //
-//   * The other user (within the kbfsedits package) will collate the
+//   - The other user (within the kbfsedits package) will collate the
 //     histories from multiple TlfHistory instances together using
 //     `getHistory()` from each one.  It may also construct pretty
 //     versions of individual edit histories for a particular TLF.

--- a/go/kbfs/kbfsgit/runner_test.go
+++ b/go/kbfs/kbfsgit/runner_test.go
@@ -216,7 +216,7 @@ func testPushWithTemplate(ctx context.Context, t *testing.T,
 		outputMap[line] = true
 	}
 
-	dsts := make([]interface{}, 0, len(refspecs))
+	dsts := make([]any, 0, len(refspecs))
 	for _, refspec := range refspecs {
 		dsts = append(dsts, gogitcfg.RefSpec(refspec).Dst(""))
 	}

--- a/go/kbfs/kbfsmd/merkle_leaf.go
+++ b/go/kbfs/kbfsmd/merkle_leaf.go
@@ -22,7 +22,7 @@ type MerkleLeaf struct {
 var _ merkle.ValueConstructor = (*MerkleLeaf)(nil)
 
 // Construct implements the go-merkle-tree.ValueConstructor interface.
-func (l MerkleLeaf) Construct() interface{} {
+func (l MerkleLeaf) Construct() any {
 	// In the Merkle tree leaves are simply byte slices.
 	return &[]byte{}
 }
@@ -35,7 +35,7 @@ type EncryptedMerkleLeaf struct {
 }
 
 // Construct implements the go-merkle-tree.ValueConstructor interface.
-func (el EncryptedMerkleLeaf) Construct() interface{} {
+func (el EncryptedMerkleLeaf) Construct() any {
 	// In the Merkle tree leaves are simply byte slices.
 	return &[]byte{}
 }

--- a/go/kbfs/kbfsmd/root_metadata_v2_test.go
+++ b/go/kbfs/kbfsmd/root_metadata_v2_test.go
@@ -189,7 +189,7 @@ func TestWriterMetadataV2EncodedFields(t *testing.T) {
 	buf, err := c.Encode(wm)
 	require.NoError(t, err)
 
-	var m map[string]interface{}
+	var m map[string]any
 	err = c.Decode(buf, &m)
 	require.NoError(t, err)
 

--- a/go/kbfs/kbfsmd/server_errors.go
+++ b/go/kbfs/kbfsmd/server_errors.go
@@ -420,12 +420,12 @@ type ServerErrorUnwrapper struct{}
 var _ rpc.ErrorUnwrapper = ServerErrorUnwrapper{}
 
 // MakeArg implements rpc.ErrorUnwrapper for ServerErrorUnwrapper.
-func (eu ServerErrorUnwrapper) MakeArg() interface{} {
+func (eu ServerErrorUnwrapper) MakeArg() any {
 	return &keybase1.Status{}
 }
 
 // UnwrapError implements rpc.ErrorUnwrapper for ServerErrorUnwrapper.
-func (eu ServerErrorUnwrapper) UnwrapError(arg interface{}) (appError error, dispatchError error) {
+func (eu ServerErrorUnwrapper) UnwrapError(arg any) (appError error, dispatchError error) {
 	s, ok := arg.(*keybase1.Status)
 	if !ok {
 		return nil, errors.New("Error converting arg to keybase1.Status object in ServerErrorUnwrapper.UnwrapError")

--- a/go/kbfs/libdokan/dokan_info.go
+++ b/go/kbfs/libdokan/dokan_info.go
@@ -24,7 +24,7 @@ type errorPrinter struct {
 	buf bytes.Buffer
 }
 
-func (ep *errorPrinter) Printf(s string, os ...interface{}) {
+func (ep *errorPrinter) Printf(s string, os ...any) {
 	fmt.Fprintf(&ep.buf, s, os...)
 }
 

--- a/go/kbfs/libdokan/fs.go
+++ b/go/kbfs/libdokan/fs.go
@@ -399,7 +399,7 @@ func (f *FS) open(ctx context.Context, oc *openContext, ps []string) (dokan.File
 }
 
 // windowsPathSplit handles paths we get from Dokan.
-// As a special case `` means `\`, it gets generated
+// As a special case “ means `\`, it gets generated
 // on special occasions.
 func windowsPathSplit(raw string) ([]string, error) {
 	if raw == `` {
@@ -417,7 +417,7 @@ func (f *FS) ErrorPrint(err error) {
 }
 
 // Printf prints information from the Dokan library.
-func (f *FS) Printf(fmt string, args ...interface{}) {
+func (f *FS) Printf(fmt string, args ...any) {
 	f.log.Info("Dokan info: "+fmt, args...)
 }
 
@@ -644,7 +644,7 @@ func (f *FS) logEnter(ctx context.Context, s string) {
 	f.vlog.CLogf(ctx, libkb.VLog1, "=> %s", s)
 }
 
-func (f *FS) logEnterf(ctx context.Context, fmt string, args ...interface{}) {
+func (f *FS) logEnterf(ctx context.Context, fmt string, args ...any) {
 	f.vlog.CLogf(ctx, libkb.VLog1, "=> "+fmt, args...)
 }
 

--- a/go/kbfs/libfs/file_info.go
+++ b/go/kbfs/libfs/file_info.go
@@ -158,7 +158,7 @@ func (fis fileInfoSys) EntryInfo() data.EntryInfo {
 }
 
 // Sys implements the os.FileInfo interface for FileInfo.
-func (fi *FileInfo) Sys() interface{} {
+func (fi *FileInfo) Sys() any {
 	return fileInfoSys{fi}
 }
 
@@ -206,7 +206,7 @@ func (fif *FileInfoFast) IsDir() bool {
 }
 
 // Sys implements the os.FileInfo interface.
-func (fif *FileInfoFast) Sys() interface{} {
+func (fif *FileInfoFast) Sys() any {
 	return fif
 }
 

--- a/go/kbfs/libfs/json.go
+++ b/go/kbfs/libfs/json.go
@@ -9,7 +9,7 @@ import (
 )
 
 // PrettyJSON marshals a value to human-readable JSON.
-func PrettyJSON(value interface{}) ([]byte, error) {
+func PrettyJSON(value any) ([]byte, error) {
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return nil, err

--- a/go/kbfs/libfs/wrapped_read_file_info.go
+++ b/go/kbfs/libfs/wrapped_read_file_info.go
@@ -39,6 +39,6 @@ func (cfi *wrappedReadFileInfo) IsDir() bool {
 	return cfi.dir
 }
 
-func (cfi *wrappedReadFileInfo) Sys() interface{} {
+func (cfi *wrappedReadFileInfo) Sys() any {
 	return nil
 }

--- a/go/kbfs/libfuse/debug.go
+++ b/go/kbfs/libfuse/debug.go
@@ -20,8 +20,8 @@ var statfsOrAccessRegexp = regexp.MustCompile(`^(<-|->).* (Statfs|Access)`)
 // MakeFuseDebugFn returns a function that logs its argument to the
 // given log, suitable to assign to fuse.Debug.
 func MakeFuseDebugFn(
-	log logger.Logger, superVerbose bool) func(msg interface{}) {
-	return func(msg interface{}) {
+	log logger.Logger, superVerbose bool) func(msg any) {
+	return func(msg any) {
 		str := fmt.Sprintf("%s", msg)
 		// If superVerbose is not set, filter out Statfs and
 		// Access messages, since they're spammy on OS X.
@@ -38,8 +38,8 @@ func MakeFuseDebugFn(
 // MakeFuseVDebugFn returns a function that logs its argument to the
 // given vlog at level 1, suitable to assign to fuse.Debug.
 func MakeFuseVDebugFn(
-	vlog *libkb.VDebugLog, superVerbose bool) func(msg interface{}) {
-	return func(msg interface{}) {
+	vlog *libkb.VDebugLog, superVerbose bool) func(msg any) {
+	return func(msg any) {
 		str := fmt.Sprintf("%s", msg)
 		// If superVerbose is not set, filter out Statfs and
 		// Access messages, since they're spammy on OS X.

--- a/go/kbfs/libgit/browser_file_info.go
+++ b/go/kbfs/libgit/browser_file_info.go
@@ -46,6 +46,6 @@ func (bfi *browserFileInfo) IsDir() bool {
 	return !bfi.entry.Mode.IsFile()
 }
 
-func (bfi *browserFileInfo) Sys() interface{} {
+func (bfi *browserFileInfo) Sys() any {
 	return nil
 }

--- a/go/kbfs/libgit/diff_file_info.go
+++ b/go/kbfs/libgit/diff_file_info.go
@@ -38,6 +38,6 @@ func (cfi *diffFileInfo) IsDir() bool {
 	return false
 }
 
-func (cfi *diffFileInfo) Sys() interface{} {
+func (cfi *diffFileInfo) Sys() any {
 	return nil
 }

--- a/go/kbfs/libgit/lfs_file_info.go
+++ b/go/kbfs/libgit/lfs_file_info.go
@@ -38,6 +38,6 @@ func (lfi *lfsFileInfo) IsDir() bool {
 	return false
 }
 
-func (lfi *lfsFileInfo) Sys() interface{} {
+func (lfi *lfsFileInfo) Sys() any {
 	return nil
 }

--- a/go/kbfs/libgit/submodule_file_info.go
+++ b/go/kbfs/libgit/submodule_file_info.go
@@ -39,6 +39,6 @@ func (sfi *submoduleFileInfo) IsDir() bool {
 	return false
 }
 
-func (sfi *submoduleFileInfo) Sys() interface{} {
+func (sfi *submoduleFileInfo) Sys() any {
 	return nil
 }

--- a/go/kbfs/libkbfs/backpressure_disk_limiter.go
+++ b/go/kbfs/libkbfs/backpressure_disk_limiter.go
@@ -24,18 +24,18 @@ import (
 // Let U be the (approximate) resource usage of the journal and F be
 // the free resources. Then we want to enforce
 //
-//   U <= min(k(U+F), L),
+//	U <= min(k(U+F), L),
 //
 // where 0 < k <= 1 is some fraction, and L > 0 is the absolute
 // resource usage limit. But in addition to that, we want to set
 // thresholds 0 <= m <= M <= 1 such that we apply proportional
 // backpressure (with a given maximum delay) when
 //
-//   m <= max(U/(k(U+F)), U/L) <= M,
+//	m <= max(U/(k(U+F)), U/L) <= M,
 //
 // which is equivalent to
 //
-//   m <= U/min(k(U+F), L) <= M.
+//	m <= U/min(k(U+F), L) <= M.
 //
 // Note that this type doesn't do any locking, so it's the caller's
 // responsibility to do so.
@@ -263,7 +263,7 @@ func (bt *backpressureTracker) getStatus() backpressureTrackerStatus {
 // thresholds 0 <= m <= M such that we apply proportional backpressure
 // (with a given maximum delay) when
 //
-//   m <= (U+R)/Q <= M.
+//	m <= (U+R)/Q <= M.
 //
 // Note that this type doesn't do any locking, so it's the caller's
 // responsibility to do so.
@@ -1106,7 +1106,7 @@ type backpressureDiskLimiterStatus struct {
 }
 
 func (bdl *backpressureDiskLimiter) getStatus(
-	ctx context.Context, chargedTo keybase1.UserOrTeamID) interface{} {
+	ctx context.Context, chargedTo keybase1.UserOrTeamID) any {
 	bdl.lock.Lock()
 	defer bdl.lock.Unlock()
 

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -287,7 +287,7 @@ type badEncoder struct {
 	kbfscodec.Codec
 }
 
-func (c badEncoder) Encode(o interface{}) ([]byte, error) {
+func (c badEncoder) Encode(o any) ([]byte, error) {
 	return nil, errors.New("could not encode")
 }
 
@@ -313,7 +313,7 @@ type tooSmallEncoder struct {
 	kbfscodec.Codec
 }
 
-func (c tooSmallEncoder) Encode(o interface{}) ([]byte, error) {
+func (c tooSmallEncoder) Encode(o any) ([]byte, error) {
 	return []byte{0x1}, nil
 }
 
@@ -504,7 +504,7 @@ func (c *badDecoder) putError(buf []byte, err error) {
 	c.errors[k] = err
 }
 
-func (c *badDecoder) Decode(buf []byte, o interface{}) error {
+func (c *badDecoder) Decode(buf []byte, o any) error {
 	k := string(buf)
 	err := func() error {
 		c.errorsLock.RLock()

--- a/go/kbfs/libkbfs/block_retrieval_heap.go
+++ b/go/kbfs/libkbfs/block_retrieval_heap.go
@@ -31,14 +31,14 @@ func (brh blockRetrievalHeap) Swap(i, j int) {
 	brh[j].index = j
 }
 
-func (brh *blockRetrievalHeap) Push(item interface{}) {
+func (brh *blockRetrievalHeap) Push(item any) {
 	n := len(*brh)
 	retrieval := item.(*blockRetrieval)
 	retrieval.index = n
 	*brh = append(*brh, retrieval)
 }
 
-func (brh *blockRetrievalHeap) Pop() interface{} {
+func (brh *blockRetrievalHeap) Pop() any {
 	old := *brh
 	n := len(old)
 	x := old[n-1]

--- a/go/kbfs/libkbfs/channels.go
+++ b/go/kbfs/libkbfs/channels.go
@@ -18,7 +18,7 @@ const (
 // infinite channel without fearing a panic when we Close() it.
 type InfiniteChannelWrapper struct {
 	*channels.InfiniteChannel
-	input        chan interface{}
+	input        chan any
 	shutdownOnce sync.Once
 	shutdownCh   chan struct{}
 }
@@ -30,7 +30,7 @@ var _ channels.Channel = (*InfiniteChannelWrapper)(nil)
 func NewInfiniteChannelWrapper() *InfiniteChannelWrapper {
 	ch := &InfiniteChannelWrapper{
 		InfiniteChannel: channels.NewInfiniteChannel(),
-		input:           make(chan interface{}, defaultInfiniteBufferSize),
+		input:           make(chan any, defaultInfiniteBufferSize),
 		shutdownCh:      make(chan struct{}),
 	}
 	go ch.run()
@@ -50,7 +50,7 @@ func (ch *InfiniteChannelWrapper) run() {
 }
 
 // In returns the input channel for this infinite channel.
-func (ch *InfiniteChannelWrapper) In() chan<- interface{} {
+func (ch *InfiniteChannelWrapper) In() chan<- any {
 	return ch.input
 }
 

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3374,13 +3374,13 @@ func (cr *ConflictResolver) recordStartResolve(ci conflictInput) error {
 }
 
 // recordFinishResolve does one of two things:
-//  - in the event of success, it deletes the DB entry that recorded conflict
-//    resolution attempts for this resolver
-//  - in the event of failure, it logs that CR failed and tries to record the
-//    failure to the DB.
+//   - in the event of success, it deletes the DB entry that recorded conflict
+//     resolution attempts for this resolver
+//   - in the event of failure, it logs that CR failed and tries to record the
+//     failure to the DB.
 func (cr *ConflictResolver) recordFinishResolve(
 	ctx context.Context, ci conflictInput,
-	panicVar interface{}, receivedErr error) {
+	panicVar any, receivedErr error) {
 	db, key, _, wasStuck, err := cr.isStuckWithDbAndConflicts()
 	if err != nil {
 		cr.log.CWarningf(ctx, "could not record CR result: %+v", err)

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -89,7 +89,7 @@ type failingCodec struct {
 	kbfscodec.Codec
 }
 
-func (fc failingCodec) Encode(interface{}) ([]byte, error) {
+func (fc failingCodec) Encode(any) ([]byte, error) {
 	return nil, errors.New("Stopping resolution process early")
 }
 

--- a/go/kbfs/libkbfs/crypto_client_test.go
+++ b/go/kbfs/libkbfs/crypto_client_test.go
@@ -57,23 +57,23 @@ func (fc FakeCryptoClient) maybeWaitOnChannel(ctx context.Context) error {
 	}
 }
 
-func (fc FakeCryptoClient) Call(ctx context.Context, s string, args interface{},
-	res interface{}, _ time.Duration) error {
+func (fc FakeCryptoClient) Call(ctx context.Context, s string, args any,
+	res any, _ time.Duration) error {
 	return fc.call(ctx, s, args, res)
 }
 
-func (fc FakeCryptoClient) CallCompressed(ctx context.Context, s string, args interface{},
-	res interface{}, _ rpc.CompressionType, _ time.Duration) error {
+func (fc FakeCryptoClient) CallCompressed(ctx context.Context, s string, args any,
+	res any, _ rpc.CompressionType, _ time.Duration) error {
 	return fc.call(ctx, s, args, res)
 }
 
-func (fc FakeCryptoClient) call(ctx context.Context, s string, args interface{}, res interface{}) error {
+func (fc FakeCryptoClient) call(ctx context.Context, s string, args any, res any) error {
 	switch s {
 	case "keybase.1.crypto.signED25519":
 		if err := fc.maybeWaitOnChannel(ctx); err != nil {
 			return err
 		}
-		arg := args.([]interface{})[0].(keybase1.SignED25519Arg)
+		arg := args.([]any)[0].(keybase1.SignED25519Arg)
 		sigInfo, err := fc.Local.Sign(ctx, arg.Msg)
 		if err != nil {
 			return err
@@ -96,7 +96,7 @@ func (fc FakeCryptoClient) call(ctx context.Context, s string, args interface{},
 		if err := fc.maybeWaitOnChannel(ctx); err != nil {
 			return err
 		}
-		arg := args.([]interface{})[0].(keybase1.UnboxBytes32Arg)
+		arg := args.([]any)[0].(keybase1.UnboxBytes32Arg)
 		publicKey := kbfscrypto.MakeTLFEphemeralPublicKey(
 			arg.PeersPublicKey)
 		encryptedClientHalf := kbfscrypto.MakeEncryptedTLFCryptKeyClientHalfForTest(
@@ -115,7 +115,7 @@ func (fc FakeCryptoClient) call(ctx context.Context, s string, args interface{},
 		if err := fc.maybeWaitOnChannel(ctx); err != nil {
 			return err
 		}
-		arg := args.([]interface{})[0].(keybase1.UnboxBytes32AnyArg)
+		arg := args.([]any)[0].(keybase1.UnboxBytes32AnyArg)
 		keys := make([]EncryptedTLFCryptKeyClientAndEphemeral, 0, len(arg.Bundles))
 		for _, k := range arg.Bundles {
 			ePublicKey := kbfscrypto.MakeTLFEphemeralPublicKey(
@@ -146,7 +146,7 @@ func (fc FakeCryptoClient) call(ctx context.Context, s string, args interface{},
 	}
 }
 
-func (fc FakeCryptoClient) Notify(_ context.Context, s string, args interface{}, _ time.Duration) error {
+func (fc FakeCryptoClient) Notify(_ context.Context, s string, args any, _ time.Duration) error {
 	return errors.Errorf("Unknown notify: %s %v", s, args)
 }
 

--- a/go/kbfs/libkbfs/data_mocks_test.go
+++ b/go/kbfs/libkbfs/data_mocks_test.go
@@ -47,7 +47,7 @@ func (m *MockBlockCache) CheckForKnownPtr(arg0 tlf.ID, arg1 *data.FileBlock, arg
 }
 
 // CheckForKnownPtr indicates an expected call of CheckForKnownPtr.
-func (mr *MockBlockCacheMockRecorder) CheckForKnownPtr(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockCacheMockRecorder) CheckForKnownPtr(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckForKnownPtr", reflect.TypeOf((*MockBlockCache)(nil).CheckForKnownPtr), arg0, arg1, arg2)
 }
@@ -61,7 +61,7 @@ func (m *MockBlockCache) DeleteKnownPtr(arg0 tlf.ID, arg1 *data.FileBlock) error
 }
 
 // DeleteKnownPtr indicates an expected call of DeleteKnownPtr.
-func (mr *MockBlockCacheMockRecorder) DeleteKnownPtr(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockCacheMockRecorder) DeleteKnownPtr(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKnownPtr", reflect.TypeOf((*MockBlockCache)(nil).DeleteKnownPtr), arg0, arg1)
 }
@@ -75,7 +75,7 @@ func (m *MockBlockCache) DeletePermanent(arg0 kbfsblock.ID) error {
 }
 
 // DeletePermanent indicates an expected call of DeletePermanent.
-func (mr *MockBlockCacheMockRecorder) DeletePermanent(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockCacheMockRecorder) DeletePermanent(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePermanent", reflect.TypeOf((*MockBlockCache)(nil).DeletePermanent), arg0)
 }
@@ -89,7 +89,7 @@ func (m *MockBlockCache) DeleteTransient(arg0 kbfsblock.ID, arg1 tlf.ID) error {
 }
 
 // DeleteTransient indicates an expected call of DeleteTransient.
-func (mr *MockBlockCacheMockRecorder) DeleteTransient(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockCacheMockRecorder) DeleteTransient(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransient", reflect.TypeOf((*MockBlockCache)(nil).DeleteTransient), arg0, arg1)
 }
@@ -104,7 +104,7 @@ func (m *MockBlockCache) Get(arg0 data.BlockPointer) (data.Block, error) {
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockBlockCacheMockRecorder) Get(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockCacheMockRecorder) Get(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBlockCache)(nil).Get), arg0)
 }
@@ -134,7 +134,7 @@ func (m *MockBlockCache) GetWithLifetime(arg0 data.BlockPointer) (data.Block, da
 }
 
 // GetWithLifetime indicates an expected call of GetWithLifetime.
-func (mr *MockBlockCacheMockRecorder) GetWithLifetime(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockCacheMockRecorder) GetWithLifetime(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithLifetime", reflect.TypeOf((*MockBlockCache)(nil).GetWithLifetime), arg0)
 }
@@ -148,7 +148,7 @@ func (m *MockBlockCache) Put(arg0 data.BlockPointer, arg1 tlf.ID, arg2 data.Bloc
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockBlockCacheMockRecorder) Put(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockBlockCacheMockRecorder) Put(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockBlockCache)(nil).Put), arg0, arg1, arg2, arg3, arg4)
 }
@@ -160,7 +160,7 @@ func (m *MockBlockCache) SetCleanBytesCapacity(arg0 uint64) {
 }
 
 // SetCleanBytesCapacity indicates an expected call of SetCleanBytesCapacity.
-func (mr *MockBlockCacheMockRecorder) SetCleanBytesCapacity(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockCacheMockRecorder) SetCleanBytesCapacity(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCleanBytesCapacity", reflect.TypeOf((*MockBlockCache)(nil).SetCleanBytesCapacity), arg0)
 }
@@ -197,7 +197,7 @@ func (m *MockBlockSplitter) CheckSplit(arg0 *data.FileBlock) int64 {
 }
 
 // CheckSplit indicates an expected call of CheckSplit.
-func (mr *MockBlockSplitterMockRecorder) CheckSplit(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockSplitterMockRecorder) CheckSplit(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckSplit", reflect.TypeOf((*MockBlockSplitter)(nil).CheckSplit), arg0)
 }
@@ -211,7 +211,7 @@ func (m *MockBlockSplitter) CopyUntilSplit(arg0 *data.FileBlock, arg1 bool, arg2
 }
 
 // CopyUntilSplit indicates an expected call of CopyUntilSplit.
-func (mr *MockBlockSplitterMockRecorder) CopyUntilSplit(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockBlockSplitterMockRecorder) CopyUntilSplit(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyUntilSplit", reflect.TypeOf((*MockBlockSplitter)(nil).CopyUntilSplit), arg0, arg1, arg2, arg3)
 }
@@ -239,7 +239,7 @@ func (m *MockBlockSplitter) ShouldEmbedData(arg0 uint64) bool {
 }
 
 // ShouldEmbedData indicates an expected call of ShouldEmbedData.
-func (mr *MockBlockSplitterMockRecorder) ShouldEmbedData(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockSplitterMockRecorder) ShouldEmbedData(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldEmbedData", reflect.TypeOf((*MockBlockSplitter)(nil).ShouldEmbedData), arg0)
 }
@@ -254,7 +254,7 @@ func (m *MockBlockSplitter) SplitDirIfNeeded(arg0 *data.DirBlock) ([]*data.DirBl
 }
 
 // SplitDirIfNeeded indicates an expected call of SplitDirIfNeeded.
-func (mr *MockBlockSplitterMockRecorder) SplitDirIfNeeded(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockSplitterMockRecorder) SplitDirIfNeeded(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SplitDirIfNeeded", reflect.TypeOf((*MockBlockSplitter)(nil).SplitDirIfNeeded), arg0)
 }
@@ -289,7 +289,7 @@ func (m *MockBlockWithPtrs) AppendNewIndirectPtr(arg0 data.BlockPointer, arg1 da
 }
 
 // AppendNewIndirectPtr indicates an expected call of AppendNewIndirectPtr.
-func (mr *MockBlockWithPtrsMockRecorder) AppendNewIndirectPtr(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) AppendNewIndirectPtr(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendNewIndirectPtr", reflect.TypeOf((*MockBlockWithPtrs)(nil).AppendNewIndirectPtr), arg0, arg1)
 }
@@ -315,7 +315,7 @@ func (m *MockBlockWithPtrs) ClearIndirectPtrSize(arg0 int) {
 }
 
 // ClearIndirectPtrSize indicates an expected call of ClearIndirectPtrSize.
-func (mr *MockBlockWithPtrsMockRecorder) ClearIndirectPtrSize(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) ClearIndirectPtrSize(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearIndirectPtrSize", reflect.TypeOf((*MockBlockWithPtrs)(nil).ClearIndirectPtrSize), arg0)
 }
@@ -372,7 +372,7 @@ func (m *MockBlockWithPtrs) IndirectPtr(arg0 int) (data.BlockInfo, data.Offset) 
 }
 
 // IndirectPtr indicates an expected call of IndirectPtr.
-func (mr *MockBlockWithPtrsMockRecorder) IndirectPtr(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) IndirectPtr(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndirectPtr", reflect.TypeOf((*MockBlockWithPtrs)(nil).IndirectPtr), arg0)
 }
@@ -456,7 +456,7 @@ func (m *MockBlockWithPtrs) OffsetExceedsData(arg0, arg1 data.Offset) bool {
 }
 
 // OffsetExceedsData indicates an expected call of OffsetExceedsData.
-func (mr *MockBlockWithPtrsMockRecorder) OffsetExceedsData(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) OffsetExceedsData(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OffsetExceedsData", reflect.TypeOf((*MockBlockWithPtrs)(nil).OffsetExceedsData), arg0, arg1)
 }
@@ -468,7 +468,7 @@ func (m *MockBlockWithPtrs) Set(arg0 data.Block) {
 }
 
 // Set indicates an expected call of Set.
-func (mr *MockBlockWithPtrsMockRecorder) Set(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) Set(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockBlockWithPtrs)(nil).Set), arg0)
 }
@@ -480,7 +480,7 @@ func (m *MockBlockWithPtrs) SetEncodedSize(arg0 uint32) {
 }
 
 // SetEncodedSize indicates an expected call of SetEncodedSize.
-func (mr *MockBlockWithPtrsMockRecorder) SetEncodedSize(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) SetEncodedSize(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEncodedSize", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetEncodedSize), arg0)
 }
@@ -492,7 +492,7 @@ func (m *MockBlockWithPtrs) SetIndirectPtrInfo(arg0 int, arg1 data.BlockInfo) {
 }
 
 // SetIndirectPtrInfo indicates an expected call of SetIndirectPtrInfo.
-func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrInfo(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrInfo(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIndirectPtrInfo", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetIndirectPtrInfo), arg0, arg1)
 }
@@ -504,7 +504,7 @@ func (m *MockBlockWithPtrs) SetIndirectPtrOff(arg0 int, arg1 data.Offset) {
 }
 
 // SetIndirectPtrOff indicates an expected call of SetIndirectPtrOff.
-func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrOff(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrOff(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIndirectPtrOff", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetIndirectPtrOff), arg0, arg1)
 }
@@ -516,7 +516,7 @@ func (m *MockBlockWithPtrs) SetIndirectPtrType(arg0 int, arg1 data.BlockDirectTy
 }
 
 // SetIndirectPtrType indicates an expected call of SetIndirectPtrType.
-func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrType(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrType(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIndirectPtrType", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetIndirectPtrType), arg0, arg1)
 }
@@ -528,7 +528,7 @@ func (m *MockBlockWithPtrs) SwapIndirectPtrs(arg0 int, arg1 data.BlockWithPtrs, 
 }
 
 // SwapIndirectPtrs indicates an expected call of SwapIndirectPtrs.
-func (mr *MockBlockWithPtrsMockRecorder) SwapIndirectPtrs(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockWithPtrsMockRecorder) SwapIndirectPtrs(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SwapIndirectPtrs", reflect.TypeOf((*MockBlockWithPtrs)(nil).SwapIndirectPtrs), arg0, arg1, arg2)
 }
@@ -577,7 +577,7 @@ func (m *MockDirtyBlockCache) BlockSyncFinished(arg0 tlf.ID, arg1 int64) {
 }
 
 // BlockSyncFinished indicates an expected call of BlockSyncFinished.
-func (mr *MockDirtyBlockCacheMockRecorder) BlockSyncFinished(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) BlockSyncFinished(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockSyncFinished", reflect.TypeOf((*MockDirtyBlockCache)(nil).BlockSyncFinished), arg0, arg1)
 }
@@ -591,7 +591,7 @@ func (m *MockDirtyBlockCache) Delete(arg0 tlf.ID, arg1 data.BlockPointer, arg2 d
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockDirtyBlockCacheMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) Delete(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDirtyBlockCache)(nil).Delete), arg0, arg1, arg2)
 }
@@ -606,7 +606,7 @@ func (m *MockDirtyBlockCache) Get(arg0 context.Context, arg1 tlf.ID, arg2 data.B
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockDirtyBlockCacheMockRecorder) Get(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) Get(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDirtyBlockCache)(nil).Get), arg0, arg1, arg2, arg3)
 }
@@ -620,7 +620,7 @@ func (m *MockDirtyBlockCache) IsAnyDirty(arg0 tlf.ID) bool {
 }
 
 // IsAnyDirty indicates an expected call of IsAnyDirty.
-func (mr *MockDirtyBlockCacheMockRecorder) IsAnyDirty(arg0 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) IsAnyDirty(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAnyDirty", reflect.TypeOf((*MockDirtyBlockCache)(nil).IsAnyDirty), arg0)
 }
@@ -634,7 +634,7 @@ func (m *MockDirtyBlockCache) IsDirty(arg0 tlf.ID, arg1 data.BlockPointer, arg2 
 }
 
 // IsDirty indicates an expected call of IsDirty.
-func (mr *MockDirtyBlockCacheMockRecorder) IsDirty(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) IsDirty(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDirty", reflect.TypeOf((*MockDirtyBlockCache)(nil).IsDirty), arg0, arg1, arg2)
 }
@@ -648,7 +648,7 @@ func (m *MockDirtyBlockCache) Put(arg0 context.Context, arg1 tlf.ID, arg2 data.B
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockDirtyBlockCacheMockRecorder) Put(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) Put(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockDirtyBlockCache)(nil).Put), arg0, arg1, arg2, arg3, arg4)
 }
@@ -663,7 +663,7 @@ func (m *MockDirtyBlockCache) RequestPermissionToDirty(arg0 context.Context, arg
 }
 
 // RequestPermissionToDirty indicates an expected call of RequestPermissionToDirty.
-func (mr *MockDirtyBlockCacheMockRecorder) RequestPermissionToDirty(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) RequestPermissionToDirty(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestPermissionToDirty", reflect.TypeOf((*MockDirtyBlockCache)(nil).RequestPermissionToDirty), arg0, arg1, arg2)
 }
@@ -677,7 +677,7 @@ func (m *MockDirtyBlockCache) ShouldForceSync(arg0 tlf.ID) bool {
 }
 
 // ShouldForceSync indicates an expected call of ShouldForceSync.
-func (mr *MockDirtyBlockCacheMockRecorder) ShouldForceSync(arg0 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) ShouldForceSync(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldForceSync", reflect.TypeOf((*MockDirtyBlockCache)(nil).ShouldForceSync), arg0)
 }
@@ -703,7 +703,7 @@ func (m *MockDirtyBlockCache) SyncFinished(arg0 tlf.ID, arg1 int64) {
 }
 
 // SyncFinished indicates an expected call of SyncFinished.
-func (mr *MockDirtyBlockCacheMockRecorder) SyncFinished(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) SyncFinished(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncFinished", reflect.TypeOf((*MockDirtyBlockCache)(nil).SyncFinished), arg0, arg1)
 }
@@ -715,7 +715,7 @@ func (m *MockDirtyBlockCache) UpdateSyncingBytes(arg0 tlf.ID, arg1 int64) {
 }
 
 // UpdateSyncingBytes indicates an expected call of UpdateSyncingBytes.
-func (mr *MockDirtyBlockCacheMockRecorder) UpdateSyncingBytes(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) UpdateSyncingBytes(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSyncingBytes", reflect.TypeOf((*MockDirtyBlockCache)(nil).UpdateSyncingBytes), arg0, arg1)
 }
@@ -727,7 +727,7 @@ func (m *MockDirtyBlockCache) UpdateUnsyncedBytes(arg0 tlf.ID, arg1 int64, arg2 
 }
 
 // UpdateUnsyncedBytes indicates an expected call of UpdateUnsyncedBytes.
-func (mr *MockDirtyBlockCacheMockRecorder) UpdateUnsyncedBytes(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) UpdateUnsyncedBytes(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUnsyncedBytes", reflect.TypeOf((*MockDirtyBlockCache)(nil).UpdateUnsyncedBytes), arg0, arg1, arg2)
 }

--- a/go/kbfs/libkbfs/disk_journal.go
+++ b/go/kbfs/libkbfs/disk_journal.go
@@ -259,7 +259,7 @@ func (j *diskJournal) removeEarliest() (empty bool, err error) {
 
 // The functions below are for reading and writing journal entries.
 
-func (j diskJournal) readJournalEntry(o journalOrdinal) (interface{}, error) {
+func (j diskJournal) readJournalEntry(o journalOrdinal) (any, error) {
 	p := j.journalEntryPath(o)
 	entry := reflect.New(j.entryType)
 	err := kbfscodec.DeserializeFromFile(j.codec, p, entry)
@@ -271,7 +271,7 @@ func (j diskJournal) readJournalEntry(o journalOrdinal) (interface{}, error) {
 }
 
 func (j *diskJournal) writeJournalEntry(
-	o journalOrdinal, entry interface{}) error {
+	o journalOrdinal, entry any) error {
 	entryType := reflect.TypeOf(entry)
 	if entryType != j.entryType {
 		panic(errors.Errorf("Expected entry type %v, got %v",
@@ -290,7 +290,7 @@ func (j *diskJournal) writeJournalEntry(
 // successful, appendJournalEntry returns the ordinal of the
 // just-appended entry.
 func (j *diskJournal) appendJournalEntry(
-	o *journalOrdinal, entry interface{}) (journalOrdinal, error) {
+	o *journalOrdinal, entry any) (journalOrdinal, error) {
 	var next journalOrdinal
 	if j.empty() {
 		if o != nil {

--- a/go/kbfs/libkbfs/disk_limiter.go
+++ b/go/kbfs/libkbfs/disk_limiter.go
@@ -138,5 +138,5 @@ type DiskLimiter interface {
 
 	// getStatus returns an object that's marshallable into JSON
 	// for use in displaying status.
-	getStatus(ctx context.Context, chargedTo keybase1.UserOrTeamID) interface{}
+	getStatus(ctx context.Context, chargedTo keybase1.UserOrTeamID) any
 }

--- a/go/kbfs/libkbfs/fetch_decider.go
+++ b/go/kbfs/libkbfs/fetch_decider.go
@@ -25,7 +25,7 @@ type fetchDecider struct {
 	log     logger.Logger
 	vlog    *libkb.VDebugLog
 	fetcher func(ctx context.Context) error
-	tagKey  interface{}
+	tagKey  any
 	tagName string
 
 	blockingForTest chan<- struct{}
@@ -37,7 +37,7 @@ type fetchDecider struct {
 
 func newFetchDecider(
 	log logger.Logger, vlog *libkb.VDebugLog,
-	fetcher func(ctx context.Context) error, tagKey interface{}, tagName string,
+	fetcher func(ctx context.Context) error, tagKey any, tagName string,
 	clock clockGetter) *fetchDecider {
 	return &fetchDecider{
 		log:         log,

--- a/go/kbfs/libkbfs/flag_size.go
+++ b/go/kbfs/libkbfs/flag_size.go
@@ -16,7 +16,7 @@ type SizeFlag struct {
 }
 
 // Get for flag interface.
-func (sf SizeFlag) Get() interface{} { return *sf.v }
+func (sf SizeFlag) Get() any { return *sf.v }
 
 // String for flag interface.
 func (sf SizeFlag) String() string {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -209,37 +209,37 @@ type editChannelActivity struct {
 // concurrent access whenever possible.  See design/state_machine.md
 // for more details.  There are three important locks:
 //
-// 1) mdWriterLock: Any "remote-sync" operation (one which modifies the
-//    folder's metadata) must take this lock during the entirety of
-//    its operation, to avoid forking the MD.
+//  1. mdWriterLock: Any "remote-sync" operation (one which modifies the
+//     folder's metadata) must take this lock during the entirety of
+//     its operation, to avoid forking the MD.
 //
-// 2) headLock: This is a read/write mutex.  It must be taken for
-//    reading before accessing any part of the current head MD.  It
-//    should be taken for the shortest time possible -- that means in
-//    general that it should be taken, and the MD copied to a
-//    goroutine-local variable, and then it can be released.
-//    Remote-sync operations should take it for writing after pushing
-//    all of the blocks and MD to the KBFS servers (i.e., all network
-//    accesses), and then hold it until after all notifications have
-//    been fired, to ensure that no concurrent "local" operations ever
-//    see inconsistent state locally.
+//  2. headLock: This is a read/write mutex.  It must be taken for
+//     reading before accessing any part of the current head MD.  It
+//     should be taken for the shortest time possible -- that means in
+//     general that it should be taken, and the MD copied to a
+//     goroutine-local variable, and then it can be released.
+//     Remote-sync operations should take it for writing after pushing
+//     all of the blocks and MD to the KBFS servers (i.e., all network
+//     accesses), and then hold it until after all notifications have
+//     been fired, to ensure that no concurrent "local" operations ever
+//     see inconsistent state locally.
 //
-// 3) blockLock: This too is a read/write mutex.  It must be taken for
-//    reading before accessing any blocks in the block cache that
-//    belong to this folder/branch.  This includes checking their
-//    dirty status.  It should be taken for the shortest time possible
-//    -- that means in general it should be taken, and then the blocks
-//    that will be modified should be copied to local variables in the
-//    goroutine, and then it should be released.  The blocks should
-//    then be modified locally, and then readied and pushed out
-//    remotely.  Only after the blocks have been pushed to the server
-//    should a remote-sync operation take the lock again (this time
-//    for writing) and put/finalize the blocks.  Write and Truncate
-//    should take blockLock for their entire lifetime, since they
-//    don't involve writes over the network.  Furthermore, if a block
-//    is not in the cache and needs to be fetched, we should release
-//    the mutex before doing the network operation, and lock it again
-//    before writing the block back to the cache.
+//  3. blockLock: This too is a read/write mutex.  It must be taken for
+//     reading before accessing any blocks in the block cache that
+//     belong to this folder/branch.  This includes checking their
+//     dirty status.  It should be taken for the shortest time possible
+//     -- that means in general it should be taken, and then the blocks
+//     that will be modified should be copied to local variables in the
+//     goroutine, and then it should be released.  The blocks should
+//     then be modified locally, and then readied and pushed out
+//     remotely.  Only after the blocks have been pushed to the server
+//     should a remote-sync operation take the lock again (this time
+//     for writing) and put/finalize the blocks.  Write and Truncate
+//     should take blockLock for their entire lifetime, since they
+//     don't involve writes over the network.  Furthermore, if a block
+//     is not in the cache and needs to be fetched, we should release
+//     the mutex before doing the network operation, and lock it again
+//     before writing the block back to the cache.
 //
 // We want to allow writes and truncates to a file that's currently
 // being sync'd, like any good networked file system.  The tricky part
@@ -1089,7 +1089,7 @@ func (fbo *folderBranchOps) syncOneNode(
 }
 
 func (fbo *folderBranchOps) startOp(
-	ctx context.Context, fs string, args ...interface{}) (
+	ctx context.Context, fs string, args ...any) (
 	time.Time, *time.Timer) {
 	now := fbo.config.Clock().Now()
 	// Immediately log with vlog, and if the operation takes more than
@@ -1100,7 +1100,7 @@ func (fbo *folderBranchOps) startOp(
 		case <-ctx.Done():
 			return
 		default:
-			newArgs := make([]interface{}, len(args)+1)
+			newArgs := make([]any, len(args)+1)
 			newArgs[0] = now
 			copy(newArgs[1:], args)
 			fbo.deferLog.CDebugf(
@@ -1112,10 +1112,10 @@ func (fbo *folderBranchOps) startOp(
 
 func (fbo *folderBranchOps) endOp(
 	ctx context.Context, startTime time.Time, timer *time.Timer, fs string,
-	args ...interface{}) {
+	args ...any) {
 	timer.Stop()
 	d := fbo.config.Clock().Now().Sub(startTime)
-	newArgs := make([]interface{}, len(args)+1)
+	newArgs := make([]any, len(args)+1)
 	newArgs[0] = d
 	copy(newArgs[1:], args)
 	fbo.defer2Log.CDebugf(ctx, "[duration=%s] "+fs, newArgs...)
@@ -3711,7 +3711,7 @@ func (fbo *folderBranchOps) statEntry(ctx context.Context, node Node) (
 }
 
 func (fbo *folderBranchOps) deferLogIfErr(
-	ctx context.Context, err error, fs string, args ...interface{}) {
+	ctx context.Context, err error, fs string, args ...any) {
 	if err != nil {
 		fbo.defer2Log.CDebugf(ctx, fs, args...)
 	} else {
@@ -5782,22 +5782,22 @@ type cleanupFn func(context.Context, *kbfssync.LockState, []data.BlockPointer, e
 // startSyncLocked readies the blocks and other state needed to sync a
 // single file.  It returns:
 //
-// * `doSync`: Whether or not the sync should actually happen.
-// * `stillDirty`: Whether the file should still be considered dirty when
-//   this function returns.  (That is, if `doSync` is false, and `stillDirty`
-//   is true, then the file has outstanding changes but the sync was vetoed for
-//   some other reason.)
-// * `fblock`: the root file block for the file being sync'd.
-// * `lbc`: A local block cache consisting of a dirtied version of the parent
-//   directory for this file.
-// * `bps`: All the blocks that need to be put to the server.
-// * `syncState`: Must be passed to the `FinishSyncLocked` call after the
-//   update completes.
-// * `cleanupFn`: A function that, if non-nil, must be called after the sync
-//   is done.  `cleanupFn` should be passed the set of bad blocks that couldn't
-//   be sync'd (if any), and the error.
-// * `err`: The best, greatest return value, everyone says it's absolutely
-//   stunning.
+//   - `doSync`: Whether or not the sync should actually happen.
+//   - `stillDirty`: Whether the file should still be considered dirty when
+//     this function returns.  (That is, if `doSync` is false, and `stillDirty`
+//     is true, then the file has outstanding changes but the sync was vetoed for
+//     some other reason.)
+//   - `fblock`: the root file block for the file being sync'd.
+//   - `lbc`: A local block cache consisting of a dirtied version of the parent
+//     directory for this file.
+//   - `bps`: All the blocks that need to be put to the server.
+//   - `syncState`: Must be passed to the `FinishSyncLocked` call after the
+//     update completes.
+//   - `cleanupFn`: A function that, if non-nil, must be called after the sync
+//     is done.  `cleanupFn` should be passed the set of bad blocks that couldn't
+//     be sync'd (if any), and the error.
+//   - `err`: The best, greatest return value, everyone says it's absolutely
+//     stunning.
 func (fbo *folderBranchOps) startSyncLocked(ctx context.Context,
 	lState *kbfssync.LockState, md *RootMetadata, node Node, file data.Path) (
 	doSync, stillDirty bool, fblock *data.FileBlock, dirtyDe *data.DirEntry,

--- a/go/kbfs/libkbfs/folder_branch_status_test.go
+++ b/go/kbfs/libkbfs/folder_branch_status_test.go
@@ -88,7 +88,7 @@ type mockNodeMatcher struct {
 	node *MockNode
 }
 
-func (m mockNodeMatcher) Matches(x interface{}) bool {
+func (m mockNodeMatcher) Matches(x any) bool {
 	n, ok := x.(*MockNode)
 	if !ok {
 		return false

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -95,7 +95,7 @@ type JournalManagerStatus struct {
 	UnflushedBytes    int64
 	UnflushedPaths    []string
 	EndEstimate       *time.Time
-	DiskLimiterStatus interface{}
+	DiskLimiterStatus any
 	Conflicts         []ConflictJournalRecord `json:",omitempty"`
 	ClearedConflicts  []ConflictJournalRecord `json:",omitempty"`
 }
@@ -141,7 +141,7 @@ type clearedConflictVal struct {
 // server journal is 108: 51 for the TLF journal, and 57 for
 // everything else.
 //
-//   /v1/de...-...(53 characters total)...ff(/tlf journal)
+//	/v1/de...-...(53 characters total)...ff(/tlf journal)
 type JournalManager struct {
 	config     Config
 	defaultBWS TLFJournalBackgroundWorkStatus

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -586,7 +586,7 @@ type ptrMatcher struct {
 }
 
 // Matches implements the Matcher interface for ptrMatcher.
-func (p ptrMatcher) Matches(x interface{}) bool {
+func (p ptrMatcher) Matches(x any) bool {
 	xPtr, ok := x.(data.BlockPointer)
 	if !ok {
 		return false
@@ -3874,7 +3874,7 @@ func (fi *fakeFileInfo) IsDir() bool {
 	return fi.et == data.Dir
 }
 
-func (fi *fakeFileInfo) Sys() interface{} {
+func (fi *fakeFileInfo) Sys() any {
 	return nil
 }
 

--- a/go/kbfs/libkbfs/kbfs_service.go
+++ b/go/kbfs/libkbfs/kbfs_service.go
@@ -21,12 +21,12 @@ type KBFSErrorUnwrapper struct {
 var _ rpc.ErrorUnwrapper = KBFSErrorUnwrapper{}
 
 // MakeArg implements rpc.ErrorUnwrapper.
-func (eu KBFSErrorUnwrapper) MakeArg() interface{} {
+func (eu KBFSErrorUnwrapper) MakeArg() any {
 	return &keybase1.Status{}
 }
 
 // UnwrapError implements rpc.ErrorUnwrapper.
-func (eu KBFSErrorUnwrapper) UnwrapError(arg interface{}) (appError error,
+func (eu KBFSErrorUnwrapper) UnwrapError(arg any) (appError error,
 	dispatchError error) {
 	s, ok := arg.(*keybase1.Status)
 	if !ok {

--- a/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
@@ -69,17 +69,17 @@ type fakeKeybaseClient struct {
 
 var _ rpc.GenericClient = (*fakeKeybaseClient)(nil)
 
-func (c *fakeKeybaseClient) Call(ctx context.Context, s string, args interface{},
-	res interface{}, _ time.Duration) error {
+func (c *fakeKeybaseClient) Call(ctx context.Context, s string, args any,
+	res any, _ time.Duration) error {
 	return c.call(ctx, s, args, res)
 }
 
-func (c *fakeKeybaseClient) CallCompressed(ctx context.Context, s string, args interface{},
-	res interface{}, _ rpc.CompressionType, _ time.Duration) error {
+func (c *fakeKeybaseClient) CallCompressed(ctx context.Context, s string, args any,
+	res any, _ rpc.CompressionType, _ time.Duration) error {
 	return c.call(ctx, s, args, res)
 }
 
-func (c *fakeKeybaseClient) call(ctx context.Context, s string, args interface{}, res interface{}) error {
+func (c *fakeKeybaseClient) call(ctx context.Context, s string, args any, res any) error {
 	switch s {
 	case "keybase.1.session.currentSession":
 		*res.(*keybase1.Session) = keybase1.Session{
@@ -93,7 +93,7 @@ func (c *fakeKeybaseClient) call(ctx context.Context, s string, args interface{}
 		return nil
 
 	case "keybase.1.identify.identifyLite":
-		arg := args.([]interface{})[0].(keybase1.IdentifyLiteArg)
+		arg := args.([]any)[0].(keybase1.IdentifyLiteArg)
 		uidStr := strings.TrimPrefix(arg.Assertion, "uid:")
 		if len(uidStr) == len(arg.Assertion) {
 			return fmt.Errorf("Non-uid assertion %s", arg.Assertion)
@@ -116,7 +116,7 @@ func (c *fakeKeybaseClient) call(ctx context.Context, s string, args interface{}
 		return nil
 
 	case "keybase.1.user.loadUserPlusKeysV2":
-		arg := args.([]interface{})[0].(keybase1.LoadUserPlusKeysV2Arg)
+		arg := args.([]any)[0].(keybase1.LoadUserPlusKeysV2Arg)
 
 		userInfo, ok := c.users[arg.Uid]
 		if !ok {
@@ -144,7 +144,7 @@ func (c *fakeKeybaseClient) call(ctx context.Context, s string, args interface{}
 		return nil
 
 	case "keybase.1.kbfs.FSEditList":
-		c.editResponse = args.([]interface{})[0].(keybase1.FSEditListArg)
+		c.editResponse = args.([]any)[0].(keybase1.FSEditListArg)
 		return nil
 
 	default:
@@ -152,7 +152,7 @@ func (c *fakeKeybaseClient) call(ctx context.Context, s string, args interface{}
 	}
 }
 
-func (c *fakeKeybaseClient) Notify(_ context.Context, s string, args interface{}, timeout time.Duration) error {
+func (c *fakeKeybaseClient) Notify(_ context.Context, s string, args any, timeout time.Duration) error {
 	return fmt.Errorf("Unknown notify: %s %v", s, args)
 }
 

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -58,7 +58,7 @@ func (m *MockBlockOps) Archive(arg0 context.Context, arg1 tlf.ID, arg2 []data.Bl
 }
 
 // Archive indicates an expected call of Archive.
-func (mr *MockBlockOpsMockRecorder) Archive(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockOpsMockRecorder) Archive(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Archive", reflect.TypeOf((*MockBlockOps)(nil).Archive), arg0, arg1, arg2)
 }
@@ -87,7 +87,7 @@ func (m *MockBlockOps) Delete(arg0 context.Context, arg1 tlf.ID, arg2 []data.Blo
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockBlockOpsMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockOpsMockRecorder) Delete(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockBlockOps)(nil).Delete), arg0, arg1, arg2)
 }
@@ -101,7 +101,7 @@ func (m *MockBlockOps) Get(arg0 context.Context, arg1 libkey.KeyMetadata, arg2 d
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockBlockOpsMockRecorder) Get(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockBlockOpsMockRecorder) Get(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBlockOps)(nil).Get), arg0, arg1, arg2, arg3, arg4, arg5)
 }
@@ -117,7 +117,7 @@ func (m *MockBlockOps) GetEncodedSizes(arg0 context.Context, arg1 libkey.KeyMeta
 }
 
 // GetEncodedSizes indicates an expected call of GetEncodedSizes.
-func (mr *MockBlockOpsMockRecorder) GetEncodedSizes(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockOpsMockRecorder) GetEncodedSizes(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncodedSizes", reflect.TypeOf((*MockBlockOps)(nil).GetEncodedSizes), arg0, arg1, arg2)
 }
@@ -132,7 +132,7 @@ func (m *MockBlockOps) GetLiveCount(arg0 context.Context, arg1 tlf.ID, arg2 []da
 }
 
 // GetLiveCount indicates an expected call of GetLiveCount.
-func (mr *MockBlockOpsMockRecorder) GetLiveCount(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockOpsMockRecorder) GetLiveCount(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLiveCount", reflect.TypeOf((*MockBlockOps)(nil).GetLiveCount), arg0, arg1, arg2)
 }
@@ -163,7 +163,7 @@ func (m *MockBlockOps) Ready(arg0 context.Context, arg1 libkey.KeyMetadata, arg2
 }
 
 // Ready indicates an expected call of Ready.
-func (mr *MockBlockOpsMockRecorder) Ready(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockOpsMockRecorder) Ready(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ready", reflect.TypeOf((*MockBlockOps)(nil).Ready), arg0, arg1, arg2)
 }
@@ -177,7 +177,7 @@ func (m *MockBlockOps) Shutdown(arg0 context.Context) error {
 }
 
 // Shutdown indicates an expected call of Shutdown.
-func (mr *MockBlockOpsMockRecorder) Shutdown(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockOpsMockRecorder) Shutdown(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockBlockOps)(nil).Shutdown), arg0)
 }
@@ -191,7 +191,7 @@ func (m *MockBlockOps) TogglePrefetcher(arg0 bool) <-chan struct{} {
 }
 
 // TogglePrefetcher indicates an expected call of TogglePrefetcher.
-func (mr *MockBlockOpsMockRecorder) TogglePrefetcher(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockOpsMockRecorder) TogglePrefetcher(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TogglePrefetcher", reflect.TypeOf((*MockBlockOps)(nil).TogglePrefetcher), arg0)
 }
@@ -228,7 +228,7 @@ func (m *MockBlockServer) AddBlockReference(arg0 context.Context, arg1 tlf.ID, a
 }
 
 // AddBlockReference indicates an expected call of AddBlockReference.
-func (mr *MockBlockServerMockRecorder) AddBlockReference(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) AddBlockReference(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBlockReference", reflect.TypeOf((*MockBlockServer)(nil).AddBlockReference), arg0, arg1, arg2, arg3)
 }
@@ -242,7 +242,7 @@ func (m *MockBlockServer) ArchiveBlockReferences(arg0 context.Context, arg1 tlf.
 }
 
 // ArchiveBlockReferences indicates an expected call of ArchiveBlockReferences.
-func (mr *MockBlockServerMockRecorder) ArchiveBlockReferences(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) ArchiveBlockReferences(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveBlockReferences", reflect.TypeOf((*MockBlockServer)(nil).ArchiveBlockReferences), arg0, arg1, arg2)
 }
@@ -270,7 +270,7 @@ func (m *MockBlockServer) Get(arg0 context.Context, arg1 tlf.ID, arg2 kbfsblock.
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockBlockServerMockRecorder) Get(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) Get(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBlockServer)(nil).Get), arg0, arg1, arg2, arg3, arg4)
 }
@@ -286,7 +286,7 @@ func (m *MockBlockServer) GetEncodedSizes(arg0 context.Context, arg1 tlf.ID, arg
 }
 
 // GetEncodedSizes indicates an expected call of GetEncodedSizes.
-func (mr *MockBlockServerMockRecorder) GetEncodedSizes(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) GetEncodedSizes(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncodedSizes", reflect.TypeOf((*MockBlockServer)(nil).GetEncodedSizes), arg0, arg1, arg2, arg3)
 }
@@ -301,7 +301,7 @@ func (m *MockBlockServer) GetLiveBlockReferences(arg0 context.Context, arg1 tlf.
 }
 
 // GetLiveBlockReferences indicates an expected call of GetLiveBlockReferences.
-func (mr *MockBlockServerMockRecorder) GetLiveBlockReferences(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) GetLiveBlockReferences(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLiveBlockReferences", reflect.TypeOf((*MockBlockServer)(nil).GetLiveBlockReferences), arg0, arg1, arg2)
 }
@@ -316,7 +316,7 @@ func (m *MockBlockServer) GetTeamQuotaInfo(arg0 context.Context, arg1 keybase1.T
 }
 
 // GetTeamQuotaInfo indicates an expected call of GetTeamQuotaInfo.
-func (mr *MockBlockServerMockRecorder) GetTeamQuotaInfo(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) GetTeamQuotaInfo(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamQuotaInfo", reflect.TypeOf((*MockBlockServer)(nil).GetTeamQuotaInfo), arg0, arg1)
 }
@@ -331,7 +331,7 @@ func (m *MockBlockServer) GetUserQuotaInfo(arg0 context.Context) (*kbfsblock.Quo
 }
 
 // GetUserQuotaInfo indicates an expected call of GetUserQuotaInfo.
-func (mr *MockBlockServerMockRecorder) GetUserQuotaInfo(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) GetUserQuotaInfo(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserQuotaInfo", reflect.TypeOf((*MockBlockServer)(nil).GetUserQuotaInfo), arg0)
 }
@@ -346,7 +346,7 @@ func (m *MockBlockServer) IsUnflushed(arg0 context.Context, arg1 tlf.ID, arg2 kb
 }
 
 // IsUnflushed indicates an expected call of IsUnflushed.
-func (mr *MockBlockServerMockRecorder) IsUnflushed(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) IsUnflushed(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUnflushed", reflect.TypeOf((*MockBlockServer)(nil).IsUnflushed), arg0, arg1, arg2)
 }
@@ -360,7 +360,7 @@ func (m *MockBlockServer) Put(arg0 context.Context, arg1 tlf.ID, arg2 kbfsblock.
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockBlockServerMockRecorder) Put(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) Put(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockBlockServer)(nil).Put), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
@@ -374,7 +374,7 @@ func (m *MockBlockServer) PutAgain(arg0 context.Context, arg1 tlf.ID, arg2 kbfsb
 }
 
 // PutAgain indicates an expected call of PutAgain.
-func (mr *MockBlockServerMockRecorder) PutAgain(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) PutAgain(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAgain", reflect.TypeOf((*MockBlockServer)(nil).PutAgain), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
@@ -386,7 +386,7 @@ func (m *MockBlockServer) RefreshAuthToken(arg0 context.Context) {
 }
 
 // RefreshAuthToken indicates an expected call of RefreshAuthToken.
-func (mr *MockBlockServerMockRecorder) RefreshAuthToken(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) RefreshAuthToken(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshAuthToken", reflect.TypeOf((*MockBlockServer)(nil).RefreshAuthToken), arg0)
 }
@@ -401,7 +401,7 @@ func (m *MockBlockServer) RemoveBlockReferences(arg0 context.Context, arg1 tlf.I
 }
 
 // RemoveBlockReferences indicates an expected call of RemoveBlockReferences.
-func (mr *MockBlockServerMockRecorder) RemoveBlockReferences(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) RemoveBlockReferences(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveBlockReferences", reflect.TypeOf((*MockBlockServer)(nil).RemoveBlockReferences), arg0, arg1, arg2)
 }
@@ -413,7 +413,7 @@ func (m *MockBlockServer) Shutdown(arg0 context.Context) {
 }
 
 // Shutdown indicates an expected call of Shutdown.
-func (mr *MockBlockServerMockRecorder) Shutdown(arg0 interface{}) *gomock.Call {
+func (mr *MockBlockServerMockRecorder) Shutdown(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockBlockServer)(nil).Shutdown), arg0)
 }
@@ -464,7 +464,7 @@ func (m *MockChat) GetChannels(arg0 context.Context, arg1 tlf.CanonicalName, arg
 }
 
 // GetChannels indicates an expected call of GetChannels.
-func (mr *MockChatMockRecorder) GetChannels(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockChatMockRecorder) GetChannels(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannels", reflect.TypeOf((*MockChat)(nil).GetChannels), arg0, arg1, arg2, arg3)
 }
@@ -479,7 +479,7 @@ func (m *MockChat) GetConversationID(arg0 context.Context, arg1 tlf.CanonicalNam
 }
 
 // GetConversationID indicates an expected call of GetConversationID.
-func (mr *MockChatMockRecorder) GetConversationID(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockChatMockRecorder) GetConversationID(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConversationID", reflect.TypeOf((*MockChat)(nil).GetConversationID), arg0, arg1, arg2, arg3, arg4)
 }
@@ -494,7 +494,7 @@ func (m *MockChat) GetGroupedInbox(arg0 context.Context, arg1 chat1.TopicType, a
 }
 
 // GetGroupedInbox indicates an expected call of GetGroupedInbox.
-func (mr *MockChatMockRecorder) GetGroupedInbox(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockChatMockRecorder) GetGroupedInbox(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupedInbox", reflect.TypeOf((*MockChat)(nil).GetGroupedInbox), arg0, arg1, arg2)
 }
@@ -510,7 +510,7 @@ func (m *MockChat) ReadChannel(arg0 context.Context, arg1 chat1.ConversationID, 
 }
 
 // ReadChannel indicates an expected call of ReadChannel.
-func (mr *MockChatMockRecorder) ReadChannel(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockChatMockRecorder) ReadChannel(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChannel", reflect.TypeOf((*MockChat)(nil).ReadChannel), arg0, arg1, arg2)
 }
@@ -522,7 +522,7 @@ func (m *MockChat) RegisterForMessages(arg0 chat1.ConversationID, arg1 ChatChann
 }
 
 // RegisterForMessages indicates an expected call of RegisterForMessages.
-func (mr *MockChatMockRecorder) RegisterForMessages(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockChatMockRecorder) RegisterForMessages(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterForMessages", reflect.TypeOf((*MockChat)(nil).RegisterForMessages), arg0, arg1)
 }
@@ -536,7 +536,7 @@ func (m *MockChat) SendTextMessage(arg0 context.Context, arg1 tlf.CanonicalName,
 }
 
 // SendTextMessage indicates an expected call of SendTextMessage.
-func (mr *MockChatMockRecorder) SendTextMessage(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockChatMockRecorder) SendTextMessage(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTextMessage", reflect.TypeOf((*MockChat)(nil).SendTextMessage), arg0, arg1, arg2, arg3, arg4)
 }
@@ -610,7 +610,7 @@ func (m *MockCrypto) DecryptBlock(arg0 kbfscrypto.EncryptedBlock, arg1 kbfscrypt
 }
 
 // DecryptBlock indicates an expected call of DecryptBlock.
-func (mr *MockCryptoMockRecorder) DecryptBlock(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) DecryptBlock(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptBlock", reflect.TypeOf((*MockCrypto)(nil).DecryptBlock), arg0, arg1, arg2, arg3)
 }
@@ -625,7 +625,7 @@ func (m *MockCrypto) DecryptPrivateMetadata(arg0 kbfscrypto.EncryptedPrivateMeta
 }
 
 // DecryptPrivateMetadata indicates an expected call of DecryptPrivateMetadata.
-func (mr *MockCryptoMockRecorder) DecryptPrivateMetadata(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) DecryptPrivateMetadata(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptPrivateMetadata", reflect.TypeOf((*MockCrypto)(nil).DecryptPrivateMetadata), arg0, arg1)
 }
@@ -640,7 +640,7 @@ func (m *MockCrypto) DecryptTLFCryptKeyClientHalf(arg0 context.Context, arg1 kbf
 }
 
 // DecryptTLFCryptKeyClientHalf indicates an expected call of DecryptTLFCryptKeyClientHalf.
-func (mr *MockCryptoMockRecorder) DecryptTLFCryptKeyClientHalf(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) DecryptTLFCryptKeyClientHalf(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptTLFCryptKeyClientHalf", reflect.TypeOf((*MockCrypto)(nil).DecryptTLFCryptKeyClientHalf), arg0, arg1, arg2)
 }
@@ -656,7 +656,7 @@ func (m *MockCrypto) DecryptTLFCryptKeyClientHalfAny(arg0 context.Context, arg1 
 }
 
 // DecryptTLFCryptKeyClientHalfAny indicates an expected call of DecryptTLFCryptKeyClientHalfAny.
-func (mr *MockCryptoMockRecorder) DecryptTLFCryptKeyClientHalfAny(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) DecryptTLFCryptKeyClientHalfAny(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptTLFCryptKeyClientHalfAny", reflect.TypeOf((*MockCrypto)(nil).DecryptTLFCryptKeyClientHalfAny), arg0, arg1, arg2)
 }
@@ -671,7 +671,7 @@ func (m *MockCrypto) DecryptTeamMerkleLeaf(arg0 context.Context, arg1 keybase1.T
 }
 
 // DecryptTeamMerkleLeaf indicates an expected call of DecryptTeamMerkleLeaf.
-func (mr *MockCryptoMockRecorder) DecryptTeamMerkleLeaf(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) DecryptTeamMerkleLeaf(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptTeamMerkleLeaf", reflect.TypeOf((*MockCrypto)(nil).DecryptTeamMerkleLeaf), arg0, arg1, arg2, arg3, arg4)
 }
@@ -687,7 +687,7 @@ func (m *MockCrypto) EncryptBlock(arg0 data.Block, arg1 kbfscrypto.TLFCryptKey, 
 }
 
 // EncryptBlock indicates an expected call of EncryptBlock.
-func (mr *MockCryptoMockRecorder) EncryptBlock(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) EncryptBlock(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptBlock", reflect.TypeOf((*MockCrypto)(nil).EncryptBlock), arg0, arg1, arg2)
 }
@@ -702,7 +702,7 @@ func (m *MockCrypto) EncryptPrivateMetadata(arg0 PrivateMetadata, arg1 kbfscrypt
 }
 
 // EncryptPrivateMetadata indicates an expected call of EncryptPrivateMetadata.
-func (mr *MockCryptoMockRecorder) EncryptPrivateMetadata(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) EncryptPrivateMetadata(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptPrivateMetadata", reflect.TypeOf((*MockCrypto)(nil).EncryptPrivateMetadata), arg0, arg1)
 }
@@ -795,7 +795,7 @@ func (m *MockCrypto) MakeRandomTlfID(arg0 tlf.Type) (tlf.ID, error) {
 }
 
 // MakeRandomTlfID indicates an expected call of MakeRandomTlfID.
-func (mr *MockCryptoMockRecorder) MakeRandomTlfID(arg0 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) MakeRandomTlfID(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeRandomTlfID", reflect.TypeOf((*MockCrypto)(nil).MakeRandomTlfID), arg0)
 }
@@ -837,7 +837,7 @@ func (m *MockCrypto) Sign(arg0 context.Context, arg1 []byte) (kbfscrypto.Signatu
 }
 
 // Sign indicates an expected call of Sign.
-func (mr *MockCryptoMockRecorder) Sign(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) Sign(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockCrypto)(nil).Sign), arg0, arg1)
 }
@@ -852,7 +852,7 @@ func (m *MockCrypto) SignForKBFS(arg0 context.Context, arg1 []byte) (kbfscrypto.
 }
 
 // SignForKBFS indicates an expected call of SignForKBFS.
-func (mr *MockCryptoMockRecorder) SignForKBFS(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) SignForKBFS(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignForKBFS", reflect.TypeOf((*MockCrypto)(nil).SignForKBFS), arg0, arg1)
 }
@@ -867,7 +867,7 @@ func (m *MockCrypto) SignToString(arg0 context.Context, arg1 []byte) (string, er
 }
 
 // SignToString indicates an expected call of SignToString.
-func (mr *MockCryptoMockRecorder) SignToString(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCryptoMockRecorder) SignToString(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignToString", reflect.TypeOf((*MockCrypto)(nil).SignToString), arg0, arg1)
 }
@@ -904,7 +904,7 @@ func (m *MockKBFSOps) AddFavorite(arg0 context.Context, arg1 favorites.Folder, a
 }
 
 // AddFavorite indicates an expected call of AddFavorite.
-func (mr *MockKBFSOpsMockRecorder) AddFavorite(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) AddFavorite(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddFavorite", reflect.TypeOf((*MockKBFSOps)(nil).AddFavorite), arg0, arg1, arg2)
 }
@@ -916,7 +916,7 @@ func (m *MockKBFSOps) AddRootNodeWrapper(arg0 func(Node) Node) {
 }
 
 // AddRootNodeWrapper indicates an expected call of AddRootNodeWrapper.
-func (mr *MockKBFSOpsMockRecorder) AddRootNodeWrapper(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) AddRootNodeWrapper(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRootNodeWrapper", reflect.TypeOf((*MockKBFSOps)(nil).AddRootNodeWrapper), arg0)
 }
@@ -930,7 +930,7 @@ func (m *MockKBFSOps) CancelUploads(arg0 context.Context, arg1 data.FolderBranch
 }
 
 // CancelUploads indicates an expected call of CancelUploads.
-func (mr *MockKBFSOpsMockRecorder) CancelUploads(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) CancelUploads(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelUploads", reflect.TypeOf((*MockKBFSOps)(nil).CancelUploads), arg0, arg1)
 }
@@ -944,7 +944,7 @@ func (m *MockKBFSOps) CheckMigrationPerms(arg0 context.Context, arg1 tlf.ID) err
 }
 
 // CheckMigrationPerms indicates an expected call of CheckMigrationPerms.
-func (mr *MockKBFSOpsMockRecorder) CheckMigrationPerms(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) CheckMigrationPerms(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckMigrationPerms", reflect.TypeOf((*MockKBFSOps)(nil).CheckMigrationPerms), arg0, arg1)
 }
@@ -956,7 +956,7 @@ func (m *MockKBFSOps) ClearCachedFavorites(arg0 context.Context) {
 }
 
 // ClearCachedFavorites indicates an expected call of ClearCachedFavorites.
-func (mr *MockKBFSOpsMockRecorder) ClearCachedFavorites(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) ClearCachedFavorites(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearCachedFavorites", reflect.TypeOf((*MockKBFSOps)(nil).ClearCachedFavorites), arg0)
 }
@@ -970,7 +970,7 @@ func (m *MockKBFSOps) ClearConflictView(arg0 context.Context, arg1 tlf.ID) error
 }
 
 // ClearConflictView indicates an expected call of ClearConflictView.
-func (mr *MockKBFSOpsMockRecorder) ClearConflictView(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) ClearConflictView(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearConflictView", reflect.TypeOf((*MockKBFSOps)(nil).ClearConflictView), arg0, arg1)
 }
@@ -982,7 +982,7 @@ func (m *MockKBFSOps) ClearPrivateFolderMD(arg0 context.Context) {
 }
 
 // ClearPrivateFolderMD indicates an expected call of ClearPrivateFolderMD.
-func (mr *MockKBFSOpsMockRecorder) ClearPrivateFolderMD(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) ClearPrivateFolderMD(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearPrivateFolderMD", reflect.TypeOf((*MockKBFSOps)(nil).ClearPrivateFolderMD), arg0)
 }
@@ -998,7 +998,7 @@ func (m *MockKBFSOps) CreateDir(arg0 context.Context, arg1 Node, arg2 data.PathP
 }
 
 // CreateDir indicates an expected call of CreateDir.
-func (mr *MockKBFSOpsMockRecorder) CreateDir(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) CreateDir(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDir", reflect.TypeOf((*MockKBFSOps)(nil).CreateDir), arg0, arg1, arg2)
 }
@@ -1014,7 +1014,7 @@ func (m *MockKBFSOps) CreateFile(arg0 context.Context, arg1 Node, arg2 data.Path
 }
 
 // CreateFile indicates an expected call of CreateFile.
-func (mr *MockKBFSOpsMockRecorder) CreateFile(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) CreateFile(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFile", reflect.TypeOf((*MockKBFSOps)(nil).CreateFile), arg0, arg1, arg2, arg3, arg4)
 }
@@ -1029,7 +1029,7 @@ func (m *MockKBFSOps) CreateLink(arg0 context.Context, arg1 Node, arg2, arg3 dat
 }
 
 // CreateLink indicates an expected call of CreateLink.
-func (mr *MockKBFSOpsMockRecorder) CreateLink(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) CreateLink(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLink", reflect.TypeOf((*MockKBFSOps)(nil).CreateLink), arg0, arg1, arg2, arg3)
 }
@@ -1043,7 +1043,7 @@ func (m *MockKBFSOps) DeleteFavorite(arg0 context.Context, arg1 favorites.Folder
 }
 
 // DeleteFavorite indicates an expected call of DeleteFavorite.
-func (mr *MockKBFSOpsMockRecorder) DeleteFavorite(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) DeleteFavorite(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFavorite", reflect.TypeOf((*MockKBFSOps)(nil).DeleteFavorite), arg0, arg1)
 }
@@ -1057,7 +1057,7 @@ func (m *MockKBFSOps) FinishResolvingConflict(arg0 context.Context, arg1 data.Fo
 }
 
 // FinishResolvingConflict indicates an expected call of FinishResolvingConflict.
-func (mr *MockKBFSOpsMockRecorder) FinishResolvingConflict(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) FinishResolvingConflict(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishResolvingConflict", reflect.TypeOf((*MockKBFSOps)(nil).FinishResolvingConflict), arg0, arg1)
 }
@@ -1072,7 +1072,7 @@ func (m *MockKBFSOps) FolderConflictStatus(arg0 context.Context, arg1 data.Folde
 }
 
 // FolderConflictStatus indicates an expected call of FolderConflictStatus.
-func (mr *MockKBFSOpsMockRecorder) FolderConflictStatus(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) FolderConflictStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FolderConflictStatus", reflect.TypeOf((*MockKBFSOps)(nil).FolderConflictStatus), arg0, arg1)
 }
@@ -1088,7 +1088,7 @@ func (m *MockKBFSOps) FolderStatus(arg0 context.Context, arg1 data.FolderBranch)
 }
 
 // FolderStatus indicates an expected call of FolderStatus.
-func (mr *MockKBFSOpsMockRecorder) FolderStatus(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) FolderStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FolderStatus", reflect.TypeOf((*MockKBFSOps)(nil).FolderStatus), arg0, arg1)
 }
@@ -1100,7 +1100,7 @@ func (m *MockKBFSOps) ForceFastForward(arg0 context.Context) {
 }
 
 // ForceFastForward indicates an expected call of ForceFastForward.
-func (mr *MockKBFSOpsMockRecorder) ForceFastForward(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) ForceFastForward(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceFastForward", reflect.TypeOf((*MockKBFSOps)(nil).ForceFastForward), arg0)
 }
@@ -1114,7 +1114,7 @@ func (m *MockKBFSOps) ForceStuckConflictForTesting(arg0 context.Context, arg1 tl
 }
 
 // ForceStuckConflictForTesting indicates an expected call of ForceStuckConflictForTesting.
-func (mr *MockKBFSOpsMockRecorder) ForceStuckConflictForTesting(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) ForceStuckConflictForTesting(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceStuckConflictForTesting", reflect.TypeOf((*MockKBFSOps)(nil).ForceStuckConflictForTesting), arg0, arg1)
 }
@@ -1128,7 +1128,7 @@ func (m *MockKBFSOps) GetAllSyncedTlfMDs(arg0 context.Context) map[tlf.ID]Synced
 }
 
 // GetAllSyncedTlfMDs indicates an expected call of GetAllSyncedTlfMDs.
-func (mr *MockKBFSOpsMockRecorder) GetAllSyncedTlfMDs(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetAllSyncedTlfMDs(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllSyncedTlfMDs", reflect.TypeOf((*MockKBFSOps)(nil).GetAllSyncedTlfMDs), arg0)
 }
@@ -1143,7 +1143,7 @@ func (m *MockKBFSOps) GetBadge(arg0 context.Context) (keybase1.FilesTabBadge, er
 }
 
 // GetBadge indicates an expected call of GetBadge.
-func (mr *MockKBFSOpsMockRecorder) GetBadge(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetBadge(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBadge", reflect.TypeOf((*MockKBFSOps)(nil).GetBadge), arg0)
 }
@@ -1158,7 +1158,7 @@ func (m *MockKBFSOps) GetDirChildren(arg0 context.Context, arg1 Node) (map[data.
 }
 
 // GetDirChildren indicates an expected call of GetDirChildren.
-func (mr *MockKBFSOpsMockRecorder) GetDirChildren(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetDirChildren(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDirChildren", reflect.TypeOf((*MockKBFSOps)(nil).GetDirChildren), arg0, arg1)
 }
@@ -1173,7 +1173,7 @@ func (m *MockKBFSOps) GetEditHistory(arg0 context.Context, arg1 data.FolderBranc
 }
 
 // GetEditHistory indicates an expected call of GetEditHistory.
-func (mr *MockKBFSOpsMockRecorder) GetEditHistory(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetEditHistory(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEditHistory", reflect.TypeOf((*MockKBFSOps)(nil).GetEditHistory), arg0, arg1)
 }
@@ -1188,7 +1188,7 @@ func (m *MockKBFSOps) GetFavorites(arg0 context.Context) ([]favorites.Folder, er
 }
 
 // GetFavorites indicates an expected call of GetFavorites.
-func (mr *MockKBFSOpsMockRecorder) GetFavorites(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetFavorites(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFavorites", reflect.TypeOf((*MockKBFSOps)(nil).GetFavorites), arg0)
 }
@@ -1203,7 +1203,7 @@ func (m *MockKBFSOps) GetFavoritesAll(arg0 context.Context) (keybase1.FavoritesR
 }
 
 // GetFavoritesAll indicates an expected call of GetFavoritesAll.
-func (mr *MockKBFSOpsMockRecorder) GetFavoritesAll(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetFavoritesAll(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFavoritesAll", reflect.TypeOf((*MockKBFSOps)(nil).GetFavoritesAll), arg0)
 }
@@ -1218,7 +1218,7 @@ func (m *MockKBFSOps) GetFolderWithFavFlags(arg0 context.Context, arg1 *tlfhandl
 }
 
 // GetFolderWithFavFlags indicates an expected call of GetFolderWithFavFlags.
-func (mr *MockKBFSOpsMockRecorder) GetFolderWithFavFlags(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetFolderWithFavFlags(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFolderWithFavFlags", reflect.TypeOf((*MockKBFSOps)(nil).GetFolderWithFavFlags), arg0, arg1)
 }
@@ -1233,7 +1233,7 @@ func (m *MockKBFSOps) GetNodeMetadata(arg0 context.Context, arg1 Node) (NodeMeta
 }
 
 // GetNodeMetadata indicates an expected call of GetNodeMetadata.
-func (mr *MockKBFSOpsMockRecorder) GetNodeMetadata(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetNodeMetadata(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeMetadata", reflect.TypeOf((*MockKBFSOps)(nil).GetNodeMetadata), arg0, arg1)
 }
@@ -1249,7 +1249,7 @@ func (m *MockKBFSOps) GetOrCreateRootNode(arg0 context.Context, arg1 *tlfhandle.
 }
 
 // GetOrCreateRootNode indicates an expected call of GetOrCreateRootNode.
-func (mr *MockKBFSOpsMockRecorder) GetOrCreateRootNode(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetOrCreateRootNode(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateRootNode", reflect.TypeOf((*MockKBFSOps)(nil).GetOrCreateRootNode), arg0, arg1, arg2)
 }
@@ -1265,7 +1265,7 @@ func (m *MockKBFSOps) GetRootNode(arg0 context.Context, arg1 *tlfhandle.Handle, 
 }
 
 // GetRootNode indicates an expected call of GetRootNode.
-func (mr *MockKBFSOpsMockRecorder) GetRootNode(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetRootNode(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRootNode", reflect.TypeOf((*MockKBFSOps)(nil).GetRootNode), arg0, arg1, arg2)
 }
@@ -1281,7 +1281,7 @@ func (m *MockKBFSOps) GetRootNodeMetadata(arg0 context.Context, arg1 data.Folder
 }
 
 // GetRootNodeMetadata indicates an expected call of GetRootNodeMetadata.
-func (mr *MockKBFSOpsMockRecorder) GetRootNodeMetadata(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetRootNodeMetadata(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRootNodeMetadata", reflect.TypeOf((*MockKBFSOps)(nil).GetRootNodeMetadata), arg0, arg1)
 }
@@ -1296,7 +1296,7 @@ func (m *MockKBFSOps) GetSyncConfig(arg0 context.Context, arg1 tlf.ID) (keybase1
 }
 
 // GetSyncConfig indicates an expected call of GetSyncConfig.
-func (mr *MockKBFSOpsMockRecorder) GetSyncConfig(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetSyncConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncConfig", reflect.TypeOf((*MockKBFSOps)(nil).GetSyncConfig), arg0, arg1)
 }
@@ -1312,7 +1312,7 @@ func (m *MockKBFSOps) GetTLFCryptKeys(arg0 context.Context, arg1 *tlfhandle.Hand
 }
 
 // GetTLFCryptKeys indicates an expected call of GetTLFCryptKeys.
-func (mr *MockKBFSOpsMockRecorder) GetTLFCryptKeys(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetTLFCryptKeys(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFCryptKeys", reflect.TypeOf((*MockKBFSOps)(nil).GetTLFCryptKeys), arg0, arg1)
 }
@@ -1327,7 +1327,7 @@ func (m *MockKBFSOps) GetTLFHandle(arg0 context.Context, arg1 Node) (*tlfhandle.
 }
 
 // GetTLFHandle indicates an expected call of GetTLFHandle.
-func (mr *MockKBFSOpsMockRecorder) GetTLFHandle(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetTLFHandle(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFHandle", reflect.TypeOf((*MockKBFSOps)(nil).GetTLFHandle), arg0, arg1)
 }
@@ -1342,7 +1342,7 @@ func (m *MockKBFSOps) GetTLFID(arg0 context.Context, arg1 *tlfhandle.Handle) (tl
 }
 
 // GetTLFID indicates an expected call of GetTLFID.
-func (mr *MockKBFSOpsMockRecorder) GetTLFID(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetTLFID(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFID", reflect.TypeOf((*MockKBFSOps)(nil).GetTLFID), arg0, arg1)
 }
@@ -1357,7 +1357,7 @@ func (m *MockKBFSOps) GetUpdateHistory(arg0 context.Context, arg1 data.FolderBra
 }
 
 // GetUpdateHistory indicates an expected call of GetUpdateHistory.
-func (mr *MockKBFSOpsMockRecorder) GetUpdateHistory(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) GetUpdateHistory(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateHistory", reflect.TypeOf((*MockKBFSOps)(nil).GetUpdateHistory), arg0, arg1, arg2, arg3)
 }
@@ -1371,7 +1371,7 @@ func (m *MockKBFSOps) InvalidateNodeAndChildren(arg0 context.Context, arg1 Node)
 }
 
 // InvalidateNodeAndChildren indicates an expected call of InvalidateNodeAndChildren.
-func (mr *MockKBFSOpsMockRecorder) InvalidateNodeAndChildren(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) InvalidateNodeAndChildren(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateNodeAndChildren", reflect.TypeOf((*MockKBFSOps)(nil).InvalidateNodeAndChildren), arg0, arg1)
 }
@@ -1401,7 +1401,7 @@ func (m *MockKBFSOps) Lookup(arg0 context.Context, arg1 Node, arg2 data.PathPart
 }
 
 // Lookup indicates an expected call of Lookup.
-func (mr *MockKBFSOpsMockRecorder) Lookup(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) Lookup(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lookup", reflect.TypeOf((*MockKBFSOps)(nil).Lookup), arg0, arg1, arg2)
 }
@@ -1415,7 +1415,7 @@ func (m *MockKBFSOps) MigrateToImplicitTeam(arg0 context.Context, arg1 tlf.ID) e
 }
 
 // MigrateToImplicitTeam indicates an expected call of MigrateToImplicitTeam.
-func (mr *MockKBFSOpsMockRecorder) MigrateToImplicitTeam(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) MigrateToImplicitTeam(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateToImplicitTeam", reflect.TypeOf((*MockKBFSOps)(nil).MigrateToImplicitTeam), arg0, arg1)
 }
@@ -1427,7 +1427,7 @@ func (m *MockKBFSOps) NewNotificationChannel(arg0 context.Context, arg1 *tlfhand
 }
 
 // NewNotificationChannel indicates an expected call of NewNotificationChannel.
-func (mr *MockKBFSOpsMockRecorder) NewNotificationChannel(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) NewNotificationChannel(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewNotificationChannel", reflect.TypeOf((*MockKBFSOps)(nil).NewNotificationChannel), arg0, arg1, arg2, arg3)
 }
@@ -1439,7 +1439,7 @@ func (m *MockKBFSOps) PushConnectionStatusChange(arg0 string, arg1 error) {
 }
 
 // PushConnectionStatusChange indicates an expected call of PushConnectionStatusChange.
-func (mr *MockKBFSOpsMockRecorder) PushConnectionStatusChange(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) PushConnectionStatusChange(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushConnectionStatusChange", reflect.TypeOf((*MockKBFSOps)(nil).PushConnectionStatusChange), arg0, arg1)
 }
@@ -1466,7 +1466,7 @@ func (m *MockKBFSOps) Read(arg0 context.Context, arg1 Node, arg2 []byte, arg3 in
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockKBFSOpsMockRecorder) Read(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) Read(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockKBFSOps)(nil).Read), arg0, arg1, arg2, arg3)
 }
@@ -1478,7 +1478,7 @@ func (m *MockKBFSOps) RefreshCachedFavorites(arg0 context.Context, arg1 Favorite
 }
 
 // RefreshCachedFavorites indicates an expected call of RefreshCachedFavorites.
-func (mr *MockKBFSOpsMockRecorder) RefreshCachedFavorites(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) RefreshCachedFavorites(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshCachedFavorites", reflect.TypeOf((*MockKBFSOps)(nil).RefreshCachedFavorites), arg0, arg1)
 }
@@ -1490,7 +1490,7 @@ func (m *MockKBFSOps) RefreshEditHistory(arg0 favorites.Folder) {
 }
 
 // RefreshEditHistory indicates an expected call of RefreshEditHistory.
-func (mr *MockKBFSOpsMockRecorder) RefreshEditHistory(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) RefreshEditHistory(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshEditHistory", reflect.TypeOf((*MockKBFSOps)(nil).RefreshEditHistory), arg0)
 }
@@ -1504,7 +1504,7 @@ func (m *MockKBFSOps) RemoveDir(arg0 context.Context, arg1 Node, arg2 data.PathP
 }
 
 // RemoveDir indicates an expected call of RemoveDir.
-func (mr *MockKBFSOpsMockRecorder) RemoveDir(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) RemoveDir(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDir", reflect.TypeOf((*MockKBFSOps)(nil).RemoveDir), arg0, arg1, arg2)
 }
@@ -1518,7 +1518,7 @@ func (m *MockKBFSOps) RemoveEntry(arg0 context.Context, arg1 Node, arg2 data.Pat
 }
 
 // RemoveEntry indicates an expected call of RemoveEntry.
-func (mr *MockKBFSOpsMockRecorder) RemoveEntry(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) RemoveEntry(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveEntry", reflect.TypeOf((*MockKBFSOps)(nil).RemoveEntry), arg0, arg1, arg2)
 }
@@ -1532,7 +1532,7 @@ func (m *MockKBFSOps) Rename(arg0 context.Context, arg1 Node, arg2 data.PathPart
 }
 
 // Rename indicates an expected call of Rename.
-func (mr *MockKBFSOpsMockRecorder) Rename(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) Rename(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockKBFSOps)(nil).Rename), arg0, arg1, arg2, arg3, arg4)
 }
@@ -1544,7 +1544,7 @@ func (m *MockKBFSOps) RequestRekey(arg0 context.Context, arg1 tlf.ID) {
 }
 
 // RequestRekey indicates an expected call of RequestRekey.
-func (mr *MockKBFSOpsMockRecorder) RequestRekey(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) RequestRekey(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestRekey", reflect.TypeOf((*MockKBFSOps)(nil).RequestRekey), arg0, arg1)
 }
@@ -1558,7 +1558,7 @@ func (m *MockKBFSOps) Reset(arg0 context.Context, arg1 *tlfhandle.Handle, arg2 *
 }
 
 // Reset indicates an expected call of Reset.
-func (mr *MockKBFSOpsMockRecorder) Reset(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) Reset(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockKBFSOps)(nil).Reset), arg0, arg1, arg2)
 }
@@ -1572,7 +1572,7 @@ func (m *MockKBFSOps) SetEx(arg0 context.Context, arg1 Node, arg2 bool) error {
 }
 
 // SetEx indicates an expected call of SetEx.
-func (mr *MockKBFSOpsMockRecorder) SetEx(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) SetEx(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEx", reflect.TypeOf((*MockKBFSOps)(nil).SetEx), arg0, arg1, arg2)
 }
@@ -1584,7 +1584,7 @@ func (m *MockKBFSOps) SetFavoritesHomeTLFInfo(arg0 context.Context, arg1 homeTLF
 }
 
 // SetFavoritesHomeTLFInfo indicates an expected call of SetFavoritesHomeTLFInfo.
-func (mr *MockKBFSOpsMockRecorder) SetFavoritesHomeTLFInfo(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) SetFavoritesHomeTLFInfo(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFavoritesHomeTLFInfo", reflect.TypeOf((*MockKBFSOps)(nil).SetFavoritesHomeTLFInfo), arg0, arg1)
 }
@@ -1598,7 +1598,7 @@ func (m *MockKBFSOps) SetMtime(arg0 context.Context, arg1 Node, arg2 *time.Time)
 }
 
 // SetMtime indicates an expected call of SetMtime.
-func (mr *MockKBFSOpsMockRecorder) SetMtime(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) SetMtime(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMtime", reflect.TypeOf((*MockKBFSOps)(nil).SetMtime), arg0, arg1, arg2)
 }
@@ -1613,7 +1613,7 @@ func (m *MockKBFSOps) SetSyncConfig(arg0 context.Context, arg1 tlf.ID, arg2 keyb
 }
 
 // SetSyncConfig indicates an expected call of SetSyncConfig.
-func (mr *MockKBFSOpsMockRecorder) SetSyncConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) SetSyncConfig(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSyncConfig", reflect.TypeOf((*MockKBFSOps)(nil).SetSyncConfig), arg0, arg1, arg2)
 }
@@ -1627,7 +1627,7 @@ func (m *MockKBFSOps) Shutdown(arg0 context.Context) error {
 }
 
 // Shutdown indicates an expected call of Shutdown.
-func (mr *MockKBFSOpsMockRecorder) Shutdown(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) Shutdown(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockKBFSOps)(nil).Shutdown), arg0)
 }
@@ -1642,7 +1642,7 @@ func (m *MockKBFSOps) Stat(arg0 context.Context, arg1 Node) (data.EntryInfo, err
 }
 
 // Stat indicates an expected call of Stat.
-func (mr *MockKBFSOpsMockRecorder) Stat(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) Stat(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockKBFSOps)(nil).Stat), arg0, arg1)
 }
@@ -1658,7 +1658,7 @@ func (m *MockKBFSOps) Status(arg0 context.Context) (KBFSStatus, <-chan StatusUpd
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockKBFSOpsMockRecorder) Status(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) Status(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockKBFSOps)(nil).Status), arg0)
 }
@@ -1687,7 +1687,7 @@ func (m *MockKBFSOps) SyncAll(arg0 context.Context, arg1 data.FolderBranch) erro
 }
 
 // SyncAll indicates an expected call of SyncAll.
-func (mr *MockKBFSOpsMockRecorder) SyncAll(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) SyncAll(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncAll", reflect.TypeOf((*MockKBFSOps)(nil).SyncAll), arg0, arg1)
 }
@@ -1701,7 +1701,7 @@ func (m *MockKBFSOps) SyncFromServer(arg0 context.Context, arg1 data.FolderBranc
 }
 
 // SyncFromServer indicates an expected call of SyncFromServer.
-func (mr *MockKBFSOpsMockRecorder) SyncFromServer(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) SyncFromServer(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncFromServer", reflect.TypeOf((*MockKBFSOps)(nil).SyncFromServer), arg0, arg1, arg2)
 }
@@ -1713,7 +1713,7 @@ func (m *MockKBFSOps) TeamAbandoned(arg0 context.Context, arg1 keybase1.TeamID) 
 }
 
 // TeamAbandoned indicates an expected call of TeamAbandoned.
-func (mr *MockKBFSOpsMockRecorder) TeamAbandoned(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) TeamAbandoned(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeamAbandoned", reflect.TypeOf((*MockKBFSOps)(nil).TeamAbandoned), arg0, arg1)
 }
@@ -1725,7 +1725,7 @@ func (m *MockKBFSOps) TeamNameChanged(arg0 context.Context, arg1 keybase1.TeamID
 }
 
 // TeamNameChanged indicates an expected call of TeamNameChanged.
-func (mr *MockKBFSOpsMockRecorder) TeamNameChanged(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) TeamNameChanged(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeamNameChanged", reflect.TypeOf((*MockKBFSOps)(nil).TeamNameChanged), arg0, arg1)
 }
@@ -1739,7 +1739,7 @@ func (m *MockKBFSOps) Truncate(arg0 context.Context, arg1 Node, arg2 uint64) err
 }
 
 // Truncate indicates an expected call of Truncate.
-func (mr *MockKBFSOpsMockRecorder) Truncate(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) Truncate(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Truncate", reflect.TypeOf((*MockKBFSOps)(nil).Truncate), arg0, arg1, arg2)
 }
@@ -1753,7 +1753,7 @@ func (m *MockKBFSOps) UnstageForTesting(arg0 context.Context, arg1 data.FolderBr
 }
 
 // UnstageForTesting indicates an expected call of UnstageForTesting.
-func (mr *MockKBFSOpsMockRecorder) UnstageForTesting(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) UnstageForTesting(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnstageForTesting", reflect.TypeOf((*MockKBFSOps)(nil).UnstageForTesting), arg0, arg1)
 }
@@ -1767,7 +1767,7 @@ func (m *MockKBFSOps) Write(arg0 context.Context, arg1 Node, arg2 []byte, arg3 i
 }
 
 // Write indicates an expected call of Write.
-func (mr *MockKBFSOpsMockRecorder) Write(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) Write(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockKBFSOps)(nil).Write), arg0, arg1, arg2, arg3)
 }
@@ -1804,7 +1804,7 @@ func (m *MockKBPKI) CreateTeamTLF(arg0 context.Context, arg1 keybase1.TeamID, ar
 }
 
 // CreateTeamTLF indicates an expected call of CreateTeamTLF.
-func (mr *MockKBPKIMockRecorder) CreateTeamTLF(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) CreateTeamTLF(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeamTLF", reflect.TypeOf((*MockKBPKI)(nil).CreateTeamTLF), arg0, arg1, arg2)
 }
@@ -1818,7 +1818,7 @@ func (m *MockKBPKI) FavoriteAdd(arg0 context.Context, arg1 keybase1.FolderHandle
 }
 
 // FavoriteAdd indicates an expected call of FavoriteAdd.
-func (mr *MockKBPKIMockRecorder) FavoriteAdd(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) FavoriteAdd(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FavoriteAdd", reflect.TypeOf((*MockKBPKI)(nil).FavoriteAdd), arg0, arg1)
 }
@@ -1832,7 +1832,7 @@ func (m *MockKBPKI) FavoriteDelete(arg0 context.Context, arg1 keybase1.FolderHan
 }
 
 // FavoriteDelete indicates an expected call of FavoriteDelete.
-func (mr *MockKBPKIMockRecorder) FavoriteDelete(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) FavoriteDelete(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FavoriteDelete", reflect.TypeOf((*MockKBPKI)(nil).FavoriteDelete), arg0, arg1)
 }
@@ -1847,7 +1847,7 @@ func (m *MockKBPKI) FavoriteList(arg0 context.Context) (keybase1.FavoritesResult
 }
 
 // FavoriteList indicates an expected call of FavoriteList.
-func (mr *MockKBPKIMockRecorder) FavoriteList(arg0 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) FavoriteList(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FavoriteList", reflect.TypeOf((*MockKBPKI)(nil).FavoriteList), arg0)
 }
@@ -1862,7 +1862,7 @@ func (m *MockKBPKI) GetCryptPublicKeys(arg0 context.Context, arg1 keybase1.UID, 
 }
 
 // GetCryptPublicKeys indicates an expected call of GetCryptPublicKeys.
-func (mr *MockKBPKIMockRecorder) GetCryptPublicKeys(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetCryptPublicKeys(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCryptPublicKeys", reflect.TypeOf((*MockKBPKI)(nil).GetCryptPublicKeys), arg0, arg1, arg2)
 }
@@ -1878,7 +1878,7 @@ func (m *MockKBPKI) GetCurrentMerkleRoot(arg0 context.Context) (keybase1.MerkleR
 }
 
 // GetCurrentMerkleRoot indicates an expected call of GetCurrentMerkleRoot.
-func (mr *MockKBPKIMockRecorder) GetCurrentMerkleRoot(arg0 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetCurrentMerkleRoot(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentMerkleRoot", reflect.TypeOf((*MockKBPKI)(nil).GetCurrentMerkleRoot), arg0)
 }
@@ -1893,7 +1893,7 @@ func (m *MockKBPKI) GetCurrentSession(arg0 context.Context) (idutil.SessionInfo,
 }
 
 // GetCurrentSession indicates an expected call of GetCurrentSession.
-func (mr *MockKBPKIMockRecorder) GetCurrentSession(arg0 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetCurrentSession(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentSession", reflect.TypeOf((*MockKBPKI)(nil).GetCurrentSession), arg0)
 }
@@ -1908,7 +1908,7 @@ func (m *MockKBPKI) GetNormalizedUsername(arg0 context.Context, arg1 keybase1.Us
 }
 
 // GetNormalizedUsername indicates an expected call of GetNormalizedUsername.
-func (mr *MockKBPKIMockRecorder) GetNormalizedUsername(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetNormalizedUsername(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNormalizedUsername", reflect.TypeOf((*MockKBPKI)(nil).GetNormalizedUsername), arg0, arg1, arg2)
 }
@@ -1923,7 +1923,7 @@ func (m *MockKBPKI) GetTeamRootID(arg0 context.Context, arg1 keybase1.TeamID, ar
 }
 
 // GetTeamRootID indicates an expected call of GetTeamRootID.
-func (mr *MockKBPKIMockRecorder) GetTeamRootID(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetTeamRootID(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamRootID", reflect.TypeOf((*MockKBPKI)(nil).GetTeamRootID), arg0, arg1, arg2)
 }
@@ -1939,7 +1939,7 @@ func (m *MockKBPKI) GetTeamTLFCryptKeys(arg0 context.Context, arg1 keybase1.Team
 }
 
 // GetTeamTLFCryptKeys indicates an expected call of GetTeamTLFCryptKeys.
-func (mr *MockKBPKIMockRecorder) GetTeamTLFCryptKeys(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetTeamTLFCryptKeys(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockKBPKI)(nil).GetTeamTLFCryptKeys), arg0, arg1, arg2, arg3)
 }
@@ -1953,7 +1953,7 @@ func (m *MockKBPKI) HasVerifyingKey(arg0 context.Context, arg1 keybase1.UID, arg
 }
 
 // HasVerifyingKey indicates an expected call of HasVerifyingKey.
-func (mr *MockKBPKIMockRecorder) HasVerifyingKey(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) HasVerifyingKey(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasVerifyingKey", reflect.TypeOf((*MockKBPKI)(nil).HasVerifyingKey), arg0, arg1, arg2, arg3, arg4)
 }
@@ -1969,7 +1969,7 @@ func (m *MockKBPKI) Identify(arg0 context.Context, arg1, arg2 string, arg3 keyba
 }
 
 // Identify indicates an expected call of Identify.
-func (mr *MockKBPKIMockRecorder) Identify(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) Identify(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockKBPKI)(nil).Identify), arg0, arg1, arg2, arg3)
 }
@@ -1984,7 +1984,7 @@ func (m *MockKBPKI) IdentifyImplicitTeam(arg0 context.Context, arg1, arg2 string
 }
 
 // IdentifyImplicitTeam indicates an expected call of IdentifyImplicitTeam.
-func (mr *MockKBPKIMockRecorder) IdentifyImplicitTeam(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) IdentifyImplicitTeam(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IdentifyImplicitTeam", reflect.TypeOf((*MockKBPKI)(nil).IdentifyImplicitTeam), arg0, arg1, arg2, arg3, arg4, arg5)
 }
@@ -1996,7 +1996,7 @@ func (m *MockKBPKI) InvalidateTeamCacheForID(arg0 keybase1.TeamID) {
 }
 
 // InvalidateTeamCacheForID indicates an expected call of InvalidateTeamCacheForID.
-func (mr *MockKBPKIMockRecorder) InvalidateTeamCacheForID(arg0 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) InvalidateTeamCacheForID(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateTeamCacheForID", reflect.TypeOf((*MockKBPKI)(nil).InvalidateTeamCacheForID), arg0)
 }
@@ -2011,7 +2011,7 @@ func (m *MockKBPKI) IsTeamReader(arg0 context.Context, arg1 keybase1.TeamID, arg
 }
 
 // IsTeamReader indicates an expected call of IsTeamReader.
-func (mr *MockKBPKIMockRecorder) IsTeamReader(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) IsTeamReader(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockKBPKI)(nil).IsTeamReader), arg0, arg1, arg2, arg3)
 }
@@ -2026,7 +2026,7 @@ func (m *MockKBPKI) IsTeamWriter(arg0 context.Context, arg1 keybase1.TeamID, arg
 }
 
 // IsTeamWriter indicates an expected call of IsTeamWriter.
-func (mr *MockKBPKIMockRecorder) IsTeamWriter(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) IsTeamWriter(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).IsTeamWriter), arg0, arg1, arg2, arg3, arg4)
 }
@@ -2041,7 +2041,7 @@ func (m *MockKBPKI) NoLongerTeamWriter(arg0 context.Context, arg1 keybase1.TeamI
 }
 
 // NoLongerTeamWriter indicates an expected call of NoLongerTeamWriter.
-func (mr *MockKBPKIMockRecorder) NoLongerTeamWriter(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) NoLongerTeamWriter(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).NoLongerTeamWriter), arg0, arg1, arg2, arg3, arg4, arg5)
 }
@@ -2056,7 +2056,7 @@ func (m *MockKBPKI) NormalizeSocialAssertion(arg0 context.Context, arg1 string) 
 }
 
 // NormalizeSocialAssertion indicates an expected call of NormalizeSocialAssertion.
-func (mr *MockKBPKIMockRecorder) NormalizeSocialAssertion(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) NormalizeSocialAssertion(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NormalizeSocialAssertion", reflect.TypeOf((*MockKBPKI)(nil).NormalizeSocialAssertion), arg0, arg1)
 }
@@ -2070,7 +2070,7 @@ func (m *MockKBPKI) Notify(arg0 context.Context, arg1 *keybase1.FSNotification) 
 }
 
 // Notify indicates an expected call of Notify.
-func (mr *MockKBPKIMockRecorder) Notify(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) Notify(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockKBPKI)(nil).Notify), arg0, arg1)
 }
@@ -2084,7 +2084,7 @@ func (m *MockKBPKI) NotifyPathUpdated(arg0 context.Context, arg1 string) error {
 }
 
 // NotifyPathUpdated indicates an expected call of NotifyPathUpdated.
-func (mr *MockKBPKIMockRecorder) NotifyPathUpdated(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) NotifyPathUpdated(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyPathUpdated", reflect.TypeOf((*MockKBPKI)(nil).NotifyPathUpdated), arg0, arg1)
 }
@@ -2098,7 +2098,7 @@ func (m *MockKBPKI) PutGitMetadata(arg0 context.Context, arg1 keybase1.FolderHan
 }
 
 // PutGitMetadata indicates an expected call of PutGitMetadata.
-func (mr *MockKBPKIMockRecorder) PutGitMetadata(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) PutGitMetadata(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutGitMetadata", reflect.TypeOf((*MockKBPKI)(nil).PutGitMetadata), arg0, arg1, arg2, arg3)
 }
@@ -2114,7 +2114,7 @@ func (m *MockKBPKI) Resolve(arg0 context.Context, arg1 string, arg2 keybase1.Off
 }
 
 // Resolve indicates an expected call of Resolve.
-func (mr *MockKBPKIMockRecorder) Resolve(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) Resolve(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockKBPKI)(nil).Resolve), arg0, arg1, arg2)
 }
@@ -2129,7 +2129,7 @@ func (m *MockKBPKI) ResolveImplicitTeam(arg0 context.Context, arg1, arg2 string,
 }
 
 // ResolveImplicitTeam indicates an expected call of ResolveImplicitTeam.
-func (mr *MockKBPKIMockRecorder) ResolveImplicitTeam(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) ResolveImplicitTeam(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeam", reflect.TypeOf((*MockKBPKI)(nil).ResolveImplicitTeam), arg0, arg1, arg2, arg3, arg4)
 }
@@ -2144,7 +2144,7 @@ func (m *MockKBPKI) ResolveImplicitTeamByID(arg0 context.Context, arg1 keybase1.
 }
 
 // ResolveImplicitTeamByID indicates an expected call of ResolveImplicitTeamByID.
-func (mr *MockKBPKIMockRecorder) ResolveImplicitTeamByID(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) ResolveImplicitTeamByID(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeamByID", reflect.TypeOf((*MockKBPKI)(nil).ResolveImplicitTeamByID), arg0, arg1, arg2, arg3)
 }
@@ -2159,7 +2159,7 @@ func (m *MockKBPKI) ResolveTeamTLFID(arg0 context.Context, arg1 keybase1.TeamID,
 }
 
 // ResolveTeamTLFID indicates an expected call of ResolveTeamTLFID.
-func (mr *MockKBPKIMockRecorder) ResolveTeamTLFID(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) ResolveTeamTLFID(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveTeamTLFID", reflect.TypeOf((*MockKBPKI)(nil).ResolveTeamTLFID), arg0, arg1, arg2)
 }
@@ -2173,7 +2173,7 @@ func (m *MockKBPKI) VerifyMerkleRoot(arg0 context.Context, arg1 keybase1.MerkleR
 }
 
 // VerifyMerkleRoot indicates an expected call of VerifyMerkleRoot.
-func (mr *MockKBPKIMockRecorder) VerifyMerkleRoot(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) VerifyMerkleRoot(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMerkleRoot", reflect.TypeOf((*MockKBPKI)(nil).VerifyMerkleRoot), arg0, arg1, arg2)
 }
@@ -2208,7 +2208,7 @@ func (m *MockKeybaseService) ClearCaches(arg0 context.Context) {
 }
 
 // ClearCaches indicates an expected call of ClearCaches.
-func (mr *MockKeybaseServiceMockRecorder) ClearCaches(arg0 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) ClearCaches(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearCaches", reflect.TypeOf((*MockKeybaseService)(nil).ClearCaches), arg0)
 }
@@ -2222,7 +2222,7 @@ func (m *MockKeybaseService) CreateTeamTLF(arg0 context.Context, arg1 keybase1.T
 }
 
 // CreateTeamTLF indicates an expected call of CreateTeamTLF.
-func (mr *MockKeybaseServiceMockRecorder) CreateTeamTLF(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) CreateTeamTLF(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeamTLF", reflect.TypeOf((*MockKeybaseService)(nil).CreateTeamTLF), arg0, arg1, arg2)
 }
@@ -2237,7 +2237,7 @@ func (m *MockKeybaseService) CurrentSession(arg0 context.Context, arg1 int) (idu
 }
 
 // CurrentSession indicates an expected call of CurrentSession.
-func (mr *MockKeybaseServiceMockRecorder) CurrentSession(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) CurrentSession(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentSession", reflect.TypeOf((*MockKeybaseService)(nil).CurrentSession), arg0, arg1)
 }
@@ -2252,7 +2252,7 @@ func (m *MockKeybaseService) DecryptFavorites(arg0 context.Context, arg1 []byte)
 }
 
 // DecryptFavorites indicates an expected call of DecryptFavorites.
-func (mr *MockKeybaseServiceMockRecorder) DecryptFavorites(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) DecryptFavorites(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptFavorites", reflect.TypeOf((*MockKeybaseService)(nil).DecryptFavorites), arg0, arg1)
 }
@@ -2267,7 +2267,7 @@ func (m *MockKeybaseService) EncryptFavorites(arg0 context.Context, arg1 []byte)
 }
 
 // EncryptFavorites indicates an expected call of EncryptFavorites.
-func (mr *MockKeybaseServiceMockRecorder) EncryptFavorites(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) EncryptFavorites(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptFavorites", reflect.TypeOf((*MockKeybaseService)(nil).EncryptFavorites), arg0, arg1)
 }
@@ -2282,7 +2282,7 @@ func (m *MockKeybaseService) EstablishMountDir(arg0 context.Context) (string, er
 }
 
 // EstablishMountDir indicates an expected call of EstablishMountDir.
-func (mr *MockKeybaseServiceMockRecorder) EstablishMountDir(arg0 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) EstablishMountDir(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstablishMountDir", reflect.TypeOf((*MockKeybaseService)(nil).EstablishMountDir), arg0)
 }
@@ -2296,7 +2296,7 @@ func (m *MockKeybaseService) FavoriteAdd(arg0 context.Context, arg1 keybase1.Fol
 }
 
 // FavoriteAdd indicates an expected call of FavoriteAdd.
-func (mr *MockKeybaseServiceMockRecorder) FavoriteAdd(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) FavoriteAdd(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FavoriteAdd", reflect.TypeOf((*MockKeybaseService)(nil).FavoriteAdd), arg0, arg1)
 }
@@ -2310,7 +2310,7 @@ func (m *MockKeybaseService) FavoriteDelete(arg0 context.Context, arg1 keybase1.
 }
 
 // FavoriteDelete indicates an expected call of FavoriteDelete.
-func (mr *MockKeybaseServiceMockRecorder) FavoriteDelete(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) FavoriteDelete(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FavoriteDelete", reflect.TypeOf((*MockKeybaseService)(nil).FavoriteDelete), arg0, arg1)
 }
@@ -2325,7 +2325,7 @@ func (m *MockKeybaseService) FavoriteList(arg0 context.Context, arg1 int) (keyba
 }
 
 // FavoriteList indicates an expected call of FavoriteList.
-func (mr *MockKeybaseServiceMockRecorder) FavoriteList(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) FavoriteList(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FavoriteList", reflect.TypeOf((*MockKeybaseService)(nil).FavoriteList), arg0, arg1)
 }
@@ -2337,7 +2337,7 @@ func (m *MockKeybaseService) FlushUserFromLocalCache(arg0 context.Context, arg1 
 }
 
 // FlushUserFromLocalCache indicates an expected call of FlushUserFromLocalCache.
-func (mr *MockKeybaseServiceMockRecorder) FlushUserFromLocalCache(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) FlushUserFromLocalCache(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushUserFromLocalCache", reflect.TypeOf((*MockKeybaseService)(nil).FlushUserFromLocalCache), arg0, arg1)
 }
@@ -2353,7 +2353,7 @@ func (m *MockKeybaseService) GetCurrentMerkleRoot(arg0 context.Context) (keybase
 }
 
 // GetCurrentMerkleRoot indicates an expected call of GetCurrentMerkleRoot.
-func (mr *MockKeybaseServiceMockRecorder) GetCurrentMerkleRoot(arg0 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) GetCurrentMerkleRoot(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentMerkleRoot", reflect.TypeOf((*MockKeybaseService)(nil).GetCurrentMerkleRoot), arg0)
 }
@@ -2382,7 +2382,7 @@ func (m *MockKeybaseService) GetTeamSettings(arg0 context.Context, arg1 keybase1
 }
 
 // GetTeamSettings indicates an expected call of GetTeamSettings.
-func (mr *MockKeybaseServiceMockRecorder) GetTeamSettings(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) GetTeamSettings(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamSettings", reflect.TypeOf((*MockKeybaseService)(nil).GetTeamSettings), arg0, arg1, arg2)
 }
@@ -2398,7 +2398,7 @@ func (m *MockKeybaseService) Identify(arg0 context.Context, arg1, arg2 string, a
 }
 
 // Identify indicates an expected call of Identify.
-func (mr *MockKeybaseServiceMockRecorder) Identify(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) Identify(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockKeybaseService)(nil).Identify), arg0, arg1, arg2, arg3)
 }
@@ -2413,7 +2413,7 @@ func (m *MockKeybaseService) LoadTeamPlusKeys(arg0 context.Context, arg1 keybase
 }
 
 // LoadTeamPlusKeys indicates an expected call of LoadTeamPlusKeys.
-func (mr *MockKeybaseServiceMockRecorder) LoadTeamPlusKeys(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) LoadTeamPlusKeys(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTeamPlusKeys", reflect.TypeOf((*MockKeybaseService)(nil).LoadTeamPlusKeys), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
@@ -2428,7 +2428,7 @@ func (m *MockKeybaseService) LoadUserPlusKeys(arg0 context.Context, arg1 keybase
 }
 
 // LoadUserPlusKeys indicates an expected call of LoadUserPlusKeys.
-func (mr *MockKeybaseServiceMockRecorder) LoadUserPlusKeys(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) LoadUserPlusKeys(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadUserPlusKeys", reflect.TypeOf((*MockKeybaseService)(nil).LoadUserPlusKeys), arg0, arg1, arg2, arg3)
 }
@@ -2443,7 +2443,7 @@ func (m *MockKeybaseService) NormalizeSocialAssertion(arg0 context.Context, arg1
 }
 
 // NormalizeSocialAssertion indicates an expected call of NormalizeSocialAssertion.
-func (mr *MockKeybaseServiceMockRecorder) NormalizeSocialAssertion(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) NormalizeSocialAssertion(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NormalizeSocialAssertion", reflect.TypeOf((*MockKeybaseService)(nil).NormalizeSocialAssertion), arg0, arg1)
 }
@@ -2457,7 +2457,7 @@ func (m *MockKeybaseService) Notify(arg0 context.Context, arg1 *keybase1.FSNotif
 }
 
 // Notify indicates an expected call of Notify.
-func (mr *MockKeybaseServiceMockRecorder) Notify(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) Notify(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockKeybaseService)(nil).Notify), arg0, arg1)
 }
@@ -2471,7 +2471,7 @@ func (m *MockKeybaseService) NotifyFavoritesChanged(arg0 context.Context) error 
 }
 
 // NotifyFavoritesChanged indicates an expected call of NotifyFavoritesChanged.
-func (mr *MockKeybaseServiceMockRecorder) NotifyFavoritesChanged(arg0 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) NotifyFavoritesChanged(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyFavoritesChanged", reflect.TypeOf((*MockKeybaseService)(nil).NotifyFavoritesChanged), arg0)
 }
@@ -2485,7 +2485,7 @@ func (m *MockKeybaseService) NotifyOnlineStatusChanged(arg0 context.Context, arg
 }
 
 // NotifyOnlineStatusChanged indicates an expected call of NotifyOnlineStatusChanged.
-func (mr *MockKeybaseServiceMockRecorder) NotifyOnlineStatusChanged(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) NotifyOnlineStatusChanged(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOnlineStatusChanged", reflect.TypeOf((*MockKeybaseService)(nil).NotifyOnlineStatusChanged), arg0, arg1)
 }
@@ -2499,7 +2499,7 @@ func (m *MockKeybaseService) NotifyOverallSyncStatus(arg0 context.Context, arg1 
 }
 
 // NotifyOverallSyncStatus indicates an expected call of NotifyOverallSyncStatus.
-func (mr *MockKeybaseServiceMockRecorder) NotifyOverallSyncStatus(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) NotifyOverallSyncStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOverallSyncStatus", reflect.TypeOf((*MockKeybaseService)(nil).NotifyOverallSyncStatus), arg0, arg1)
 }
@@ -2513,7 +2513,7 @@ func (m *MockKeybaseService) NotifyPathUpdated(arg0 context.Context, arg1 string
 }
 
 // NotifyPathUpdated indicates an expected call of NotifyPathUpdated.
-func (mr *MockKeybaseServiceMockRecorder) NotifyPathUpdated(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) NotifyPathUpdated(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyPathUpdated", reflect.TypeOf((*MockKeybaseService)(nil).NotifyPathUpdated), arg0, arg1)
 }
@@ -2527,7 +2527,7 @@ func (m *MockKeybaseService) NotifySyncStatus(arg0 context.Context, arg1 *keybas
 }
 
 // NotifySyncStatus indicates an expected call of NotifySyncStatus.
-func (mr *MockKeybaseServiceMockRecorder) NotifySyncStatus(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) NotifySyncStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifySyncStatus", reflect.TypeOf((*MockKeybaseService)(nil).NotifySyncStatus), arg0, arg1)
 }
@@ -2539,7 +2539,7 @@ func (m *MockKeybaseService) OnNonPathChange(arg0 SubscriptionManagerClientID, a
 }
 
 // OnNonPathChange indicates an expected call of OnNonPathChange.
-func (mr *MockKeybaseServiceMockRecorder) OnNonPathChange(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) OnNonPathChange(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNonPathChange", reflect.TypeOf((*MockKeybaseService)(nil).OnNonPathChange), arg0, arg1, arg2)
 }
@@ -2551,7 +2551,7 @@ func (m *MockKeybaseService) OnPathChange(arg0 SubscriptionManagerClientID, arg1
 }
 
 // OnPathChange indicates an expected call of OnPathChange.
-func (mr *MockKeybaseServiceMockRecorder) OnPathChange(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) OnPathChange(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPathChange", reflect.TypeOf((*MockKeybaseService)(nil).OnPathChange), arg0, arg1, arg2, arg3)
 }
@@ -2565,7 +2565,7 @@ func (m *MockKeybaseService) PutGitMetadata(arg0 context.Context, arg1 keybase1.
 }
 
 // PutGitMetadata indicates an expected call of PutGitMetadata.
-func (mr *MockKeybaseServiceMockRecorder) PutGitMetadata(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) PutGitMetadata(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutGitMetadata", reflect.TypeOf((*MockKeybaseService)(nil).PutGitMetadata), arg0, arg1, arg2, arg3)
 }
@@ -2581,7 +2581,7 @@ func (m *MockKeybaseService) Resolve(arg0 context.Context, arg1 string, arg2 key
 }
 
 // Resolve indicates an expected call of Resolve.
-func (mr *MockKeybaseServiceMockRecorder) Resolve(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) Resolve(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockKeybaseService)(nil).Resolve), arg0, arg1, arg2)
 }
@@ -2596,7 +2596,7 @@ func (m *MockKeybaseService) ResolveIdentifyImplicitTeam(arg0 context.Context, a
 }
 
 // ResolveIdentifyImplicitTeam indicates an expected call of ResolveIdentifyImplicitTeam.
-func (mr *MockKeybaseServiceMockRecorder) ResolveIdentifyImplicitTeam(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) ResolveIdentifyImplicitTeam(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveIdentifyImplicitTeam", reflect.TypeOf((*MockKeybaseService)(nil).ResolveIdentifyImplicitTeam), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
@@ -2611,7 +2611,7 @@ func (m *MockKeybaseService) ResolveImplicitTeamByID(arg0 context.Context, arg1 
 }
 
 // ResolveImplicitTeamByID indicates an expected call of ResolveImplicitTeamByID.
-func (mr *MockKeybaseServiceMockRecorder) ResolveImplicitTeamByID(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) ResolveImplicitTeamByID(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeamByID", reflect.TypeOf((*MockKeybaseService)(nil).ResolveImplicitTeamByID), arg0, arg1)
 }
@@ -2637,7 +2637,7 @@ func (m *MockKeybaseService) VerifyMerkleRoot(arg0 context.Context, arg1 keybase
 }
 
 // VerifyMerkleRoot indicates an expected call of VerifyMerkleRoot.
-func (mr *MockKeybaseServiceMockRecorder) VerifyMerkleRoot(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) VerifyMerkleRoot(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMerkleRoot", reflect.TypeOf((*MockKeybaseService)(nil).VerifyMerkleRoot), arg0, arg1, arg2)
 }
@@ -2675,7 +2675,7 @@ func (m *MockKeyCache) GetTLFCryptKey(arg0 tlf.ID, arg1 kbfsmd.KeyGen) (kbfscryp
 }
 
 // GetTLFCryptKey indicates an expected call of GetTLFCryptKey.
-func (mr *MockKeyCacheMockRecorder) GetTLFCryptKey(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeyCacheMockRecorder) GetTLFCryptKey(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFCryptKey", reflect.TypeOf((*MockKeyCache)(nil).GetTLFCryptKey), arg0, arg1)
 }
@@ -2689,7 +2689,7 @@ func (m *MockKeyCache) PutTLFCryptKey(arg0 tlf.ID, arg1 kbfsmd.KeyGen, arg2 kbfs
 }
 
 // PutTLFCryptKey indicates an expected call of PutTLFCryptKey.
-func (mr *MockKeyCacheMockRecorder) PutTLFCryptKey(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeyCacheMockRecorder) PutTLFCryptKey(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutTLFCryptKey", reflect.TypeOf((*MockKeyCache)(nil).PutTLFCryptKey), arg0, arg1, arg2)
 }
@@ -2727,7 +2727,7 @@ func (m *MockKeyManager) GetFirstTLFCryptKey(arg0 context.Context, arg1 libkey.K
 }
 
 // GetFirstTLFCryptKey indicates an expected call of GetFirstTLFCryptKey.
-func (mr *MockKeyManagerMockRecorder) GetFirstTLFCryptKey(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeyManagerMockRecorder) GetFirstTLFCryptKey(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirstTLFCryptKey", reflect.TypeOf((*MockKeyManager)(nil).GetFirstTLFCryptKey), arg0, arg1)
 }
@@ -2742,7 +2742,7 @@ func (m *MockKeyManager) GetTLFCryptKeyForBlockDecryption(arg0 context.Context, 
 }
 
 // GetTLFCryptKeyForBlockDecryption indicates an expected call of GetTLFCryptKeyForBlockDecryption.
-func (mr *MockKeyManagerMockRecorder) GetTLFCryptKeyForBlockDecryption(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeyManagerMockRecorder) GetTLFCryptKeyForBlockDecryption(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFCryptKeyForBlockDecryption", reflect.TypeOf((*MockKeyManager)(nil).GetTLFCryptKeyForBlockDecryption), arg0, arg1, arg2)
 }
@@ -2757,7 +2757,7 @@ func (m *MockKeyManager) GetTLFCryptKeyForEncryption(arg0 context.Context, arg1 
 }
 
 // GetTLFCryptKeyForEncryption indicates an expected call of GetTLFCryptKeyForEncryption.
-func (mr *MockKeyManagerMockRecorder) GetTLFCryptKeyForEncryption(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeyManagerMockRecorder) GetTLFCryptKeyForEncryption(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFCryptKeyForEncryption", reflect.TypeOf((*MockKeyManager)(nil).GetTLFCryptKeyForEncryption), arg0, arg1)
 }
@@ -2772,7 +2772,7 @@ func (m *MockKeyManager) GetTLFCryptKeyForMDDecryption(arg0 context.Context, arg
 }
 
 // GetTLFCryptKeyForMDDecryption indicates an expected call of GetTLFCryptKeyForMDDecryption.
-func (mr *MockKeyManagerMockRecorder) GetTLFCryptKeyForMDDecryption(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeyManagerMockRecorder) GetTLFCryptKeyForMDDecryption(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFCryptKeyForMDDecryption", reflect.TypeOf((*MockKeyManager)(nil).GetTLFCryptKeyForMDDecryption), arg0, arg1, arg2)
 }
@@ -2787,7 +2787,7 @@ func (m *MockKeyManager) GetTLFCryptKeyOfAllGenerations(arg0 context.Context, ar
 }
 
 // GetTLFCryptKeyOfAllGenerations indicates an expected call of GetTLFCryptKeyOfAllGenerations.
-func (mr *MockKeyManagerMockRecorder) GetTLFCryptKeyOfAllGenerations(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeyManagerMockRecorder) GetTLFCryptKeyOfAllGenerations(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFCryptKeyOfAllGenerations", reflect.TypeOf((*MockKeyManager)(nil).GetTLFCryptKeyOfAllGenerations), arg0, arg1)
 }
@@ -2803,7 +2803,7 @@ func (m *MockKeyManager) Rekey(arg0 context.Context, arg1 *RootMetadata, arg2 bo
 }
 
 // Rekey indicates an expected call of Rekey.
-func (mr *MockKeyManagerMockRecorder) Rekey(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeyManagerMockRecorder) Rekey(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rekey", reflect.TypeOf((*MockKeyManager)(nil).Rekey), arg0, arg1, arg2)
 }
@@ -2838,7 +2838,7 @@ func (m *MockMDCache) ChangeHandleForID(arg0, arg1 *tlfhandle.Handle) {
 }
 
 // ChangeHandleForID indicates an expected call of ChangeHandleForID.
-func (mr *MockMDCacheMockRecorder) ChangeHandleForID(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDCacheMockRecorder) ChangeHandleForID(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeHandleForID", reflect.TypeOf((*MockMDCache)(nil).ChangeHandleForID), arg0, arg1)
 }
@@ -2850,7 +2850,7 @@ func (m *MockMDCache) Delete(arg0 tlf.ID, arg1 kbfsmd.Revision, arg2 kbfsmd.Bran
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockMDCacheMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDCacheMockRecorder) Delete(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockMDCache)(nil).Delete), arg0, arg1, arg2)
 }
@@ -2865,7 +2865,7 @@ func (m *MockMDCache) Get(arg0 tlf.ID, arg1 kbfsmd.Revision, arg2 kbfsmd.BranchI
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockMDCacheMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDCacheMockRecorder) Get(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockMDCache)(nil).Get), arg0, arg1, arg2)
 }
@@ -2880,7 +2880,7 @@ func (m *MockMDCache) GetIDForHandle(arg0 *tlfhandle.Handle) (tlf.ID, error) {
 }
 
 // GetIDForHandle indicates an expected call of GetIDForHandle.
-func (mr *MockMDCacheMockRecorder) GetIDForHandle(arg0 interface{}) *gomock.Call {
+func (mr *MockMDCacheMockRecorder) GetIDForHandle(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDForHandle", reflect.TypeOf((*MockMDCache)(nil).GetIDForHandle), arg0)
 }
@@ -2897,7 +2897,7 @@ func (m *MockMDCache) GetNextMD(arg0 tlf.ID, arg1 keybase1.Seqno) (*kbfsmd.Merkl
 }
 
 // GetNextMD indicates an expected call of GetNextMD.
-func (mr *MockMDCacheMockRecorder) GetNextMD(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDCacheMockRecorder) GetNextMD(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextMD", reflect.TypeOf((*MockMDCache)(nil).GetNextMD), arg0, arg1)
 }
@@ -2909,7 +2909,7 @@ func (m *MockMDCache) MarkPutToServer(arg0 tlf.ID, arg1 kbfsmd.Revision, arg2 kb
 }
 
 // MarkPutToServer indicates an expected call of MarkPutToServer.
-func (mr *MockMDCacheMockRecorder) MarkPutToServer(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDCacheMockRecorder) MarkPutToServer(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkPutToServer", reflect.TypeOf((*MockMDCache)(nil).MarkPutToServer), arg0, arg1, arg2)
 }
@@ -2923,7 +2923,7 @@ func (m *MockMDCache) Put(arg0 ImmutableRootMetadata) error {
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockMDCacheMockRecorder) Put(arg0 interface{}) *gomock.Call {
+func (mr *MockMDCacheMockRecorder) Put(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockMDCache)(nil).Put), arg0)
 }
@@ -2937,7 +2937,7 @@ func (m *MockMDCache) PutIDForHandle(arg0 *tlfhandle.Handle, arg1 tlf.ID) error 
 }
 
 // PutIDForHandle indicates an expected call of PutIDForHandle.
-func (mr *MockMDCacheMockRecorder) PutIDForHandle(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDCacheMockRecorder) PutIDForHandle(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutIDForHandle", reflect.TypeOf((*MockMDCache)(nil).PutIDForHandle), arg0, arg1)
 }
@@ -2951,7 +2951,7 @@ func (m *MockMDCache) PutNextMD(arg0 tlf.ID, arg1 keybase1.Seqno, arg2 *kbfsmd.M
 }
 
 // PutNextMD indicates an expected call of PutNextMD.
-func (mr *MockMDCacheMockRecorder) PutNextMD(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockMDCacheMockRecorder) PutNextMD(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutNextMD", reflect.TypeOf((*MockMDCache)(nil).PutNextMD), arg0, arg1, arg2, arg3, arg4)
 }
@@ -2965,7 +2965,7 @@ func (m *MockMDCache) Replace(arg0 ImmutableRootMetadata, arg1 kbfsmd.BranchID) 
 }
 
 // Replace indicates an expected call of Replace.
-func (mr *MockMDCacheMockRecorder) Replace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDCacheMockRecorder) Replace(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Replace", reflect.TypeOf((*MockMDCache)(nil).Replace), arg0, arg1)
 }
@@ -3003,7 +3003,7 @@ func (m *MockMDOps) GetForTLF(arg0 context.Context, arg1 tlf.ID, arg2 *keybase1.
 }
 
 // GetForTLF indicates an expected call of GetForTLF.
-func (mr *MockMDOpsMockRecorder) GetForTLF(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) GetForTLF(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetForTLF", reflect.TypeOf((*MockMDOps)(nil).GetForTLF), arg0, arg1, arg2)
 }
@@ -3018,7 +3018,7 @@ func (m *MockMDOps) GetForTLFByTime(arg0 context.Context, arg1 tlf.ID, arg2 time
 }
 
 // GetForTLFByTime indicates an expected call of GetForTLFByTime.
-func (mr *MockMDOpsMockRecorder) GetForTLFByTime(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) GetForTLFByTime(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetForTLFByTime", reflect.TypeOf((*MockMDOps)(nil).GetForTLFByTime), arg0, arg1, arg2)
 }
@@ -3033,7 +3033,7 @@ func (m *MockMDOps) GetIDForHandle(arg0 context.Context, arg1 *tlfhandle.Handle)
 }
 
 // GetIDForHandle indicates an expected call of GetIDForHandle.
-func (mr *MockMDOpsMockRecorder) GetIDForHandle(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) GetIDForHandle(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDForHandle", reflect.TypeOf((*MockMDOps)(nil).GetIDForHandle), arg0, arg1)
 }
@@ -3048,7 +3048,7 @@ func (m *MockMDOps) GetLatestHandleForTLF(arg0 context.Context, arg1 tlf.ID) (tl
 }
 
 // GetLatestHandleForTLF indicates an expected call of GetLatestHandleForTLF.
-func (mr *MockMDOpsMockRecorder) GetLatestHandleForTLF(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) GetLatestHandleForTLF(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestHandleForTLF", reflect.TypeOf((*MockMDOps)(nil).GetLatestHandleForTLF), arg0, arg1)
 }
@@ -3063,7 +3063,7 @@ func (m *MockMDOps) GetRange(arg0 context.Context, arg1 tlf.ID, arg2, arg3 kbfsm
 }
 
 // GetRange indicates an expected call of GetRange.
-func (mr *MockMDOpsMockRecorder) GetRange(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) GetRange(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRange", reflect.TypeOf((*MockMDOps)(nil).GetRange), arg0, arg1, arg2, arg3, arg4)
 }
@@ -3078,7 +3078,7 @@ func (m *MockMDOps) GetUnmergedForTLF(arg0 context.Context, arg1 tlf.ID, arg2 kb
 }
 
 // GetUnmergedForTLF indicates an expected call of GetUnmergedForTLF.
-func (mr *MockMDOpsMockRecorder) GetUnmergedForTLF(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) GetUnmergedForTLF(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnmergedForTLF", reflect.TypeOf((*MockMDOps)(nil).GetUnmergedForTLF), arg0, arg1, arg2)
 }
@@ -3093,7 +3093,7 @@ func (m *MockMDOps) GetUnmergedRange(arg0 context.Context, arg1 tlf.ID, arg2 kbf
 }
 
 // GetUnmergedRange indicates an expected call of GetUnmergedRange.
-func (mr *MockMDOpsMockRecorder) GetUnmergedRange(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) GetUnmergedRange(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnmergedRange", reflect.TypeOf((*MockMDOps)(nil).GetUnmergedRange), arg0, arg1, arg2, arg3, arg4)
 }
@@ -3107,7 +3107,7 @@ func (m *MockMDOps) PruneBranch(arg0 context.Context, arg1 tlf.ID, arg2 kbfsmd.B
 }
 
 // PruneBranch indicates an expected call of PruneBranch.
-func (mr *MockMDOpsMockRecorder) PruneBranch(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) PruneBranch(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneBranch", reflect.TypeOf((*MockMDOps)(nil).PruneBranch), arg0, arg1, arg2)
 }
@@ -3122,7 +3122,7 @@ func (m *MockMDOps) Put(arg0 context.Context, arg1 *RootMetadata, arg2 kbfscrypt
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockMDOpsMockRecorder) Put(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) Put(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockMDOps)(nil).Put), arg0, arg1, arg2, arg3, arg4, arg5)
 }
@@ -3137,7 +3137,7 @@ func (m *MockMDOps) PutUnmerged(arg0 context.Context, arg1 *RootMetadata, arg2 k
 }
 
 // PutUnmerged indicates an expected call of PutUnmerged.
-func (mr *MockMDOpsMockRecorder) PutUnmerged(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) PutUnmerged(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUnmerged", reflect.TypeOf((*MockMDOps)(nil).PutUnmerged), arg0, arg1, arg2, arg3)
 }
@@ -3152,7 +3152,7 @@ func (m *MockMDOps) ResolveBranch(arg0 context.Context, arg1 tlf.ID, arg2 kbfsmd
 }
 
 // ResolveBranch indicates an expected call of ResolveBranch.
-func (mr *MockMDOpsMockRecorder) ResolveBranch(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) ResolveBranch(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBranch", reflect.TypeOf((*MockMDOps)(nil).ResolveBranch), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
@@ -3167,7 +3167,7 @@ func (m *MockMDOps) ValidateLatestHandleNotFinal(arg0 context.Context, arg1 *tlf
 }
 
 // ValidateLatestHandleNotFinal indicates an expected call of ValidateLatestHandleNotFinal.
-func (mr *MockMDOpsMockRecorder) ValidateLatestHandleNotFinal(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) ValidateLatestHandleNotFinal(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateLatestHandleNotFinal", reflect.TypeOf((*MockMDOps)(nil).ValidateLatestHandleNotFinal), arg0, arg1)
 }
@@ -3202,7 +3202,7 @@ func (m *MockMDServer) CancelRegistration(arg0 context.Context, arg1 tlf.ID) {
 }
 
 // CancelRegistration indicates an expected call of CancelRegistration.
-func (mr *MockMDServerMockRecorder) CancelRegistration(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) CancelRegistration(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelRegistration", reflect.TypeOf((*MockMDServer)(nil).CancelRegistration), arg0, arg1)
 }
@@ -3216,7 +3216,7 @@ func (m *MockMDServer) CheckForRekeys(arg0 context.Context) <-chan error {
 }
 
 // CheckForRekeys indicates an expected call of CheckForRekeys.
-func (mr *MockMDServerMockRecorder) CheckForRekeys(arg0 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) CheckForRekeys(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckForRekeys", reflect.TypeOf((*MockMDServer)(nil).CheckForRekeys), arg0)
 }
@@ -3228,7 +3228,7 @@ func (m *MockMDServer) CheckReachability(arg0 context.Context) {
 }
 
 // CheckReachability indicates an expected call of CheckReachability.
-func (mr *MockMDServerMockRecorder) CheckReachability(arg0 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) CheckReachability(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckReachability", reflect.TypeOf((*MockMDServer)(nil).CheckReachability), arg0)
 }
@@ -3269,7 +3269,7 @@ func (m *MockMDServer) FindNextMD(arg0 context.Context, arg1 tlf.ID, arg2 keybas
 }
 
 // FindNextMD indicates an expected call of FindNextMD.
-func (mr *MockMDServerMockRecorder) FindNextMD(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) FindNextMD(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindNextMD", reflect.TypeOf((*MockMDServer)(nil).FindNextMD), arg0, arg1, arg2)
 }
@@ -3285,7 +3285,7 @@ func (m *MockMDServer) GetForHandle(arg0 context.Context, arg1 tlf.Handle, arg2 
 }
 
 // GetForHandle indicates an expected call of GetForHandle.
-func (mr *MockMDServerMockRecorder) GetForHandle(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) GetForHandle(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetForHandle", reflect.TypeOf((*MockMDServer)(nil).GetForHandle), arg0, arg1, arg2, arg3)
 }
@@ -3300,7 +3300,7 @@ func (m *MockMDServer) GetForTLF(arg0 context.Context, arg1 tlf.ID, arg2 kbfsmd.
 }
 
 // GetForTLF indicates an expected call of GetForTLF.
-func (mr *MockMDServerMockRecorder) GetForTLF(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) GetForTLF(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetForTLF", reflect.TypeOf((*MockMDServer)(nil).GetForTLF), arg0, arg1, arg2, arg3, arg4)
 }
@@ -3315,7 +3315,7 @@ func (m *MockMDServer) GetForTLFByTime(arg0 context.Context, arg1 tlf.ID, arg2 t
 }
 
 // GetForTLFByTime indicates an expected call of GetForTLFByTime.
-func (mr *MockMDServerMockRecorder) GetForTLFByTime(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) GetForTLFByTime(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetForTLFByTime", reflect.TypeOf((*MockMDServer)(nil).GetForTLFByTime), arg0, arg1, arg2)
 }
@@ -3331,7 +3331,7 @@ func (m *MockMDServer) GetKeyBundles(arg0 context.Context, arg1 tlf.ID, arg2 kbf
 }
 
 // GetKeyBundles indicates an expected call of GetKeyBundles.
-func (mr *MockMDServerMockRecorder) GetKeyBundles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) GetKeyBundles(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyBundles", reflect.TypeOf((*MockMDServer)(nil).GetKeyBundles), arg0, arg1, arg2, arg3)
 }
@@ -3346,7 +3346,7 @@ func (m *MockMDServer) GetLatestHandleForTLF(arg0 context.Context, arg1 tlf.ID) 
 }
 
 // GetLatestHandleForTLF indicates an expected call of GetLatestHandleForTLF.
-func (mr *MockMDServerMockRecorder) GetLatestHandleForTLF(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) GetLatestHandleForTLF(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestHandleForTLF", reflect.TypeOf((*MockMDServer)(nil).GetLatestHandleForTLF), arg0, arg1)
 }
@@ -3361,7 +3361,7 @@ func (m *MockMDServer) GetMerkleRootLatest(arg0 context.Context, arg1 keybase1.M
 }
 
 // GetMerkleRootLatest indicates an expected call of GetMerkleRootLatest.
-func (mr *MockMDServerMockRecorder) GetMerkleRootLatest(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) GetMerkleRootLatest(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMerkleRootLatest", reflect.TypeOf((*MockMDServer)(nil).GetMerkleRootLatest), arg0, arg1)
 }
@@ -3376,7 +3376,7 @@ func (m *MockMDServer) GetRange(arg0 context.Context, arg1 tlf.ID, arg2 kbfsmd.B
 }
 
 // GetRange indicates an expected call of GetRange.
-func (mr *MockMDServerMockRecorder) GetRange(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) GetRange(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRange", reflect.TypeOf((*MockMDServer)(nil).GetRange), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
@@ -3404,7 +3404,7 @@ func (m *MockMDServer) Lock(arg0 context.Context, arg1 tlf.ID, arg2 keybase1.Loc
 }
 
 // Lock indicates an expected call of Lock.
-func (mr *MockMDServerMockRecorder) Lock(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) Lock(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lock", reflect.TypeOf((*MockMDServer)(nil).Lock), arg0, arg1, arg2)
 }
@@ -3433,7 +3433,7 @@ func (m *MockMDServer) PruneBranch(arg0 context.Context, arg1 tlf.ID, arg2 kbfsm
 }
 
 // PruneBranch indicates an expected call of PruneBranch.
-func (mr *MockMDServerMockRecorder) PruneBranch(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) PruneBranch(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneBranch", reflect.TypeOf((*MockMDServer)(nil).PruneBranch), arg0, arg1, arg2)
 }
@@ -3447,7 +3447,7 @@ func (m *MockMDServer) Put(arg0 context.Context, arg1 *RootMetadataSigned, arg2 
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockMDServerMockRecorder) Put(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) Put(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockMDServer)(nil).Put), arg0, arg1, arg2, arg3, arg4)
 }
@@ -3459,7 +3459,7 @@ func (m *MockMDServer) RefreshAuthToken(arg0 context.Context) {
 }
 
 // RefreshAuthToken indicates an expected call of RefreshAuthToken.
-func (mr *MockMDServerMockRecorder) RefreshAuthToken(arg0 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) RefreshAuthToken(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshAuthToken", reflect.TypeOf((*MockMDServer)(nil).RefreshAuthToken), arg0)
 }
@@ -3474,7 +3474,7 @@ func (m *MockMDServer) RegisterForUpdate(arg0 context.Context, arg1 tlf.ID, arg2
 }
 
 // RegisterForUpdate indicates an expected call of RegisterForUpdate.
-func (mr *MockMDServerMockRecorder) RegisterForUpdate(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) RegisterForUpdate(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterForUpdate", reflect.TypeOf((*MockMDServer)(nil).RegisterForUpdate), arg0, arg1, arg2)
 }
@@ -3488,7 +3488,7 @@ func (m *MockMDServer) ReleaseLock(arg0 context.Context, arg1 tlf.ID, arg2 keyba
 }
 
 // ReleaseLock indicates an expected call of ReleaseLock.
-func (mr *MockMDServerMockRecorder) ReleaseLock(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) ReleaseLock(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseLock", reflect.TypeOf((*MockMDServer)(nil).ReleaseLock), arg0, arg1, arg2)
 }
@@ -3514,7 +3514,7 @@ func (m *MockMDServer) StartImplicitTeamMigration(arg0 context.Context, arg1 tlf
 }
 
 // StartImplicitTeamMigration indicates an expected call of StartImplicitTeamMigration.
-func (mr *MockMDServerMockRecorder) StartImplicitTeamMigration(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) StartImplicitTeamMigration(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartImplicitTeamMigration", reflect.TypeOf((*MockMDServer)(nil).StartImplicitTeamMigration), arg0, arg1)
 }
@@ -3529,7 +3529,7 @@ func (m *MockMDServer) TruncateLock(arg0 context.Context, arg1 tlf.ID) (bool, er
 }
 
 // TruncateLock indicates an expected call of TruncateLock.
-func (mr *MockMDServerMockRecorder) TruncateLock(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) TruncateLock(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TruncateLock", reflect.TypeOf((*MockMDServer)(nil).TruncateLock), arg0, arg1)
 }
@@ -3544,7 +3544,7 @@ func (m *MockMDServer) TruncateUnlock(arg0 context.Context, arg1 tlf.ID) (bool, 
 }
 
 // TruncateUnlock indicates an expected call of TruncateUnlock.
-func (mr *MockMDServerMockRecorder) TruncateUnlock(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMDServerMockRecorder) TruncateUnlock(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TruncateUnlock", reflect.TypeOf((*MockMDServer)(nil).TruncateUnlock), arg0, arg1)
 }
@@ -3581,7 +3581,7 @@ func (m *MockNode) ChildName(arg0 string) data.PathPartString {
 }
 
 // ChildName indicates an expected call of ChildName.
-func (mr *MockNodeMockRecorder) ChildName(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) ChildName(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChildName", reflect.TypeOf((*MockNode)(nil).ChildName), arg0)
 }
@@ -3607,7 +3607,7 @@ func (m *MockNode) FillCacheDuration(arg0 *time.Duration) {
 }
 
 // FillCacheDuration indicates an expected call of FillCacheDuration.
-func (mr *MockNodeMockRecorder) FillCacheDuration(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) FillCacheDuration(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FillCacheDuration", reflect.TypeOf((*MockNode)(nil).FillCacheDuration), arg0)
 }
@@ -3649,7 +3649,7 @@ func (m *MockNode) GetFS(arg0 context.Context) NodeFSReadOnly {
 }
 
 // GetFS indicates an expected call of GetFS.
-func (mr *MockNodeMockRecorder) GetFS(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) GetFS(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFS", reflect.TypeOf((*MockNode)(nil).GetFS), arg0)
 }
@@ -3663,7 +3663,7 @@ func (m *MockNode) GetFile(arg0 context.Context) billy.File {
 }
 
 // GetFile indicates an expected call of GetFile.
-func (mr *MockNodeMockRecorder) GetFile(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) GetFile(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFile", reflect.TypeOf((*MockNode)(nil).GetFile), arg0)
 }
@@ -3734,7 +3734,7 @@ func (m *MockNode) Readonly(arg0 context.Context) bool {
 }
 
 // Readonly indicates an expected call of Readonly.
-func (mr *MockNodeMockRecorder) Readonly(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) Readonly(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Readonly", reflect.TypeOf((*MockNode)(nil).Readonly), arg0)
 }
@@ -3749,7 +3749,7 @@ func (m *MockNode) RemoveDir(arg0 context.Context, arg1 data.PathPartString) (bo
 }
 
 // RemoveDir indicates an expected call of RemoveDir.
-func (mr *MockNodeMockRecorder) RemoveDir(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) RemoveDir(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDir", reflect.TypeOf((*MockNode)(nil).RemoveDir), arg0, arg1)
 }
@@ -3768,7 +3768,7 @@ func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.Path
 }
 
 // ShouldCreateMissedLookup indicates an expected call of ShouldCreateMissedLookup.
-func (mr *MockNodeMockRecorder) ShouldCreateMissedLookup(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) ShouldCreateMissedLookup(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldCreateMissedLookup", reflect.TypeOf((*MockNode)(nil).ShouldCreateMissedLookup), arg0, arg1)
 }
@@ -3782,7 +3782,7 @@ func (m *MockNode) ShouldRetryOnDirRead(arg0 context.Context) bool {
 }
 
 // ShouldRetryOnDirRead indicates an expected call of ShouldRetryOnDirRead.
-func (mr *MockNodeMockRecorder) ShouldRetryOnDirRead(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) ShouldRetryOnDirRead(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldRetryOnDirRead", reflect.TypeOf((*MockNode)(nil).ShouldRetryOnDirRead), arg0)
 }
@@ -3810,7 +3810,7 @@ func (m *MockNode) WrapChild(arg0 Node) Node {
 }
 
 // WrapChild indicates an expected call of WrapChild.
-func (mr *MockNodeMockRecorder) WrapChild(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) WrapChild(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WrapChild", reflect.TypeOf((*MockNode)(nil).WrapChild), arg0)
 }
@@ -3845,7 +3845,7 @@ func (m *MockNodeCache) AddRootWrapper(arg0 func(Node) Node) {
 }
 
 // AddRootWrapper indicates an expected call of AddRootWrapper.
-func (mr *MockNodeCacheMockRecorder) AddRootWrapper(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) AddRootWrapper(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRootWrapper", reflect.TypeOf((*MockNodeCache)(nil).AddRootWrapper), arg0)
 }
@@ -3859,7 +3859,7 @@ func (m *MockNodeCache) AllNodeChildren(arg0 Node) []Node {
 }
 
 // AllNodeChildren indicates an expected call of AllNodeChildren.
-func (mr *MockNodeCacheMockRecorder) AllNodeChildren(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) AllNodeChildren(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllNodeChildren", reflect.TypeOf((*MockNodeCache)(nil).AllNodeChildren), arg0)
 }
@@ -3887,7 +3887,7 @@ func (m *MockNodeCache) Get(arg0 data.BlockRef) Node {
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockNodeCacheMockRecorder) Get(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) Get(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockNodeCache)(nil).Get), arg0)
 }
@@ -3902,7 +3902,7 @@ func (m *MockNodeCache) GetOrCreate(arg0 data.BlockPointer, arg1 data.PathPartSt
 }
 
 // GetOrCreate indicates an expected call of GetOrCreate.
-func (mr *MockNodeCacheMockRecorder) GetOrCreate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) GetOrCreate(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreate", reflect.TypeOf((*MockNodeCache)(nil).GetOrCreate), arg0, arg1, arg2, arg3)
 }
@@ -3916,7 +3916,7 @@ func (m *MockNodeCache) IsUnlinked(arg0 Node) bool {
 }
 
 // IsUnlinked indicates an expected call of IsUnlinked.
-func (mr *MockNodeCacheMockRecorder) IsUnlinked(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) IsUnlinked(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUnlinked", reflect.TypeOf((*MockNodeCache)(nil).IsUnlinked), arg0)
 }
@@ -3931,7 +3931,7 @@ func (m *MockNodeCache) Move(arg0 data.BlockRef, arg1 Node, arg2 data.PathPartSt
 }
 
 // Move indicates an expected call of Move.
-func (mr *MockNodeCacheMockRecorder) Move(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) Move(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Move", reflect.TypeOf((*MockNodeCache)(nil).Move), arg0, arg1, arg2)
 }
@@ -3959,7 +3959,7 @@ func (m *MockNodeCache) PathFromNode(arg0 Node) data.Path {
 }
 
 // PathFromNode indicates an expected call of PathFromNode.
-func (mr *MockNodeCacheMockRecorder) PathFromNode(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) PathFromNode(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PathFromNode", reflect.TypeOf((*MockNodeCache)(nil).PathFromNode), arg0)
 }
@@ -3971,7 +3971,7 @@ func (m *MockNodeCache) SetObfuscatorMaker(arg0 func() data.Obfuscator) {
 }
 
 // SetObfuscatorMaker indicates an expected call of SetObfuscatorMaker.
-func (mr *MockNodeCacheMockRecorder) SetObfuscatorMaker(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) SetObfuscatorMaker(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetObfuscatorMaker", reflect.TypeOf((*MockNodeCache)(nil).SetObfuscatorMaker), arg0)
 }
@@ -3985,7 +3985,7 @@ func (m *MockNodeCache) Unlink(arg0 data.BlockRef, arg1 data.Path, arg2 data.Dir
 }
 
 // Unlink indicates an expected call of Unlink.
-func (mr *MockNodeCacheMockRecorder) Unlink(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) Unlink(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlink", reflect.TypeOf((*MockNodeCache)(nil).Unlink), arg0, arg1, arg2)
 }
@@ -3999,7 +3999,7 @@ func (m *MockNodeCache) UnlinkedDirEntry(arg0 Node) data.DirEntry {
 }
 
 // UnlinkedDirEntry indicates an expected call of UnlinkedDirEntry.
-func (mr *MockNodeCacheMockRecorder) UnlinkedDirEntry(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) UnlinkedDirEntry(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkedDirEntry", reflect.TypeOf((*MockNodeCache)(nil).UnlinkedDirEntry), arg0)
 }
@@ -4013,7 +4013,7 @@ func (m *MockNodeCache) UpdatePointer(arg0 data.BlockRef, arg1 data.BlockPointer
 }
 
 // UpdatePointer indicates an expected call of UpdatePointer.
-func (mr *MockNodeCacheMockRecorder) UpdatePointer(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) UpdatePointer(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePointer", reflect.TypeOf((*MockNodeCache)(nil).UpdatePointer), arg0, arg1)
 }
@@ -4025,7 +4025,7 @@ func (m *MockNodeCache) UpdateUnlinkedDirEntry(arg0 Node, arg1 data.DirEntry) {
 }
 
 // UpdateUnlinkedDirEntry indicates an expected call of UpdateUnlinkedDirEntry.
-func (mr *MockNodeCacheMockRecorder) UpdateUnlinkedDirEntry(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNodeCacheMockRecorder) UpdateUnlinkedDirEntry(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUnlinkedDirEntry", reflect.TypeOf((*MockNodeCache)(nil).UpdateUnlinkedDirEntry), arg0, arg1)
 }
@@ -4099,7 +4099,7 @@ func (m *MockNotifier) RegisterForChanges(arg0 []data.FolderBranch, arg1 Observe
 }
 
 // RegisterForChanges indicates an expected call of RegisterForChanges.
-func (mr *MockNotifierMockRecorder) RegisterForChanges(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNotifierMockRecorder) RegisterForChanges(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterForChanges", reflect.TypeOf((*MockNotifier)(nil).RegisterForChanges), arg0, arg1)
 }
@@ -4113,7 +4113,7 @@ func (m *MockNotifier) RegisterForSyncedTlfs(arg0 SyncedTlfObserver) error {
 }
 
 // RegisterForSyncedTlfs indicates an expected call of RegisterForSyncedTlfs.
-func (mr *MockNotifierMockRecorder) RegisterForSyncedTlfs(arg0 interface{}) *gomock.Call {
+func (mr *MockNotifierMockRecorder) RegisterForSyncedTlfs(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterForSyncedTlfs", reflect.TypeOf((*MockNotifier)(nil).RegisterForSyncedTlfs), arg0)
 }
@@ -4127,7 +4127,7 @@ func (m *MockNotifier) UnregisterFromChanges(arg0 []data.FolderBranch, arg1 Obse
 }
 
 // UnregisterFromChanges indicates an expected call of UnregisterFromChanges.
-func (mr *MockNotifierMockRecorder) UnregisterFromChanges(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNotifierMockRecorder) UnregisterFromChanges(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterFromChanges", reflect.TypeOf((*MockNotifier)(nil).UnregisterFromChanges), arg0, arg1)
 }
@@ -4141,7 +4141,7 @@ func (m *MockNotifier) UnregisterFromSyncedTlfs(arg0 SyncedTlfObserver) error {
 }
 
 // UnregisterFromSyncedTlfs indicates an expected call of UnregisterFromSyncedTlfs.
-func (mr *MockNotifierMockRecorder) UnregisterFromSyncedTlfs(arg0 interface{}) *gomock.Call {
+func (mr *MockNotifierMockRecorder) UnregisterFromSyncedTlfs(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterFromSyncedTlfs", reflect.TypeOf((*MockNotifier)(nil).UnregisterFromSyncedTlfs), arg0)
 }
@@ -4176,7 +4176,7 @@ func (m *MockRekeyQueue) Enqueue(arg0 tlf.ID) {
 }
 
 // Enqueue indicates an expected call of Enqueue.
-func (mr *MockRekeyQueueMockRecorder) Enqueue(arg0 interface{}) *gomock.Call {
+func (mr *MockRekeyQueueMockRecorder) Enqueue(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enqueue", reflect.TypeOf((*MockRekeyQueue)(nil).Enqueue), arg0)
 }
@@ -4190,7 +4190,7 @@ func (m *MockRekeyQueue) IsRekeyPending(arg0 tlf.ID) bool {
 }
 
 // IsRekeyPending indicates an expected call of IsRekeyPending.
-func (mr *MockRekeyQueueMockRecorder) IsRekeyPending(arg0 interface{}) *gomock.Call {
+func (mr *MockRekeyQueueMockRecorder) IsRekeyPending(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRekeyPending", reflect.TypeOf((*MockRekeyQueue)(nil).IsRekeyPending), arg0)
 }
@@ -4251,7 +4251,7 @@ func (m *MockReporter) Notify(arg0 context.Context, arg1 *keybase1.FSNotificatio
 }
 
 // Notify indicates an expected call of Notify.
-func (mr *MockReporterMockRecorder) Notify(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockReporterMockRecorder) Notify(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockReporter)(nil).Notify), arg0, arg1)
 }
@@ -4263,7 +4263,7 @@ func (m *MockReporter) NotifyFavoritesChanged(arg0 context.Context) {
 }
 
 // NotifyFavoritesChanged indicates an expected call of NotifyFavoritesChanged.
-func (mr *MockReporterMockRecorder) NotifyFavoritesChanged(arg0 interface{}) *gomock.Call {
+func (mr *MockReporterMockRecorder) NotifyFavoritesChanged(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyFavoritesChanged", reflect.TypeOf((*MockReporter)(nil).NotifyFavoritesChanged), arg0)
 }
@@ -4275,7 +4275,7 @@ func (m *MockReporter) NotifyOverallSyncStatus(arg0 context.Context, arg1 keybas
 }
 
 // NotifyOverallSyncStatus indicates an expected call of NotifyOverallSyncStatus.
-func (mr *MockReporterMockRecorder) NotifyOverallSyncStatus(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockReporterMockRecorder) NotifyOverallSyncStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOverallSyncStatus", reflect.TypeOf((*MockReporter)(nil).NotifyOverallSyncStatus), arg0, arg1)
 }
@@ -4287,7 +4287,7 @@ func (m *MockReporter) NotifyPathUpdated(arg0 context.Context, arg1 string) {
 }
 
 // NotifyPathUpdated indicates an expected call of NotifyPathUpdated.
-func (mr *MockReporterMockRecorder) NotifyPathUpdated(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockReporterMockRecorder) NotifyPathUpdated(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyPathUpdated", reflect.TypeOf((*MockReporter)(nil).NotifyPathUpdated), arg0, arg1)
 }
@@ -4299,7 +4299,7 @@ func (m *MockReporter) NotifySyncStatus(arg0 context.Context, arg1 *keybase1.FSP
 }
 
 // NotifySyncStatus indicates an expected call of NotifySyncStatus.
-func (mr *MockReporterMockRecorder) NotifySyncStatus(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockReporterMockRecorder) NotifySyncStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifySyncStatus", reflect.TypeOf((*MockReporter)(nil).NotifySyncStatus), arg0, arg1)
 }
@@ -4311,7 +4311,7 @@ func (m *MockReporter) OnlineStatusChanged(arg0 context.Context, arg1 bool) {
 }
 
 // OnlineStatusChanged indicates an expected call of OnlineStatusChanged.
-func (mr *MockReporterMockRecorder) OnlineStatusChanged(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockReporterMockRecorder) OnlineStatusChanged(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnlineStatusChanged", reflect.TypeOf((*MockReporter)(nil).OnlineStatusChanged), arg0, arg1)
 }
@@ -4323,7 +4323,7 @@ func (m *MockReporter) ReportErr(arg0 context.Context, arg1 tlf.CanonicalName, a
 }
 
 // ReportErr indicates an expected call of ReportErr.
-func (mr *MockReporterMockRecorder) ReportErr(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockReporterMockRecorder) ReportErr(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportErr", reflect.TypeOf((*MockReporter)(nil).ReportErr), arg0, arg1, arg2, arg3, arg4)
 }
@@ -4370,7 +4370,7 @@ func (m *MockSubscriptionNotifier) OnNonPathChange(arg0 SubscriptionManagerClien
 }
 
 // OnNonPathChange indicates an expected call of OnNonPathChange.
-func (mr *MockSubscriptionNotifierMockRecorder) OnNonPathChange(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockSubscriptionNotifierMockRecorder) OnNonPathChange(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNonPathChange", reflect.TypeOf((*MockSubscriptionNotifier)(nil).OnNonPathChange), arg0, arg1, arg2)
 }
@@ -4382,7 +4382,7 @@ func (m *MockSubscriptionNotifier) OnPathChange(arg0 SubscriptionManagerClientID
 }
 
 // OnPathChange indicates an expected call of OnPathChange.
-func (mr *MockSubscriptionNotifierMockRecorder) OnPathChange(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockSubscriptionNotifierMockRecorder) OnPathChange(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPathChange", reflect.TypeOf((*MockSubscriptionNotifier)(nil).OnPathChange), arg0, arg1, arg2, arg3)
 }
@@ -4417,7 +4417,7 @@ func (m *MockSubscriptionManagerPublisher) PublishChange(arg0 keybase1.Subscript
 }
 
 // PublishChange indicates an expected call of PublishChange.
-func (mr *MockSubscriptionManagerPublisherMockRecorder) PublishChange(arg0 interface{}) *gomock.Call {
+func (mr *MockSubscriptionManagerPublisherMockRecorder) PublishChange(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishChange", reflect.TypeOf((*MockSubscriptionManagerPublisher)(nil).PublishChange), arg0)
 }

--- a/go/kbfs/libkbfs/libkey_mocks_test.go
+++ b/go/kbfs/libkbfs/libkey_mocks_test.go
@@ -46,7 +46,7 @@ func (m *MockKeyOps) DeleteTLFCryptKeyServerHalf(arg0 context.Context, arg1 keyb
 }
 
 // DeleteTLFCryptKeyServerHalf indicates an expected call of DeleteTLFCryptKeyServerHalf.
-func (mr *MockKeyOpsMockRecorder) DeleteTLFCryptKeyServerHalf(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKeyOpsMockRecorder) DeleteTLFCryptKeyServerHalf(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTLFCryptKeyServerHalf", reflect.TypeOf((*MockKeyOps)(nil).DeleteTLFCryptKeyServerHalf), arg0, arg1, arg2, arg3)
 }
@@ -61,7 +61,7 @@ func (m *MockKeyOps) GetTLFCryptKeyServerHalf(arg0 context.Context, arg1 kbfscry
 }
 
 // GetTLFCryptKeyServerHalf indicates an expected call of GetTLFCryptKeyServerHalf.
-func (mr *MockKeyOpsMockRecorder) GetTLFCryptKeyServerHalf(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeyOpsMockRecorder) GetTLFCryptKeyServerHalf(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFCryptKeyServerHalf", reflect.TypeOf((*MockKeyOps)(nil).GetTLFCryptKeyServerHalf), arg0, arg1, arg2)
 }
@@ -75,7 +75,7 @@ func (m *MockKeyOps) PutTLFCryptKeyServerHalves(arg0 context.Context, arg1 kbfsm
 }
 
 // PutTLFCryptKeyServerHalves indicates an expected call of PutTLFCryptKeyServerHalves.
-func (mr *MockKeyOpsMockRecorder) PutTLFCryptKeyServerHalves(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeyOpsMockRecorder) PutTLFCryptKeyServerHalves(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutTLFCryptKeyServerHalves", reflect.TypeOf((*MockKeyOps)(nil).PutTLFCryptKeyServerHalves), arg0, arg1)
 }
@@ -112,7 +112,7 @@ func (m *MockKeyServer) DeleteTLFCryptKeyServerHalf(arg0 context.Context, arg1 k
 }
 
 // DeleteTLFCryptKeyServerHalf indicates an expected call of DeleteTLFCryptKeyServerHalf.
-func (mr *MockKeyServerMockRecorder) DeleteTLFCryptKeyServerHalf(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKeyServerMockRecorder) DeleteTLFCryptKeyServerHalf(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTLFCryptKeyServerHalf", reflect.TypeOf((*MockKeyServer)(nil).DeleteTLFCryptKeyServerHalf), arg0, arg1, arg2, arg3)
 }
@@ -127,7 +127,7 @@ func (m *MockKeyServer) GetTLFCryptKeyServerHalf(arg0 context.Context, arg1 kbfs
 }
 
 // GetTLFCryptKeyServerHalf indicates an expected call of GetTLFCryptKeyServerHalf.
-func (mr *MockKeyServerMockRecorder) GetTLFCryptKeyServerHalf(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeyServerMockRecorder) GetTLFCryptKeyServerHalf(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFCryptKeyServerHalf", reflect.TypeOf((*MockKeyServer)(nil).GetTLFCryptKeyServerHalf), arg0, arg1, arg2)
 }
@@ -141,7 +141,7 @@ func (m *MockKeyServer) PutTLFCryptKeyServerHalves(arg0 context.Context, arg1 kb
 }
 
 // PutTLFCryptKeyServerHalves indicates an expected call of PutTLFCryptKeyServerHalves.
-func (mr *MockKeyServerMockRecorder) PutTLFCryptKeyServerHalves(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeyServerMockRecorder) PutTLFCryptKeyServerHalves(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutTLFCryptKeyServerHalves", reflect.TypeOf((*MockKeyServer)(nil).PutTLFCryptKeyServerHalves), arg0, arg1)
 }

--- a/go/kbfs/libkbfs/md_journal_test.go
+++ b/go/kbfs/libkbfs/md_journal_test.go
@@ -216,9 +216,9 @@ type noLogTB struct {
 	testing.TB
 }
 
-func (tb noLogTB) Log(args ...interface{}) {}
+func (tb noLogTB) Log(args ...any) {}
 
-func (tb noLogTB) Logf(format string, args ...interface{}) {}
+func (tb noLogTB) Logf(format string, args ...any) {}
 
 func BenchmarkMDJournalBasic(b *testing.B) {
 	runBenchmarkOverMetadataVers(b, benchmarkMDJournalBasic)

--- a/go/kbfs/libkbfs/md_ops_test.go
+++ b/go/kbfs/libkbfs/md_ops_test.go
@@ -156,7 +156,7 @@ type kmdMatcher struct {
 	kmd libkey.KeyMetadata
 }
 
-func (m kmdMatcher) Matches(x interface{}) bool {
+func (m kmdMatcher) Matches(x any) bool {
 	kmd, ok := x.(libkey.KeyMetadata)
 	if !ok {
 		return false
@@ -882,7 +882,7 @@ type failEncodeCodec struct {
 	err error
 }
 
-func (c failEncodeCodec) Encode(obj interface{}) ([]byte, error) {
+func (c failEncodeCodec) Encode(obj any) ([]byte, error) {
 	return nil, c.err
 }
 

--- a/go/kbfs/libkbfs/ops.go
+++ b/go/kbfs/libkbfs/ops.go
@@ -859,10 +859,10 @@ func (w WriteRange) End() uint64 {
 // operation and `other` overlap in some way.  Specifically, it
 // returns true if:
 //
-// - both operations are writes and their write ranges overlap;
-// - one operation is a write and one is a truncate, and the truncate is
-//   within the write's range or before it; or
-// - both operations are truncates.
+//   - both operations are writes and their write ranges overlap;
+//   - one operation is a write and one is a truncate, and the truncate is
+//     within the write's range or before it; or
+//   - both operations are truncates.
 func (w WriteRange) Affects(other WriteRange) bool {
 	if w.isTruncate() {
 		if other.isTruncate() {
@@ -1605,7 +1605,7 @@ func invertOpForLocalNotifications(oldOp op) (newOp op, err error) {
 // we need them to be pointers so they correctly satisfy the op
 // interface.  So this function simply converts them into pointers as
 // needed.
-func opPointerizer(iface interface{}) reflect.Value {
+func opPointerizer(iface any) reflect.Value {
 	switch op := iface.(type) {
 	default:
 		return reflect.ValueOf(iface)

--- a/go/kbfs/libkbfs/ops_test.go
+++ b/go/kbfs/libkbfs/ops_test.go
@@ -160,7 +160,7 @@ func TestWriteRangeUnknownFields(t *testing.T) {
 // of opPointerizer and RegisterOps. registerOpsFuture is used by
 // testStructUnknownFields.
 
-func opPointerizerFuture(iface interface{}) reflect.Value {
+func opPointerizerFuture(iface any) reflect.Value {
 	switch op := iface.(type) {
 	default:
 		return reflect.ValueOf(iface)
@@ -475,7 +475,7 @@ func TestGcOpUnknownFields(t *testing.T) {
 }
 
 type testOps struct {
-	Ops []interface{}
+	Ops []any
 }
 
 // Tests that ops can be serialized and deserialized as extensions.

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -1425,21 +1425,21 @@ func (p *blockPrefetcher) handleNetStateChange(
 // a -> {b -> {c, d}, e -> {f, g}}:
 // * state of prefetch tree in `p.prefetches`.
 // 1) a is fetched, triggers b and e.
-//    * a:2 -> {b:1, e:1}
-// 2) b is fetched, decrements b and a by 1, and triggers c and d to increment
-//    b and a by 2.
-//    * a:3 -> {b:2 -> {c:1, d:1}, e:1}
-// 3) c is fetched, and isTail==true so it completes up the tree.
-//    * a:2 -> {b:1 -> {d:1}, e:1}
-// 4) d is fetched, and isTail==true so it completes up the tree.
-//    * a:1 -> {e:1}
-// 5) e is fetched, decrements e and a by 1, and triggers f and g to increment
-//    e an a by 2.
-//    * a:2 -> {e:2 -> {f:1, g:1}}
-// 6) f is fetched, and isTail==true so it completes up the tree.
-//    * a:1 -> {e:1 -> {g:1}}
-// 7) g is fetched, completing g, e, and a.
-//    * <empty>
+//   - a:2 -> {b:1, e:1}
+//  2. b is fetched, decrements b and a by 1, and triggers c and d to increment
+//     b and a by 2.
+//     * a:3 -> {b:2 -> {c:1, d:1}, e:1}
+//  3. c is fetched, and isTail==true so it completes up the tree.
+//     * a:2 -> {b:1 -> {d:1}, e:1}
+//  4. d is fetched, and isTail==true so it completes up the tree.
+//     * a:1 -> {e:1}
+//  5. e is fetched, decrements e and a by 1, and triggers f and g to increment
+//     e an a by 2.
+//     * a:2 -> {e:2 -> {f:1, g:1}}
+//  6. f is fetched, and isTail==true so it completes up the tree.
+//     * a:1 -> {e:1 -> {g:1}}
+//  7. g is fetched, completing g, e, and a.
+//     * <empty>
 //
 // Blocks may have multiple parents over time, since this block's current
 // parent might not have finished prefetching by the time it's changed by a
@@ -1468,7 +1468,7 @@ func (p *blockPrefetcher) run(
 		p.inFlightFetches.Close()
 	}()
 	isShuttingDown := false
-	var shuttingDownCh <-chan interface{}
+	var shuttingDownCh <-chan any
 	first := true
 	appState := keybase1.MobileAppState_FOREGROUND
 	netState := keybase1.MobileNetworkState_NONE

--- a/go/kbfs/libkbfs/safe_test_reporter_test.go
+++ b/go/kbfs/libkbfs/safe_test_reporter_test.go
@@ -47,12 +47,12 @@ func (ctr *SafeTestReporter) error(s string) {
 	ctr.t.Errorf("\r%s: %s", makePrefix(), s)
 }
 
-func (ctr *SafeTestReporter) Errorf(format string, args ...interface{}) {
+func (ctr *SafeTestReporter) Errorf(format string, args ...any) {
 	ctr.error(fmt.Sprintf(format, args...))
 }
 
 // Fatalf errors and then panics.
-func (ctr *SafeTestReporter) Fatalf(format string, args ...interface{}) {
+func (ctr *SafeTestReporter) Fatalf(format string, args ...any) {
 	s := fmt.Sprintf(format, args...)
 	ctr.error(s)
 	// panic here, since a Goexit() might leave the main thread

--- a/go/kbfs/libkbfs/semaphore_disk_limiter.go
+++ b/go/kbfs/libkbfs/semaphore_disk_limiter.go
@@ -223,7 +223,7 @@ type semaphoreDiskLimiterStatus struct {
 }
 
 func (sdl semaphoreDiskLimiter) getStatus(
-	_ context.Context, _ keybase1.UserOrTeamID) interface{} {
+	_ context.Context, _ keybase1.UserOrTeamID) any {
 	byteFree := sdl.byteSemaphore.Count()
 	fileFree := sdl.fileSemaphore.Count()
 	usedQuotaBytes, quotaBytes := sdl.quotaTracker.getQuotaInfo()

--- a/go/kbfs/libkbfs/subscription_manager_test.go
+++ b/go/kbfs/libkbfs/subscription_manager_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func waitForCall(t *testing.T, timeout time.Duration) (
-	waiter func(), done func(args ...interface{})) {
+	waiter func(), done func(args ...any)) {
 	ch := make(chan struct{})
 	return func() {
 			select {
@@ -29,7 +29,7 @@ func waitForCall(t *testing.T, timeout time.Duration) (
 				t.Fatalf("waiting on lastMockDone timeout")
 			case <-ch:
 			}
-		}, func(args ...interface{}) {
+		}, func(args ...any) {
 			ch <- struct{}{}
 		}
 }
@@ -52,10 +52,10 @@ func initSubscriptionManagerTest(t *testing.T) (config Config,
 }
 
 type sliceMatcherNoOrder struct {
-	x interface{}
+	x any
 }
 
-func (e sliceMatcherNoOrder) Matches(x interface{}) bool {
+func (e sliceMatcherNoOrder) Matches(x any) bool {
 	vExpected := reflect.ValueOf(e.x)
 	vGot := reflect.ValueOf(x)
 	if vExpected.Kind() != reflect.Slice || vGot.Kind() != reflect.Slice {

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -110,23 +110,23 @@ func MakeTestBlockServerOrBust(t logger.TestLogBackend, c *ConfigLocal,
 // in rpc and use that instead.
 
 type testLogger interface {
-	Logf(format string, args ...interface{})
+	Logf(format string, args ...any)
 }
 
 type testLogOutput struct {
 	t testLogger
 }
 
-func (t testLogOutput) log(ch string, fmts string, args []interface{}) {
+func (t testLogOutput) log(ch string, fmts string, args []any) {
 	fmts = fmt.Sprintf("[%s] %s", ch, fmts)
 	t.t.Logf(fmts, args...)
 }
 
-func (t testLogOutput) Info(fmt string, args ...interface{})    { t.log("I", fmt, args) }
-func (t testLogOutput) Error(fmt string, args ...interface{})   { t.log("E", fmt, args) }
-func (t testLogOutput) Debug(fmt string, args ...interface{})   { t.log("D", fmt, args) }
-func (t testLogOutput) Warning(fmt string, args ...interface{}) { t.log("W", fmt, args) }
-func (t testLogOutput) Profile(fmt string, args ...interface{}) { t.log("P", fmt, args) }
+func (t testLogOutput) Info(fmt string, args ...any)    { t.log("I", fmt, args) }
+func (t testLogOutput) Error(fmt string, args ...any)   { t.log("E", fmt, args) }
+func (t testLogOutput) Debug(fmt string, args ...any)   { t.log("D", fmt, args) }
+func (t testLogOutput) Warning(fmt string, args ...any) { t.log("W", fmt, args) }
+func (t testLogOutput) Profile(fmt string, args ...any) { t.log("P", fmt, args) }
 
 func newTestRPCLogFactory(t testLogger) rpc.LogFactory {
 	return rpc.NewSimpleLogFactory(testLogOutput{t}, nil)

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -1066,7 +1066,7 @@ func testTLFJournalFlushMDConflict(t *testing.T, ver kbfsmd.MetadataVer) {
 type orderedBlockServer struct {
 	BlockServer
 	lock      *sync.Mutex
-	puts      *[]interface{}
+	puts      *[]any
 	onceOnPut func()
 }
 
@@ -1090,7 +1090,7 @@ func (s *orderedBlockServer) Shutdown(context.Context) {}
 type orderedMDServer struct {
 	MDServer
 	lock      *sync.Mutex
-	puts      *[]interface{}
+	puts      *[]any
 	onceOnPut func() error
 }
 
@@ -1150,7 +1150,7 @@ func testTLFJournalFlushOrdering(t *testing.T, ver kbfsmd.MetadataVer) {
 	md1 := config.makeMD(kbfsmd.Revision(10), kbfsmd.FakeID(1))
 
 	var lock sync.Mutex
-	var puts []interface{}
+	var puts []any
 
 	bserver := orderedBlockServer{
 		lock: &lock,
@@ -1206,12 +1206,12 @@ func testTLFJournalFlushOrdering(t *testing.T, ver kbfsmd.MetadataVer) {
 	// but there are other possible orderings which respect the
 	// above is-put-before constraints and also respect the
 	// kbfsmd.Revision ordering.
-	expectedPuts1 := []interface{}{
+	expectedPuts1 := []any{
 		bid1, kbfsmd.Revision(10), bid2, bid3,
 		kbfsmd.Revision(11), kbfsmd.Revision(12),
 	}
 	// This is possible since block puts are done in parallel.
-	expectedPuts2 := []interface{}{
+	expectedPuts2 := []any{
 		bid1, kbfsmd.Revision(10), bid3, bid2,
 		kbfsmd.Revision(11), kbfsmd.Revision(12),
 	}
@@ -1237,7 +1237,7 @@ func testTLFJournalFlushOrderingAfterSquashAndCR(
 	md1 := config.makeMD(firstRev, firstPrevRoot)
 
 	var lock sync.Mutex
-	var puts []interface{}
+	var puts []any
 
 	bserver := orderedBlockServer{
 		lock: &lock,
@@ -1370,7 +1370,7 @@ func testTLFJournalFlushInterleaving(t *testing.T, ver kbfsmd.MetadataVer) {
 		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	var lock sync.Mutex
-	var puts []interface{}
+	var puts []any
 
 	bserver := orderedBlockServer{
 		lock: &lock,
@@ -1473,7 +1473,7 @@ func testTLFJournalPauseBlocksAndConvertBranch(ctx context.Context,
 	tlfJournal.onBranchChange = testBranchChangeListener{branchCh}
 
 	var lock sync.Mutex
-	var puts []interface{}
+	var puts []any
 
 	unpauseBlockPutCh := make(chan struct{})
 	noticeBlockPutCh := make(chan struct{})

--- a/go/kbfs/libkbfs/trace_logger.go
+++ b/go/kbfs/libkbfs/trace_logger.go
@@ -19,7 +19,7 @@ type traceLogger struct {
 // the right options are turned on.
 
 func (tl traceLogger) LazyTrace(
-	ctx context.Context, format string, args ...interface{}) {
+	ctx context.Context, format string, args ...any) {
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf(format, args...)
 	}

--- a/go/kbfs/libkbfs/util.go
+++ b/go/kbfs/libkbfs/util.go
@@ -92,12 +92,12 @@ const (
 
 // Warninger is an interface that only waprs the Warning method.
 type Warninger interface {
-	Warning(format string, args ...interface{})
+	Warning(format string, args ...any)
 }
 
 // CtxWithRandomIDReplayable returns a replayable context with a
 // random id associated with the given log key.
-func CtxWithRandomIDReplayable(ctx context.Context, tagKey interface{},
+func CtxWithRandomIDReplayable(ctx context.Context, tagKey any,
 	tagName string, log Warninger) context.Context {
 	ctx = logger.ConvertRPCTagsToLogTags(ctx)
 

--- a/go/kbfs/libpages/server.go
+++ b/go/kbfs/libpages/server.go
@@ -153,7 +153,7 @@ func (s *Server) getSite(ctx context.Context, root Root) (st *site, err error) {
 	return st, nil
 }
 
-func (s *Server) siteCacheEvict(_ interface{}, value interface{}) {
+func (s *Server) siteCacheEvict(_ any, value any) {
 	if s, ok := value.(*site); ok {
 		// It's possible to have a race here where a site gets evicted by the
 		// LRU cache while the server is still using it to serve a request. But
@@ -207,7 +207,7 @@ type adaptedLogger struct {
 	logger *zap.Logger
 }
 
-func (a adaptedLogger) Warning(format string, args ...interface{}) {
+func (a adaptedLogger) Warning(format string, args ...any) {
 	a.logger.Warn(a.msg, zap.String("desc", fmt.Sprintf(format, args...)))
 }
 

--- a/go/kbfs/libpages/stats_test.go
+++ b/go/kbfs/libpages/stats_test.go
@@ -15,7 +15,7 @@ func (f fileInfoForActivesGetterTest) Size() int64        { return 0 }
 func (f fileInfoForActivesGetterTest) Mode() os.FileMode  { return 0 }
 func (f fileInfoForActivesGetterTest) ModTime() time.Time { return time.Time(f) }
 func (f fileInfoForActivesGetterTest) IsDir() bool        { return false }
-func (f fileInfoForActivesGetterTest) Sys() interface{}   { return nil }
+func (f fileInfoForActivesGetterTest) Sys() any           { return nil }
 
 func makeFileInfoActivesGetterForTest(
 	tlfModTimes, hostModTimes []time.Time) fileinfoActivesGetter {

--- a/go/kbfs/metricsutil/registry_to_map.go
+++ b/go/kbfs/metricsutil/registry_to_map.go
@@ -12,10 +12,10 @@ import "github.com/rcrowley/go-metrics"
 
 // registryToMap returns a map representation of all the metrics in
 // the Registry.
-func registryToMap(r metrics.Registry) map[string]map[string]interface{} {
-	data := make(map[string]map[string]interface{})
-	r.Each(func(name string, i interface{}) {
-		values := make(map[string]interface{})
+func registryToMap(r metrics.Registry) map[string]map[string]any {
+	data := make(map[string]map[string]any)
+	r.Each(func(name string, i any) {
+		values := make(map[string]any)
 		switch metric := i.(type) {
 		case metrics.Counter:
 			values["count"] = metric.Count()
@@ -74,9 +74,9 @@ func registryToMap(r metrics.Registry) map[string]map[string]interface{} {
 
 // RegistryToInterfaceMap returns a map representation of all the
 // metrics in the Registry, but with the value type being interface{}.
-func RegistryToInterfaceMap(r metrics.Registry) map[string]interface{} {
+func RegistryToInterfaceMap(r metrics.Registry) map[string]any {
 	metricsMap := registryToMap(r)
-	interfaceMap := make(map[string]interface{})
+	interfaceMap := make(map[string]any)
 	for k, v := range metricsMap {
 		interfaceMap[k] = v
 	}

--- a/go/kbfs/metricsutil/write_metrics.go
+++ b/go/kbfs/metricsutil/write_metrics.go
@@ -21,7 +21,7 @@ import (
 // io.Writer.
 func WriteMetrics(r metrics.Registry, w io.Writer) {
 	var namedMetrics namedMetricSlice
-	r.Each(func(name string, i interface{}) {
+	r.Each(func(name string, i any) {
 		namedMetrics = append(namedMetrics, namedMetric{name, i})
 	})
 
@@ -82,7 +82,7 @@ func WriteMetrics(r metrics.Registry, w io.Writer) {
 
 type namedMetric struct {
 	name string
-	m    interface{}
+	m    any
 }
 
 // namedMetricSlice is a slice of namedMetrics that implements sort.Interface.

--- a/go/kbfs/search/doc_types.go
+++ b/go/kbfs/search/doc_types.go
@@ -121,7 +121,7 @@ func removePunct(r rune) rune {
 }
 
 func makeNameDocWithBase(
-	n libkbfs.Node, base indexedBase) (nameDoc interface{}) {
+	n libkbfs.Node, base indexedBase) (nameDoc any) {
 	// Turn all punctuation into spaces to allow for matching
 	// individual words within the filename.
 	fullName := n.GetBasename().Plaintext()
@@ -135,7 +135,7 @@ func makeNameDocWithBase(
 
 func makeNameDoc(
 	n libkbfs.Node, revision kbfsmd.Revision, mtime time.Time) (
-	nameDoc interface{}) {
+	nameDoc any) {
 	base := indexedBase{
 		TlfID:    n.GetFolderBranch().Tlf,
 		Revision: revision,
@@ -147,7 +147,7 @@ func makeNameDoc(
 func makeDoc(
 	ctx context.Context, config libkbfs.Config, n libkbfs.Node,
 	ei data.EntryInfo, revision kbfsmd.Revision, mtime time.Time) (
-	doc, nameDoc interface{}, err error) {
+	doc, nameDoc any, err error) {
 	base := indexedBase{
 		TlfID:    n.GetFolderBranch().Tlf,
 		Revision: revision,

--- a/go/kbfs/search/indexer.go
+++ b/go/kbfs/search/indexer.go
@@ -263,7 +263,7 @@ func (i *Indexer) loadIndex(ctx context.Context) (err error) {
 	i.fs = fs
 	i.once.Do(func() {
 		kvstoreConstructor := func(
-			mo store.MergeOperator, _ map[string]interface{}) (
+			mo store.MergeOperator, _ map[string]any) (
 			s store.KVStore, err error) {
 			return newBleveLevelDBStore(i.fs, false, mo)
 		}

--- a/go/kbfs/search/mapping.go
+++ b/go/kbfs/search/mapping.go
@@ -20,7 +20,7 @@ const (
 )
 
 func htmlAnalyzerConstructor(
-	config map[string]interface{}, cache *registry.Cache) (
+	config map[string]any, cache *registry.Cache) (
 	*analysis.Analyzer, error) {
 	tokenizer, err := cache.TokenizerNamed(web.Name)
 	if err != nil {

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -176,7 +176,7 @@ type inprogress struct {
 
 type handle struct {
 	file   billy.File
-	async  interface{}
+	async  any
 	path   keybase1.Path
 	cancel context.CancelFunc
 }
@@ -634,7 +634,7 @@ func (k *SimpleFS) setStat(
 	return nil
 }
 
-func (k *SimpleFS) setResult(opid keybase1.OpID, val interface{}) {
+func (k *SimpleFS) setResult(opid keybase1.OpID, val any) {
 	k.lock.Lock()
 	k.handles[opid] = &handle{async: val}
 	k.lock.Unlock()
@@ -1031,7 +1031,6 @@ func (k *SimpleFS) SimpleFSList(ctx context.Context, arg keybase1.SimpleFSListAr
 // the result for the opID when it completes.
 //
 // TODO: refactor SimpleFSList to use this too (finalDepth = 0)
-//
 func (k *SimpleFS) listRecursiveToDepth(opID keybase1.OpID,
 	path keybase1.Path, filter keybase1.ListFilter,
 	finalDepth int, refreshSubscription bool) func(context.Context) error {
@@ -1166,7 +1165,7 @@ func (k *SimpleFS) SimpleFSListRecursive(
 func (k *SimpleFS) SimpleFSReadList(_ context.Context, opid keybase1.OpID) (keybase1.SimpleFSListResult, error) {
 	k.lock.Lock()
 	res := k.handles[opid]
-	var x interface{}
+	var x any
 	if res != nil {
 		x = res.async
 		res.async = nil
@@ -1651,7 +1650,7 @@ func (k *SimpleFS) SimpleFSMove(
 }
 
 func (k *SimpleFS) startSyncOp(
-	ctx context.Context, name string, logarg interface{},
+	ctx context.Context, name string, logarg any,
 	path1ForIdentifyBehavior *keybase1.Path,
 	path2ForIdentifyBehavior *keybase1.Path,
 ) (context.Context, error) {
@@ -2248,7 +2247,7 @@ func (k *SimpleFS) SimpleFSReadRevisions(
 	keybase1.GetRevisionsResult, error) {
 	k.lock.Lock()
 	res := k.handles[opid]
-	var x interface{}
+	var x any
 	if res != nil {
 		x = res.async
 		res.async = nil

--- a/go/kbfs/test/dsl_test.go
+++ b/go/kbfs/test/dsl_test.go
@@ -1351,5 +1351,5 @@ func crnameEsc(path string, user username) string {
 
 type silentBenchmark struct{ *testing.B }
 
-func (silentBenchmark) Log(args ...interface{})                 {}
-func (silentBenchmark) Logf(format string, args ...interface{}) {}
+func (silentBenchmark) Log(args ...any)                 {}
+func (silentBenchmark) Logf(format string, args ...any) {}

--- a/go/kbfs/test/engine.go
+++ b/go/kbfs/test/engine.go
@@ -16,10 +16,10 @@ import (
 )
 
 // User is an implementation-defined object which acts as a handle to a particular user.
-type User interface{}
+type User any
 
 // Node is an implementation-defined object which acts as a handle to a particular filesystem node.
-type Node interface{}
+type Node any
 
 type username string
 

--- a/go/kbhttp/manager/manager.go
+++ b/go/kbhttp/manager/manager.go
@@ -49,7 +49,7 @@ func NewSrv(g *libkb.GlobalContext) *Srv {
 	return h
 }
 
-func (r *Srv) debug(ctx context.Context, msg string, args ...interface{}) {
+func (r *Srv) debug(ctx context.Context, msg string, args ...any) {
 	r.G().Log.CDebugf(ctx, "Srv: %s", fmt.Sprintf(msg, args...))
 }
 

--- a/go/kbnm/handler.go
+++ b/go/kbnm/handler.go
@@ -72,7 +72,7 @@ type handler struct {
 }
 
 // Handle accepts a request, handles it, and returns an optional result if there was no error
-func (h *handler) Handle(req *Request) (interface{}, error) {
+func (h *handler) Handle(req *Request) (any, error) {
 	switch req.Method {
 	case "chat":
 		return nil, h.handleChat(req)

--- a/go/kbnm/main.go
+++ b/go/kbnm/main.go
@@ -20,10 +20,10 @@ var Version = "dev"
 
 // Response from the kbnm service
 type Response struct {
-	Client  int         `json:"client"`
-	Status  string      `json:"status"`
-	Message string      `json:"message"`
-	Result  interface{} `json:"result,omitempty"`
+	Client  int    `json:"client"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Result  any    `json:"result,omitempty"`
 }
 
 // Request to the kbnm service
@@ -75,7 +75,7 @@ func process(h *handler, in nativemessaging.JSONDecoder, out nativemessaging.JSO
 	return abortErr
 }
 
-func exit(code int, msg string, a ...interface{}) {
+func exit(code int, msg string, a ...any) {
 	fmt.Fprintf(os.Stderr, msg+"\n", a...)
 	os.Exit(code)
 }

--- a/go/kex2/base.go
+++ b/go/kex2/base.go
@@ -14,7 +14,7 @@ import (
 )
 
 type LogContext interface {
-	Debug(format string, args ...interface{})
+	Debug(format string, args ...any)
 }
 
 type baseDevice struct {

--- a/go/kex2/provisionee.go
+++ b/go/kex2/provisionee.go
@@ -142,7 +142,7 @@ func (p *provisionee) run() (err error) {
 	return <-p.done
 }
 
-func (p *provisionee) debug(fmtString string, args ...interface{}) {
+func (p *provisionee) debug(fmtString string, args ...any) {
 	if p.arg.LogCtx != nil {
 		p.arg.LogCtx.Debug(fmtString, args...)
 	}

--- a/go/kex2/provisioner.go
+++ b/go/kex2/provisioner.go
@@ -52,7 +52,7 @@ func newProvisioner(arg ProvisionerArg) *provisioner {
 	return ret
 }
 
-func (p *provisioner) debug(fmtString string, args ...interface{}) {
+func (p *provisioner) debug(fmtString string, args ...any) {
 	if p.arg.LogCtx != nil {
 		p.arg.LogCtx.Debug(fmtString, args...)
 	}

--- a/go/kex2/rpc_test.go
+++ b/go/kex2/rpc_test.go
@@ -43,11 +43,11 @@ func newMockProvisioner(t *testing.T) *mockProvisioner {
 type nullLogOutput struct {
 }
 
-func (n *nullLogOutput) Error(s string, args ...interface{})   {}
-func (n *nullLogOutput) Warning(s string, args ...interface{}) {}
-func (n *nullLogOutput) Info(s string, args ...interface{})    {}
-func (n *nullLogOutput) Debug(s string, args ...interface{})   {}
-func (n *nullLogOutput) Profile(s string, args ...interface{}) {}
+func (n *nullLogOutput) Error(s string, args ...any)   {}
+func (n *nullLogOutput) Warning(s string, args ...any) {}
+func (n *nullLogOutput) Info(s string, args ...any)    {}
+func (n *nullLogOutput) Debug(s string, args ...any)   {}
+func (n *nullLogOutput) Profile(s string, args ...any) {}
 
 var _ rpc.LogOutput = (*nullLogOutput)(nil)
 

--- a/go/kex2/transport_test.go
+++ b/go/kex2/transport_test.go
@@ -221,7 +221,7 @@ func newTestLogCtx(t *testing.T) (ret *testLogCtx, closer func()) {
 	return ret, closer
 }
 
-func (t *testLogCtx) Debug(format string, args ...interface{}) {
+func (t *testLogCtx) Debug(format string, args ...any) {
 	t.Lock()
 	if t.t != nil {
 		t.t.Logf(format, args...)

--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -681,16 +681,16 @@ func (p Plist) plistXML() string {
 
 // Log is the logging interface for this package
 type Log interface {
-	Debug(s string, args ...interface{})
-	Info(s string, args ...interface{})
-	Errorf(s string, args ...interface{})
+	Debug(s string, args ...any)
+	Info(s string, args ...any)
+	Errorf(s string, args ...any)
 }
 
 type emptyLog struct{}
 
-func (l emptyLog) Debug(s string, args ...interface{})  {}
-func (l emptyLog) Info(s string, args ...interface{})   {}
-func (l emptyLog) Errorf(s string, args ...interface{}) {}
+func (l emptyLog) Debug(s string, args ...any)  {}
+func (l emptyLog) Info(s string, args ...any)   {}
+func (l emptyLog) Errorf(s string, args ...any) {}
 
 func writable(path string) bool {
 	return unix.Access(path, unix.W_OK) == nil

--- a/go/launchd/launchd_test.go
+++ b/go/launchd/launchd_test.go
@@ -35,7 +35,7 @@ func TestPlist(t *testing.T) {
 	data := plist.plistXML()
 	t.Logf("Plist: %s\n", data)
 
-	var i interface{}
+	var i any
 	// This tests valid XML but not actual values
 	err = xml.Unmarshal([]byte(data), &i)
 	if err != nil {

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -350,7 +350,7 @@ func doRequestShared(m MetaContext, api Requester, arg APIArg, req *http.Request
 
 		reader := newCountingReader(&buf)
 		decoder := json.NewDecoder(reader)
-		var obj interface{}
+		var obj any
 		decoder.UseNumber()
 		err = decoder.Decode(&obj)
 		jsonBytes = reader.numRead()

--- a/go/libkb/burst_cache.go
+++ b/go/libkb/burst_cache.go
@@ -45,7 +45,7 @@ func NewBurstCache(g *GlobalContext, cacheSize int, cacheLife time.Duration, cac
 }
 
 type burstCacheObj struct {
-	obj      interface{}
+	obj      any
 	cachedAt time.Time
 }
 
@@ -54,11 +54,11 @@ type burstCacheObj struct {
 // to an object as an interface{}. The caller to Load() should wrap into the
 // closure all parameters needed to actually fetch the object. They called
 // Load(), so they likely have them handy.
-type BurstCacheLoader func() (obj interface{}, err error)
+type BurstCacheLoader func() (obj any, err error)
 
 // Load item key from the burst cache. On a cache miss, load with the given loader function.
 // Return the object as an interface{}, so the caller needs to cast out of this burst cache.
-func (b *BurstCache) Load(ctx context.Context, key BurstCacheKey, loader BurstCacheLoader) (ret interface{}, err error) {
+func (b *BurstCache) Load(ctx context.Context, key BurstCacheKey, loader BurstCacheLoader) (ret any, err error) {
 	ctx = WithLogTag(ctx, "BC")
 	defer b.G().CVTrace(ctx, VLog0, fmt.Sprintf("BurstCache(%s)#Load(%s)", b.cacheName, key.String()), &err)()
 

--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -616,7 +616,7 @@ func SigchainV2TypeFromV1TypeTeams(s string) (ret SigchainV2Type, err error) {
 	return ret, err
 }
 
-func mismatchError(format string, arg ...interface{}) error {
+func mismatchError(format string, arg ...any) error {
 	return SigchainV2MismatchedFieldError{fmt.Sprintf(format, arg...)}
 }
 

--- a/go/libkb/chain_link_v2_test.go
+++ b/go/libkb/chain_link_v2_test.go
@@ -80,7 +80,7 @@ func TestOuterLinkV2WithMetadataContainerEncode(t *testing.T) {
 }
 
 func TestOuterLinkV2WithMetadataContainerDecode(t *testing.T) {
-	bytes, err := msgpack.Encode(map[string]interface{}{
+	bytes, err := msgpack.Encode(map[string]any{
 		"O": []byte{0x01, 0x02},
 	})
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestOuterLinkV2WithMetadataPointerContainerEncode(t *testing.T) {
 }
 
 func TestOuterLinkV2WithMetadataPointerContainerDecode(t *testing.T) {
-	bytes, err := msgpack.Encode(map[string]interface{}{
+	bytes, err := msgpack.Encode(map[string]any{
 		"O": []byte{0x01, 0x02},
 	})
 	require.NoError(t, err)

--- a/go/libkb/client.go
+++ b/go/libkb/client.go
@@ -145,9 +145,9 @@ func genClientConfigForScrapers(e *Env) (*ClientConfig, error) {
 }
 
 func NewClient(g *GlobalContext, config *ClientConfig, needCookie bool) (*Client, error) {
-	extraLog := func(ctx context.Context, msg string, args ...interface{}) {}
+	extraLog := func(ctx context.Context, msg string, args ...any) {}
 	if g.Env.GetExtraNetLogging() {
-		extraLog = func(ctx context.Context, msg string, args ...interface{}) {
+		extraLog = func(ctx context.Context, msg string, args ...any) {
 			if ctx == nil {
 				g.Log.Debug(msg, args...)
 			} else {
@@ -343,7 +343,7 @@ func NewInstrumentedRoundTripper(g *GlobalContext, tagger func(*http.Request) st
 		RoundTripper: xprt,
 		tagger:       tagger,
 		gzipPool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				return gzip.NewWriter(ioutil.Discard)
 			},
 		},

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -590,7 +590,7 @@ func (f *JSONConfigFile) GetRememberPassphrase(username NormalizedUsername) (boo
 	if username.IsNil() {
 		return f.GetTopLevelBool(legacyRememberPassphraseKey)
 	}
-	if m, ok := f.jw.AtKey("remember_passphrase_map").GetDataOrNil().(map[string]interface{}); ok {
+	if m, ok := f.jw.AtKey("remember_passphrase_map").GetDataOrNil().(map[string]any); ok {
 		if ret, mOk := m[username.String()]; mOk {
 			if boolRet, boolOk := ret.(bool); boolOk {
 				return boolRet, true

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -69,7 +69,7 @@ func (m MetaContext) LoginContext() LoginContext {
 	return m.loginContext
 }
 
-func (m MetaContext) VLogf(lev VDebugLevel, msg string, args ...interface{}) {
+func (m MetaContext) VLogf(lev VDebugLevel, msg string, args ...any) {
 	m.g.VDL.CLogfWithAddedDepth(m.ctx, lev, 1, msg, args...)
 }
 
@@ -91,19 +91,19 @@ func (m MetaContext) TimeTracer(label string, enabled bool) profiling.TimeTracer
 	return m.G().CTimeTracer(m.Ctx(), label, enabled)
 }
 
-func (m MetaContext) Debug(f string, args ...interface{}) {
+func (m MetaContext) Debug(f string, args ...any) {
 	m.g.Log.CloneWithAddedDepth(1).CDebugf(m.ctx, f, args...)
 }
-func (m MetaContext) PerfDebug(f string, args ...interface{}) {
+func (m MetaContext) PerfDebug(f string, args ...any) {
 	m.g.PerfLog.CloneWithAddedDepth(1).CDebugf(m.ctx, f, args...)
 }
-func (m MetaContext) Warning(f string, args ...interface{}) {
+func (m MetaContext) Warning(f string, args ...any) {
 	m.g.Log.CloneWithAddedDepth(1).CWarningf(m.ctx, f, args...)
 }
-func (m MetaContext) Error(f string, args ...interface{}) {
+func (m MetaContext) Error(f string, args ...any) {
 	m.g.Log.CloneWithAddedDepth(1).CErrorf(m.ctx, f, args...)
 }
-func (m MetaContext) Info(f string, args ...interface{}) {
+func (m MetaContext) Info(f string, args ...any) {
 	m.g.Log.CloneWithAddedDepth(1).CInfof(m.ctx, f, args...)
 }
 

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -224,7 +224,7 @@ func jsonLocalDbGet(ops LocalDbOps, id DbKey) (*jsonw.Wrapper, error) {
 	return ret, err
 }
 
-func jsonLocalDbGetInto(ops LocalDbOps, obj interface{}, id DbKey) (found bool, err error) {
+func jsonLocalDbGetInto(ops LocalDbOps, obj any, id DbKey) (found bool, err error) {
 	var buf []byte
 	buf, found, err = ops.Get(id)
 	if err == nil && found {
@@ -237,7 +237,7 @@ func jsonLocalDbGetInto(ops LocalDbOps, obj interface{}, id DbKey) (found bool, 
 	return found, err
 }
 
-func jsonLocalDbPutObj(ops LocalDbOps, id DbKey, aliases []DbKey, obj interface{}) (err error) {
+func jsonLocalDbPutObj(ops LocalDbOps, id DbKey, aliases []DbKey, obj any) (err error) {
 	var bytes []byte
 	bytes, err = json.Marshal(obj)
 	if err == nil {
@@ -255,7 +255,7 @@ func jsonLocalDbLookup(ops LocalDbOps, id DbKey) (*jsonw.Wrapper, error) {
 	return ret, err
 }
 
-func jsonLocalDbLookupIntoMsgpack(ops LocalDbOps, obj interface{}, alias DbKey) (found bool, err error) {
+func jsonLocalDbLookupIntoMsgpack(ops LocalDbOps, obj any, alias DbKey) (found bool, err error) {
 	var buf []byte
 	buf, found, err = ops.Lookup(alias)
 	if err != nil || !found {
@@ -265,7 +265,7 @@ func jsonLocalDbLookupIntoMsgpack(ops LocalDbOps, obj interface{}, alias DbKey) 
 	return true, err
 }
 
-func jsonLocalDbGetIntoMsgpack(ops LocalDbOps, obj interface{}, id DbKey) (found bool, err error) {
+func jsonLocalDbGetIntoMsgpack(ops LocalDbOps, obj any, id DbKey) (found bool, err error) {
 	var buf []byte
 	buf, found, err = ops.Get(id)
 	if err != nil || !found {
@@ -275,7 +275,7 @@ func jsonLocalDbGetIntoMsgpack(ops LocalDbOps, obj interface{}, id DbKey) (found
 	return true, err
 }
 
-func jsonLocalDbPutObjMsgpack(ops LocalDbOps, id DbKey, aliases []DbKey, obj interface{}) error {
+func jsonLocalDbPutObjMsgpack(ops LocalDbOps, id DbKey, aliases []DbKey, obj any) error {
 	bytes, err := msgpack.Encode(obj)
 	if err != nil {
 		return err
@@ -313,11 +313,11 @@ func (j *JSONLocalDb) Get(id DbKey) (*jsonw.Wrapper, error) {
 	return jsonLocalDbGet(j.engine, id)
 }
 
-func (j *JSONLocalDb) GetInto(obj interface{}, id DbKey) (found bool, err error) {
+func (j *JSONLocalDb) GetInto(obj any, id DbKey) (found bool, err error) {
 	return jsonLocalDbGetInto(j.engine, obj, id)
 }
 
-func (j *JSONLocalDb) PutObj(id DbKey, aliases []DbKey, obj interface{}) (err error) {
+func (j *JSONLocalDb) PutObj(id DbKey, aliases []DbKey, obj any) (err error) {
 	return jsonLocalDbPutObj(j.engine, id, aliases, obj)
 }
 
@@ -325,15 +325,15 @@ func (j *JSONLocalDb) Lookup(id DbKey) (*jsonw.Wrapper, error) {
 	return jsonLocalDbLookup(j.engine, id)
 }
 
-func (j *JSONLocalDb) LookupIntoMsgpack(obj interface{}, alias DbKey) (found bool, err error) {
+func (j *JSONLocalDb) LookupIntoMsgpack(obj any, alias DbKey) (found bool, err error) {
 	return jsonLocalDbLookupIntoMsgpack(j.engine, obj, alias)
 }
 
-func (j *JSONLocalDb) GetIntoMsgpack(obj interface{}, id DbKey) (found bool, err error) {
+func (j *JSONLocalDb) GetIntoMsgpack(obj any, id DbKey) (found bool, err error) {
 	return jsonLocalDbGetIntoMsgpack(j.engine, obj, id)
 }
 
-func (j *JSONLocalDb) PutObjMsgpack(id DbKey, aliases []DbKey, obj interface{}) (err error) {
+func (j *JSONLocalDb) PutObjMsgpack(id DbKey, aliases []DbKey, obj any) (err error) {
 	return jsonLocalDbPutObjMsgpack(j.engine, id, aliases, obj)
 }
 
@@ -368,11 +368,11 @@ func (j JSONLocalDbTransaction) Get(id DbKey) (*jsonw.Wrapper, error) {
 	return jsonLocalDbGet(j.tr, id)
 }
 
-func (j JSONLocalDbTransaction) GetInto(obj interface{}, id DbKey) (found bool, err error) {
+func (j JSONLocalDbTransaction) GetInto(obj any, id DbKey) (found bool, err error) {
 	return jsonLocalDbGetInto(j.tr, obj, id)
 }
 
-func (j JSONLocalDbTransaction) PutObj(id DbKey, aliases []DbKey, obj interface{}) (err error) {
+func (j JSONLocalDbTransaction) PutObj(id DbKey, aliases []DbKey, obj any) (err error) {
 	return jsonLocalDbPutObj(j.tr, id, aliases, obj)
 }
 

--- a/go/libkb/deprovision.go
+++ b/go/libkb/deprovision.go
@@ -11,7 +11,7 @@ func ClearSecretsOnDeprovision(mctx MetaContext, username NormalizedUsername) er
 
 	epick := FirstErrorPicker{}
 
-	var logger func(string, ...interface{})
+	var logger func(string, ...any)
 	if mctx.UIs().LogUI == nil {
 		logger = mctx.Info
 	} else {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -176,7 +176,7 @@ func (n NullConfiguration) GetNoPinentry() (bool, bool) {
 func (n NullConfiguration) GetStringAtPath(string) (string, bool) {
 	return "", false
 }
-func (n NullConfiguration) GetInterfaceAtPath(string) (interface{}, error) {
+func (n NullConfiguration) GetInterfaceAtPath(string) (any, error) {
 	return nil, nil
 }
 

--- a/go/libkb/erasable_kv_store.go
+++ b/go/libkb/erasable_kv_store.go
@@ -62,8 +62,8 @@ func getStorageDir(mctx MetaContext, subDir string) string {
 }
 
 type ErasableKVStore interface {
-	Put(mctx MetaContext, key string, val interface{}) error
-	Get(mctx MetaContext, key string, val interface{}) error
+	Put(mctx MetaContext, key string, val any) error
+	Get(mctx MetaContext, key string, val any) error
 	Erase(mctx MetaContext, key string) error
 	AllKeys(mctx MetaContext, keySuffix string) ([]string, error)
 }
@@ -109,7 +109,7 @@ func (s *FileErasableKVStore) noiseKey(key string) string {
 	return fmt.Sprintf("%s%s", url.QueryEscape(key), noiseSuffix)
 }
 
-func (s *FileErasableKVStore) unbox(mctx MetaContext, data []byte, noiseBytes NoiseBytes, val interface{}) (err error) {
+func (s *FileErasableKVStore) unbox(mctx MetaContext, data []byte, noiseBytes NoiseBytes, val any) (err error) {
 	defer mctx.Trace("FileErasableKVStore#unbox", &err)()
 	// Decode encrypted box
 	var boxed boxedData
@@ -143,7 +143,7 @@ func (s *FileErasableKVStore) unbox(mctx MetaContext, data []byte, noiseBytes No
 	return nil
 }
 
-func (s *FileErasableKVStore) box(mctx MetaContext, val interface{},
+func (s *FileErasableKVStore) box(mctx MetaContext, val any,
 	noiseBytes NoiseBytes) (data []byte, err error) {
 	defer mctx.Trace("FileErasableKVStore#box", &err)()
 	data, err = MPackEncode(val)
@@ -174,7 +174,7 @@ func (s *FileErasableKVStore) box(mctx MetaContext, val interface{},
 	return MPackEncode(boxed)
 }
 
-func (s *FileErasableKVStore) Put(mctx MetaContext, key string, val interface{}) (err error) {
+func (s *FileErasableKVStore) Put(mctx MetaContext, key string, val any) (err error) {
 	defer mctx.Trace(fmt.Sprintf("FileErasableKVStore#Put: %v", key), &err)()
 	s.Lock()
 	defer s.Unlock()
@@ -252,14 +252,14 @@ func (s *FileErasableKVStore) write(mctx MetaContext, key string, data []byte) (
 	return nil
 }
 
-func (s *FileErasableKVStore) Get(mctx MetaContext, key string, val interface{}) (err error) {
+func (s *FileErasableKVStore) Get(mctx MetaContext, key string, val any) (err error) {
 	defer mctx.Trace(fmt.Sprintf("FileErasableKVStore#Get: %v", key), &err)()
 	s.Lock()
 	defer s.Unlock()
 	return s.get(mctx, key, val)
 }
 
-func (s *FileErasableKVStore) get(mctx MetaContext, key string, val interface{}) (err error) {
+func (s *FileErasableKVStore) get(mctx MetaContext, key string, val any) (err error) {
 	noiseKey := s.noiseKey(key)
 	noise, err := s.read(mctx, noiseKey)
 	if err != nil {

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -69,7 +69,7 @@ type ProofErrorImpl struct {
 	Desc   string
 }
 
-func NewProofError(s keybase1.ProofStatus, d string, a ...interface{}) *ProofErrorImpl {
+func NewProofError(s keybase1.ProofStatus, d string, a ...any) *ProofErrorImpl {
 	// Don't do string interpolation if there are no substitution arguments.
 	// Fixes double-interpolation when deserializing an object.
 	if len(a) == 0 {
@@ -119,7 +119,7 @@ func (t TorSessionRequiredError) Error() string {
 	return "We can't send out PII in Tor-Strict mode; but it's needed for this operation"
 }
 
-func NewProofAPIError(s keybase1.ProofStatus, u string, d string, a ...interface{}) *ProofAPIError {
+func NewProofAPIError(s keybase1.ProofStatus, u string, d string, a ...any) *ProofAPIError {
 	base := NewProofError(s, d, a...)
 	return &ProofAPIError{*base, u}
 }
@@ -186,13 +186,13 @@ func (e AssertionParseError) Error() string {
 	return e.err
 }
 
-func NewAssertionParseError(s string, a ...interface{}) AssertionParseError {
+func NewAssertionParseError(s string, a ...any) AssertionParseError {
 	return AssertionParseError{
 		reason: AssertionParseErrorReasonGeneric,
 		err:    fmt.Sprintf(s, a...),
 	}
 }
-func NewAssertionParseErrorWithReason(reason AssertionParseErrorReason, s string, a ...interface{}) AssertionParseError {
+func NewAssertionParseErrorWithReason(reason AssertionParseErrorReason, s string, a ...any) AssertionParseError {
 	return AssertionParseError{
 		reason: reason,
 		err:    fmt.Sprintf(s, a...),
@@ -213,7 +213,7 @@ func (e AssertionCheckError) Error() string {
 	return e.err
 }
 
-func NewAssertionCheckError(s string, a ...interface{}) AssertionCheckError {
+func NewAssertionCheckError(s string, a ...any) AssertionCheckError {
 	return AssertionCheckError{
 		err: fmt.Sprintf(s, a...),
 	}
@@ -229,7 +229,7 @@ func (e NeedInputError) Error() string {
 	return e.err
 }
 
-func NewNeedInputError(s string, a ...interface{}) AssertionParseError {
+func NewNeedInputError(s string, a ...any) AssertionParseError {
 	return AssertionParseError{
 		err: fmt.Sprintf(s, a...),
 	}
@@ -694,7 +694,7 @@ func (e ServerChainError) Error() string {
 	return e.msg
 }
 
-func NewServerChainError(d string, a ...interface{}) ServerChainError {
+func NewServerChainError(d string, a ...any) ServerChainError {
 	return ServerChainError{fmt.Sprintf(d, a...)}
 }
 
@@ -1233,7 +1233,7 @@ func (r ReverseSigError) Error() string {
 	return fmt.Sprintf("Error in reverse signature: %s", r.msg)
 }
 
-func NewReverseSigError(msgf string, a ...interface{}) ReverseSigError {
+func NewReverseSigError(msgf string, a ...any) ReverseSigError {
 	return ReverseSigError{msg: fmt.Sprintf(msgf, a...)}
 }
 
@@ -1446,7 +1446,7 @@ func (e UntrackError) Error() string {
 	return fmt.Sprintf("Unfollow error: %s", e.err)
 }
 
-func NewUntrackError(d string, a ...interface{}) UntrackError {
+func NewUntrackError(d string, a ...any) UntrackError {
 	return UntrackError{
 		err: fmt.Sprintf(d, a...),
 	}
@@ -2343,7 +2343,7 @@ func (e PerUserKeyImportError) Error() string {
 	return fmt.Sprintf("per-user-key import error: %s", e.msg)
 }
 
-func NewPerUserKeyImportError(format string, args ...interface{}) PerUserKeyImportError {
+func NewPerUserKeyImportError(format string, args ...any) PerUserKeyImportError {
 	return PerUserKeyImportError{
 		msg: fmt.Sprintf(format, args...),
 	}
@@ -2451,7 +2451,7 @@ func (e ImplicitTeamDisplayNameError) Error() string {
 	return fmt.Sprintf("Error parsing implicit team name: %s", e.msg)
 }
 
-func NewImplicitTeamDisplayNameError(format string, args ...interface{}) ImplicitTeamDisplayNameError {
+func NewImplicitTeamDisplayNameError(format string, args ...any) ImplicitTeamDisplayNameError {
 	return ImplicitTeamDisplayNameError{fmt.Sprintf(format, args...)}
 }
 
@@ -2916,7 +2916,7 @@ func (e HiddenChainDataMissingError) Error() string {
 	return fmt.Sprintf("hidden chain data missing error: %s", e.note)
 }
 
-func NewHiddenChainDataMissingError(format string, args ...interface{}) HiddenChainDataMissingError {
+func NewHiddenChainDataMissingError(format string, args ...any) HiddenChainDataMissingError {
 	return HiddenChainDataMissingError{fmt.Sprintf(format, args...)}
 }
 
@@ -2944,7 +2944,7 @@ type HiddenMerkleError struct {
 	t HiddenMerkleErrorType
 }
 
-func NewHiddenMerkleError(t HiddenMerkleErrorType, format string, args ...interface{}) HiddenMerkleError {
+func NewHiddenMerkleError(t HiddenMerkleErrorType, format string, args ...any) HiddenMerkleError {
 	return HiddenMerkleError{
 		t: t,
 		m: fmt.Sprintf(format, args...),

--- a/go/libkb/generickey.go
+++ b/go/libkb/generickey.go
@@ -11,7 +11,7 @@ import (
 )
 
 type VerifyContext interface {
-	Debug(format string, args ...interface{})
+	Debug(format string, args ...any)
 }
 
 type RawPublicKey []byte

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -468,7 +468,7 @@ func migrateGUIConfig(serviceConfig ConfigReader, guiConfig *JSONFile) error {
 			errs = append(errs, err)
 		}
 	} else {
-		syncSettings, ok := syncSettings.(map[string]interface{})
+		syncSettings, ok := syncSettings.(map[string]any)
 		if !ok {
 			errs = append(errs, fmt.Errorf("Failed to coerce ui.importContacts in migration"))
 		} else {
@@ -1124,12 +1124,12 @@ func (g *GlobalContext) GetMyClientDetails() keybase1.ClientDetails {
 }
 
 type UnforwardedLoggerWithLegacyInterface interface {
-	Debug(s string, args ...interface{})
-	Error(s string, args ...interface{})
-	Errorf(s string, args ...interface{})
-	Warning(s string, args ...interface{})
-	Info(s string, args ...interface{})
-	Profile(s string, args ...interface{})
+	Debug(s string, args ...any)
+	Error(s string, args ...any)
+	Errorf(s string, args ...any)
+	Warning(s string, args ...any)
+	Info(s string, args ...any)
+	Profile(s string, args ...any)
 }
 
 func (g *GlobalContext) GetUnforwardedLogger() (log UnforwardedLoggerWithLegacyInterface) {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -177,8 +177,8 @@ func ParseWotReact(base GenericChainLink) (ret *WotReactChainLink, err error) {
 }
 
 type sigExpansion struct {
-	Key string      `json:"key"`
-	Obj interface{} `json:"obj"`
+	Key string `json:"key"`
+	Obj any    `json:"obj"`
 }
 
 // ExtractExpansionObj extracts the `obj` field from a sig expansion and verifies the
@@ -246,7 +246,6 @@ func EmbedExpansionObj(statement *jsonw.Wrapper) (expansion *jsonw.Wrapper, sum 
 
 // =========================================================================
 // Remote, Web and Social
-//
 type RemoteProofChainLink interface {
 	TypedChainLink
 	DisplayPriorityKey() string
@@ -538,7 +537,6 @@ func remoteProofInsertIntoTable(l RemoteProofChainLink, tab *IdentityTable) {
 
 // =========================================================================
 // TrackChainLink
-//
 type TrackChainLink struct {
 	GenericChainLink
 	whomUsername  NormalizedUsername
@@ -1045,7 +1043,7 @@ type WalletStellarChainLink struct {
 
 func ParseWalletStellarChainLink(b GenericChainLink) (ret *WalletStellarChainLink, err error) {
 	ret = &WalletStellarChainLink{GenericChainLink: b}
-	mkErr := func(format string, args ...interface{}) error {
+	mkErr := func(format string, args ...any) error {
 		return ChainLinkError{fmt.Sprintf(format, args...) + fmt.Sprintf(" @%s", b.ToDebugString())}
 	}
 	bodyW := b.UnmarshalPayloadJSON()

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -133,8 +133,7 @@ type CommandLine interface {
 	GetBool(string, bool) (bool, bool)
 }
 
-type Server interface {
-}
+type Server any
 
 type DBKeySet map[DbKey]struct{}
 
@@ -165,15 +164,15 @@ type LocalDb interface {
 }
 
 type KVStorer interface {
-	GetInto(obj interface{}, id DbKey) (found bool, err error)
-	PutObj(id DbKey, aliases []DbKey, obj interface{}) (err error)
+	GetInto(obj any, id DbKey) (found bool, err error)
+	PutObj(id DbKey, aliases []DbKey, obj any) (err error)
 	Delete(id DbKey) error
 	KeysWithPrefixes(prefixes ...[]byte) (DBKeySet, error)
 }
 
 type JSONReader interface {
 	GetStringAtPath(string) (string, bool)
-	GetInterfaceAtPath(string) (interface{}, error)
+	GetInterfaceAtPath(string) (any, error)
 	GetBoolAtPath(string) (bool, bool)
 	GetIntAtPath(string) (int, bool)
 	GetFloatAtPath(string) (float64, bool)
@@ -275,7 +274,7 @@ type Command interface {
 	GetUsage() Usage
 }
 
-type JSONPayload map[string]interface{}
+type JSONPayload map[string]any
 
 type APIRes struct {
 	Status     *jsonw.Wrapper
@@ -395,15 +394,15 @@ type SaltpackUI interface {
 }
 
 type LogUI interface {
-	Debug(format string, args ...interface{})
-	Info(format string, args ...interface{})
-	Warning(format string, args ...interface{})
-	Notice(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-	Critical(format string, args ...interface{})
+	Debug(format string, args ...any)
+	Info(format string, args ...any)
+	Warning(format string, args ...any)
+	Notice(format string, args ...any)
+	Errorf(format string, args ...any)
+	Critical(format string, args ...any)
 }
 
-type LogFunc func(format string, args ...interface{})
+type LogFunc func(format string, args ...any)
 
 type GPGUI interface {
 	keybase1.GpgUiInterface
@@ -473,8 +472,8 @@ type TerminalUI interface {
 	OutputDesc(OutputDescriptor, string) error
 	OutputWriter() io.Writer
 	UnescapedOutputWriter() io.Writer
-	Printf(fmt string, args ...interface{}) (int, error)
-	PrintfUnescaped(fmt string, args ...interface{}) (int, error)
+	Printf(fmt string, args ...any) (int, error)
+	PrintfUnescaped(fmt string, args ...any) (int, error)
 	// Prompt strings are not escaped: they should not be used to show unescaped user-originated data.
 	Prompt(PromptDescriptor, string) (string, error)
 	PromptForConfirmation(prompt string) error
@@ -485,9 +484,9 @@ type TerminalUI interface {
 }
 
 type DumbOutputUI interface {
-	Printf(fmt string, args ...interface{}) (int, error)
-	PrintfStderr(fmt string, args ...interface{}) (int, error)
-	PrintfUnescaped(fmt string, args ...interface{}) (int, error)
+	Printf(fmt string, args ...any) (int, error)
+	PrintfStderr(fmt string, args ...any) (int, error)
+	PrintfUnescaped(fmt string, args ...any) (int, error)
 }
 
 type UI interface {
@@ -949,15 +948,15 @@ type LRUKeyer interface {
 }
 
 type LRUer interface {
-	Get(context.Context, LRUContext, LRUKeyer) (interface{}, error)
-	Put(context.Context, LRUContext, LRUKeyer, interface{}) error
+	Get(context.Context, LRUContext, LRUKeyer) (any, error)
+	Put(context.Context, LRUContext, LRUKeyer, any) error
 	OnLogout(mctx MetaContext) error
 	OnDbNuke(mctx MetaContext) error
 }
 
 type MemLRUer interface {
-	Get(key interface{}) (interface{}, bool)
-	Put(key, value interface{}) bool
+	Get(key any) (any, bool)
+	Put(key, value any) bool
 	OnLogout(mctx MetaContext) error
 	OnDbNuke(mctx MetaContext) error
 }
@@ -980,9 +979,9 @@ type UsernamePackage struct {
 
 type SkinnyLogger interface {
 	// Error logs a message at error level, with formatting args
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	// Debug logs a message at debug level, with formatting args.
-	Debug(format string, args ...interface{})
+	Debug(format string, args ...any)
 }
 
 type UIDMapper interface {

--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -95,7 +95,7 @@ func (f *JSONFile) LoadCheckFound() (found bool, err error) {
 	}
 
 	decoder := json.NewDecoder(&buf)
-	obj := make(map[string]interface{})
+	obj := make(map[string]any)
 	// Treat empty files like an empty dictionary
 	if err = decoder.Decode(&obj); err != nil && err != io.EOF {
 		f.G().Log.Errorf("Error decoding %s file %s", f.which, f.filename)
@@ -225,11 +225,11 @@ func (f *JSONFile) save() (err error) {
 		return err
 	}
 
-	var dat interface{}
+	var dat any
 
 	if f.jw == nil {
 		// Make a default Dictionary if none already exists
-		dat = make(map[string]interface{})
+		dat = make(map[string]any)
 		f.G().Log.Warning("No value for %s file; assuming empty value (i.e., {})",
 			f.which)
 	} else {
@@ -313,7 +313,7 @@ func (f *JSONFile) save() (err error) {
 			defer fc.Close()
 
 			decoder := json.NewDecoder(fc)
-			obj := make(map[string]interface{})
+			obj := make(map[string]any)
 			if err := decoder.Decode(&obj); err != nil {
 				f.G().Log.Debug("error decoding %s: %s", filename, err)
 			} else {
@@ -377,9 +377,9 @@ func (f *jsonFileTransaction) Commit() (err error) {
 	return f.f.setTx(nil)
 }
 
-type valueGetter func(*jsonw.Wrapper) (interface{}, error)
+type valueGetter func(*jsonw.Wrapper) (any, error)
 
-func (f *JSONFile) getValueAtPath(p string, getter valueGetter) (ret interface{}, isSet bool) {
+func (f *JSONFile) getValueAtPath(p string, getter valueGetter) (ret any, isSet bool) {
 	var err error
 	ret, err = getter(f.jw.AtPath(p))
 	if err == nil {
@@ -388,19 +388,19 @@ func (f *JSONFile) getValueAtPath(p string, getter valueGetter) (ret interface{}
 	return ret, isSet
 }
 
-func getString(w *jsonw.Wrapper) (interface{}, error) {
+func getString(w *jsonw.Wrapper) (any, error) {
 	return w.GetString()
 }
 
-func getBool(w *jsonw.Wrapper) (interface{}, error) {
+func getBool(w *jsonw.Wrapper) (any, error) {
 	return w.GetBool()
 }
 
-func getInt(w *jsonw.Wrapper) (interface{}, error) {
+func getInt(w *jsonw.Wrapper) (any, error) {
 	return w.GetInt()
 }
 
-func getFloat(w *jsonw.Wrapper) (interface{}, error) {
+func getFloat(w *jsonw.Wrapper) (any, error) {
 	return w.GetFloat()
 }
 
@@ -408,7 +408,7 @@ func (f *JSONFile) GetFilename() string {
 	return f.filename
 }
 
-func (f *JSONFile) GetInterfaceAtPath(p string) (i interface{}, err error) {
+func (f *JSONFile) GetInterfaceAtPath(p string) (i any, err error) {
 	f.setMutex.RLock()
 	defer f.setMutex.RUnlock()
 	return f.jw.AtPath(p).GetInterface()
@@ -462,7 +462,7 @@ func (f *JSONFile) GetNullAtPath(p string) (isSet bool) {
 	return isSet
 }
 
-func (f *JSONFile) setValueAtPath(p string, getter valueGetter, v interface{}) error {
+func (f *JSONFile) setValueAtPath(p string, getter valueGetter, v any) error {
 	existing, err := getter(f.jw.AtPath(p))
 
 	if err != nil || existing != v {

--- a/go/libkb/leveldb_cleaner.go
+++ b/go/libkb/leveldb_cleaner.go
@@ -152,7 +152,7 @@ func (c *levelDbCleaner) monitorAppState() {
 	}
 }
 
-func (c *levelDbCleaner) log(format string, args ...interface{}) {
+func (c *levelDbCleaner) log(format string, args ...any) {
 	c.M().Debug(fmt.Sprintf("levelDbCleaner(%s): %s", c.dbName, format), args...)
 }
 

--- a/go/libkb/login_session_test.go
+++ b/go/libkb/login_session_test.go
@@ -33,7 +33,7 @@ type FakeAPI struct{}
 func (a *FakeAPI) Get(mctx MetaContext, arg APIArg) (*APIRes, error) {
 
 	decoder := json.NewDecoder(bytes.NewBufferString(fakeResponse))
-	var obj interface{}
+	var obj any
 	decoder.UseNumber()
 	err := decoder.Decode(&obj)
 	if err != nil {

--- a/go/libkb/markup.go
+++ b/go/libkb/markup.go
@@ -26,7 +26,7 @@ func NewMarkup(s string) *Markup {
 	return &Markup{markupFrame(s)}
 }
 
-func FmtMarkup(f string, args ...interface{}) *Markup {
+func FmtMarkup(f string, args ...any) *Markup {
 	return &Markup{data: markupFrame(fmt.Sprintf(f, args...))}
 }
 

--- a/go/libkb/merkle_reset_chain.go
+++ b/go/libkb/merkle_reset_chain.go
@@ -99,7 +99,7 @@ func (mr *MerkleResets) verifyAndLoad(m MetaContext, urc unverifiedResetChain) (
 
 	defer m.VTrace(VLog1, "MerkleResets#verifyAndLoad", &err)()
 
-	mkerr := func(f string, a ...interface{}) error {
+	mkerr := func(f string, a ...any) error {
 		return MerkleClientError{m: fmt.Sprintf(f, a...), t: merkleErrorBadResetChain}
 	}
 

--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -97,7 +97,7 @@ func newPerUserKeyPrev(contents PerUserKeySeed, symmetricKey NaclSecretBoxKey) (
 	// secretbox
 	sealed := secretbox.Seal(nil, contents[:], &nonce, (*[NaclSecretBoxKeySize]byte)(&symmetricKey))
 
-	parts := []interface{}{version, nonce, sealed}
+	parts := []any{version, nonce, sealed}
 
 	// msgpack
 	mh := codec.MsgpackHandle{WriteExt: true}

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -193,13 +193,13 @@ func ExportErrorAsStatus(g *GlobalContext, e error) (ret *keybase1.Status) {
 
 // =============================================================================
 
-func MakeWrapError(g *GlobalContext) func(e error) interface{} {
-	return func(e error) interface{} {
+func MakeWrapError(g *GlobalContext) func(e error) any {
+	return func(e error) any {
 		return ExportErrorAsStatus(g, e)
 	}
 }
 
-func WrapError(e error) interface{} {
+func WrapError(e error) any {
 	return ExportErrorAsStatus(nil, e)
 }
 
@@ -214,11 +214,11 @@ func NewContextifiedErrorUnwrapper(g *GlobalContext) ErrorUnwrapper {
 
 }
 
-func (c ErrorUnwrapper) MakeArg() interface{} {
+func (c ErrorUnwrapper) MakeArg() any {
 	return &keybase1.Status{}
 }
 
-func (c ErrorUnwrapper) UnwrapError(arg interface{}) (appError error, dispatchError error) {
+func (c ErrorUnwrapper) UnwrapError(arg any) (appError error, dispatchError error) {
 	targ, ok := arg.(*keybase1.Status)
 	if !ok {
 		dispatchError = errors.New("Error converting status to keybase1.Status object")

--- a/go/libkb/service_info.go
+++ b/go/libkb/service_info.go
@@ -55,7 +55,7 @@ func (s ServiceInfo) WriteFile(path string, log logger.Logger) error {
 
 // serviceLog is the log interface for ServiceInfo
 type serviceLog interface {
-	Debug(s string, args ...interface{})
+	Debug(s string, args ...any)
 }
 
 func LoadServiceInfo(path string) (*ServiceInfo, error) {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -40,19 +40,19 @@ func (c *TestConfig) GetConfigFileName() string { return c.configFileName }
 // this in order to avoid pulling in the "testing" package in exported
 // code.
 type TestingTB interface {
-	Error(args ...interface{})
-	Errorf(format string, args ...interface{})
+	Error(args ...any)
+	Errorf(format string, args ...any)
 	Fail()
 	FailNow()
 	Failed() bool
-	Fatal(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Log(args ...interface{})
-	Logf(format string, args ...interface{})
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Log(args ...any)
+	Logf(format string, args ...any)
 	Name() string
-	Skip(args ...interface{})
+	Skip(args ...any)
 	SkipNow()
-	Skipf(format string, args ...interface{})
+	Skipf(format string, args ...any)
 	Skipped() bool
 	Helper()
 }
@@ -391,15 +391,15 @@ type nullui struct {
 	gctx *GlobalContext
 }
 
-func (n *nullui) Printf(f string, args ...interface{}) (int, error) {
+func (n *nullui) Printf(f string, args ...any) (int, error) {
 	return fmt.Printf(f, args...)
 }
 
-func (n *nullui) PrintfStderr(f string, args ...interface{}) (int, error) {
+func (n *nullui) PrintfStderr(f string, args ...any) (int, error) {
 	return fmt.Fprintf(os.Stderr, f, args...)
 }
 
-func (n *nullui) PrintfUnescaped(f string, args ...interface{}) (int, error) {
+func (n *nullui) PrintfUnescaped(f string, args ...any) (int, error) {
 	return fmt.Printf(f, args...)
 }
 

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -202,8 +202,8 @@ type SafeWriter interface {
 }
 
 type SafeWriteLogger interface {
-	Debug(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
+	Debug(format string, args ...any)
+	Errorf(format string, args ...any)
 }
 
 // SafeWriteToFile to safely write to a file. Use mode=0 for default permissions.
@@ -273,9 +273,10 @@ func safeWriteToFileOnce(g SafeWriteLogger, t SafeWriter, mode os.FileMode) (err
 
 // Pluralize returns pluralized string with value.
 // For example,
-//   Pluralize(1, "zebra", "zebras", true) => "1 zebra"
-//   Pluralize(2, "zebra", "zebras", true) => "2 zebras"
-//   Pluralize(2, "zebra", "zebras", false) => "zebras"
+//
+//	Pluralize(1, "zebra", "zebras", true) => "1 zebra"
+//	Pluralize(2, "zebra", "zebras", true) => "2 zebras"
+//	Pluralize(2, "zebra", "zebras", false) => "zebras"
 func Pluralize(n int, singular string, plural string, nshow bool) string {
 	if n == 1 {
 		if nshow {
@@ -634,14 +635,16 @@ func Digest(r io.Reader) (string, error) {
 }
 
 // TimeLog calls out with the time since start.  Use like this:
-//    defer TimeLog("MyFunc", time.Now(), e.G().Log.Warning)
-func TimeLog(name string, start time.Time, out func(string, ...interface{})) {
+//
+//	defer TimeLog("MyFunc", time.Now(), e.G().Log.Warning)
+func TimeLog(name string, start time.Time, out func(string, ...any)) {
 	out("time> %s: %s", name, time.Since(start))
 }
 
 // CTimeLog calls out with the time since start.  Use like this:
-//    defer CTimeLog(ctx, "MyFunc", time.Now(), e.G().Log.Warning)
-func CTimeLog(ctx context.Context, name string, start time.Time, out func(context.Context, string, ...interface{})) {
+//
+//	defer CTimeLog(ctx, "MyFunc", time.Now(), e.G().Log.Warning)
+func CTimeLog(ctx context.Context, name string, start time.Time, out func(context.Context, string, ...any)) {
 	out(ctx, "time> %s: %s", name, time.Since(start))
 }
 
@@ -672,9 +675,9 @@ func JoinPredicate(arr []string, delimeter string, f func(s string) bool) string
 // LogTagsFromContext is a wrapper around logger.LogTagsFromContext
 // that simply casts the result to the type expected by
 // rpc.Connection.
-func LogTagsFromContext(ctx context.Context) (map[interface{}]string, bool) {
+func LogTagsFromContext(ctx context.Context) (map[any]string, bool) {
 	tags, ok := logger.LogTagsFromContext(ctx)
-	return map[interface{}]string(tags), ok
+	return map[any]string(tags), ok
 }
 
 func MakeByte24(a []byte) [24]byte {
@@ -851,7 +854,7 @@ func ShredFile(filename string) error {
 	return os.Remove(filename)
 }
 
-func MPackEncode(input interface{}) ([]byte, error) {
+func MPackEncode(input any) ([]byte, error) {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	var data []byte
 	enc := codec.NewEncoderBytes(&data, &mh)
@@ -861,7 +864,7 @@ func MPackEncode(input interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func MPackDecode(data []byte, res interface{}) error {
+func MPackDecode(data []byte, res any) error {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	dec := codec.NewDecoderBytes(data, &mh)
 	err := dec.Decode(res)
@@ -1158,23 +1161,23 @@ var throttleBatchClock = clockwork.NewRealClock()
 
 type throttleBatchEmpty struct{}
 
-func isEmptyThrottleData(arg interface{}) bool {
+func isEmptyThrottleData(arg any) bool {
 	_, ok := arg.(throttleBatchEmpty)
 	return ok
 }
 
-func ThrottleBatch(f func(interface{}), batcher func(interface{}, interface{}) interface{},
-	reset func() interface{}, delay time.Duration, leadingFire bool) (func(interface{}), func()) {
+func ThrottleBatch(f func(any), batcher func(any, any) any,
+	reset func() any, delay time.Duration, leadingFire bool) (func(any), func()) {
 	var lock sync.Mutex
 	var closeLock sync.Mutex
 	var lastCalled time.Time
-	var creation func(interface{})
+	var creation func(any)
 	hasStored := false
 	scheduled := false
 	stored := reset()
 	cancelCh := make(chan struct{})
 	closed := false
-	creation = func(arg interface{}) {
+	creation = func(arg any) {
 		lock.Lock()
 		defer lock.Unlock()
 		elapsed := throttleBatchClock.Since(lastCalled)

--- a/go/libkb/util_test.go
+++ b/go/libkb/util_test.go
@@ -249,7 +249,7 @@ func TestThrottleBatch(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	throttleBatchClock = clock
 	ch := make(chan int, 100)
-	handler := func(arg interface{}) {
+	handler := func(arg any) {
 		v, ok := arg.(int)
 		require.True(t, ok)
 		ch <- v
@@ -270,14 +270,14 @@ func TestThrottleBatch(t *testing.T) {
 		default:
 		}
 	}
-	batcher := func(batchedInt interface{}, singleInt interface{}) interface{} {
+	batcher := func(batchedInt any, singleInt any) any {
 		batched, ok := batchedInt.(int)
 		require.True(t, ok)
 		single, ok := singleInt.(int)
 		require.True(t, ok)
 		return batched + single
 	}
-	reset := func() interface{} {
+	reset := func() any {
 		return 0
 	}
 

--- a/go/libkb/vdebug.go
+++ b/go/libkb/vdebug.go
@@ -68,7 +68,7 @@ func (v *VDebugLog) getLev() VDebugLevel {
 	return v.lev
 }
 
-func (v *VDebugLog) Log(lev VDebugLevel, fs string, args ...interface{}) {
+func (v *VDebugLog) Log(lev VDebugLevel, fs string, args ...any) {
 	if lev <= v.getLev() {
 		prfx := fmt.Sprintf("{VDL:%d} ", int(lev))
 		fs = prfx + fs
@@ -76,7 +76,7 @@ func (v *VDebugLog) Log(lev VDebugLevel, fs string, args ...interface{}) {
 	}
 }
 
-func (v *VDebugLog) CLogf(ctx context.Context, lev VDebugLevel, fs string, args ...interface{}) {
+func (v *VDebugLog) CLogf(ctx context.Context, lev VDebugLevel, fs string, args ...any) {
 	if lev <= v.getLev() {
 		prfx := fmt.Sprintf("{VDL:%d} ", int(lev))
 		fs = prfx + fs
@@ -84,7 +84,7 @@ func (v *VDebugLog) CLogf(ctx context.Context, lev VDebugLevel, fs string, args 
 	}
 }
 
-func (v *VDebugLog) CLogfWithAddedDepth(ctx context.Context, lev VDebugLevel, d int, fs string, args ...interface{}) {
+func (v *VDebugLog) CLogfWithAddedDepth(ctx context.Context, lev VDebugLevel, d int, fs string, args ...any) {
 	if lev <= v.getLev() {
 		prfx := fmt.Sprintf("{VDL:%d} ", int(lev))
 		fs = prfx + fs

--- a/go/libkb/vlock.go
+++ b/go/libkb/vlock.go
@@ -20,7 +20,7 @@ func NewVerboseLock(level VDebugLevel, name string) *VerboseLock {
 	}
 }
 
-func (l *VerboseLock) Acquire(mctx MetaContext, reasonFormat string, args ...interface{}) (release VerboseLockRelease) {
+func (l *VerboseLock) Acquire(mctx MetaContext, reasonFormat string, args ...any) (release VerboseLockRelease) {
 	reason := fmt.Sprintf(reasonFormat, args...)
 	log := func(symbol string, word string) {
 		mctx.VLogf(l.level, "%v VerboseLock [%v] %v: %v", symbol, l.name, word, reason)

--- a/go/libkb/warning.go
+++ b/go/libkb/warning.go
@@ -18,7 +18,7 @@ func (s StringWarning) Warning() string {
 	return string(s)
 }
 
-func Warningf(format string, a ...interface{}) Warning {
+func Warningf(format string, a ...any) Warning {
 	return StringWarning(fmt.Sprintf(format, a...))
 }
 

--- a/go/logger/adapter.go
+++ b/go/logger/adapter.go
@@ -5,17 +5,17 @@ package logger
 
 // Loggerf is a minimal log interface (using proper formatter style methods)
 type Loggerf interface {
-	Debugf(s string, args ...interface{})
-	Infof(s string, args ...interface{})
-	Warningf(s string, args ...interface{})
-	Errorf(s string, args ...interface{})
+	Debugf(s string, args ...any)
+	Infof(s string, args ...any)
+	Warningf(s string, args ...any)
+	Errorf(s string, args ...any)
 }
 
 type loggerInternal interface {
-	Debug(s string, args ...interface{})
-	Info(s string, args ...interface{})
-	Warning(s string, args ...interface{})
-	Errorf(s string, args ...interface{})
+	Debug(s string, args ...any)
+	Info(s string, args ...any)
+	Warning(s string, args ...any)
+	Errorf(s string, args ...any)
 }
 
 type logf struct {
@@ -28,21 +28,21 @@ func NewLoggerf(log loggerInternal) Loggerf {
 }
 
 // Debugf forwards to Logger.Debug
-func (l logf) Debugf(s string, args ...interface{}) {
+func (l logf) Debugf(s string, args ...any) {
 	l.log.Debug(s, args...)
 }
 
 // Infof forwards to Logger.Info
-func (l logf) Infof(s string, args ...interface{}) {
+func (l logf) Infof(s string, args ...any) {
 	l.log.Info(s, args...)
 }
 
 // Warningf forwards to Logger.Warning
-func (l logf) Warningf(s string, args ...interface{}) {
+func (l logf) Warningf(s string, args ...any) {
 	l.log.Warning(s, args...)
 }
 
 // Errorf forwards to Logger.Errorf
-func (l logf) Errorf(s string, args ...interface{}) {
+func (l logf) Errorf(s string, args ...any) {
 	l.log.Errorf(s, args...)
 }

--- a/go/logger/context_with_logging.go
+++ b/go/logger/context_with_logging.go
@@ -23,30 +23,30 @@ func (c Context) UpdateContextToLoggerContext(ctx context.Context) ContextInterf
 	return NewContext(ctx, c.Logger)
 }
 
-func (c Context) Debug(format string, arg ...interface{}) {
+func (c Context) Debug(format string, arg ...any) {
 	c.Logger.CloneWithAddedDepth(1).CDebugf(c.ctx, format, arg...)
 }
 
-func (c Context) Info(format string, arg ...interface{}) {
+func (c Context) Info(format string, arg ...any) {
 	c.Logger.CloneWithAddedDepth(1).CInfof(c.ctx, format, arg...)
 }
 
-func (c Context) Notice(format string, arg ...interface{}) {
+func (c Context) Notice(format string, arg ...any) {
 	c.Logger.CloneWithAddedDepth(1).CNoticef(c.ctx, format, arg...)
 }
 
-func (c Context) Warning(format string, arg ...interface{}) {
+func (c Context) Warning(format string, arg ...any) {
 	c.Logger.CloneWithAddedDepth(1).CWarningf(c.ctx, format, arg...)
 }
 
-func (c Context) Error(format string, arg ...interface{}) {
+func (c Context) Error(format string, arg ...any) {
 	c.Logger.CloneWithAddedDepth(1).CErrorf(c.ctx, format, arg...)
 }
 
-func (c Context) Critical(format string, arg ...interface{}) {
+func (c Context) Critical(format string, arg ...any) {
 	c.Logger.CloneWithAddedDepth(1).CCriticalf(c.ctx, format, arg...)
 }
 
-func (c Context) Fatal(format string, arg ...interface{}) {
+func (c Context) Fatal(format string, arg ...any) {
 	c.Logger.CloneWithAddedDepth(1).CFatalf(c.ctx, format, arg...)
 }

--- a/go/logger/logger.go
+++ b/go/logger/logger.go
@@ -11,14 +11,14 @@ import (
 )
 
 type ExternalHandler interface {
-	Log(level keybase1.LogLevel, format string, args []interface{})
+	Log(level keybase1.LogLevel, format string, args []any)
 }
 
 type BaseLogger interface {
-	Debug(format string, args ...interface{})
-	Info(format string, args ...interface{})
-	Warning(format string, args ...interface{})
-	Error(format string, args ...interface{})
+	Debug(format string, args ...any)
+	Info(format string, args ...any)
+	Warning(format string, args ...any)
+	Error(format string, args ...any)
 }
 
 type ContextInterface interface {
@@ -31,32 +31,32 @@ type Logger interface {
 	BaseLogger
 	// CDebugf logs a message at debug level, with a context and
 	// formatting args.
-	CDebugf(ctx context.Context, format string, args ...interface{})
+	CDebugf(ctx context.Context, format string, args ...any)
 	// CInfo logs a message at info level, with a context and formatting args.
-	CInfof(ctx context.Context, format string, args ...interface{})
+	CInfof(ctx context.Context, format string, args ...any)
 	// Notice logs a message at notice level, with formatting args.
-	Notice(format string, args ...interface{})
+	Notice(format string, args ...any)
 	// CNoticef logs a message at notice level, with a context and
 	// formatting args.
-	CNoticef(ctx context.Context, format string, args ...interface{})
+	CNoticef(ctx context.Context, format string, args ...any)
 	// Warning logs a message at warning level, with formatting args.
-	CWarningf(ctx context.Context, format string, args ...interface{})
+	CWarningf(ctx context.Context, format string, args ...any)
 	// Error logs a message at error level, with formatting args
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	// CErrorf logs a message at error level, with a context and
 	// formatting args.
-	CErrorf(ctx context.Context, format string, args ...interface{})
+	CErrorf(ctx context.Context, format string, args ...any)
 	// Critical logs a message at critical level, with formatting args.
-	Critical(format string, args ...interface{})
+	Critical(format string, args ...any)
 	// CCriticalf logs a message at critical level, with a context and
 	// formatting args.
-	CCriticalf(ctx context.Context, format string, args ...interface{})
+	CCriticalf(ctx context.Context, format string, args ...any)
 	// Fatalf logs a message at fatal level, with formatting args.
-	Fatalf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
 	// Fatalf logs a message at fatal level, with a context and formatting args.
-	CFatalf(ctx context.Context, format string, args ...interface{})
+	CFatalf(ctx context.Context, format string, args ...any)
 	// Profile logs a profile message, with formatting args.
-	Profile(fmts string, arg ...interface{})
+	Profile(fmts string, arg ...any)
 
 	// Returns a logger that is like the current one, except with
 	// more logging depth added on.
@@ -80,74 +80,74 @@ func NewInternalLogger(log *log.Logger) *InternalLogger {
 	}
 }
 
-func (l *InternalLogger) Debug(fmt string, arg ...interface{}) {
+func (l *InternalLogger) Debug(fmt string, arg ...any) {
 	l.log.Printf(fmt, arg...)
 }
 
 func (l *InternalLogger) CDebugf(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	l.log.Printf(prepareString(ctx, fmt), arg...)
 }
 
-func (l *InternalLogger) Info(fmt string, arg ...interface{}) {
+func (l *InternalLogger) Info(fmt string, arg ...any) {
 	l.log.Printf(keybase1.LogLevel_INFO.String()+fmt, arg...)
 }
 
 func (l *InternalLogger) CInfof(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	l.log.Printf(keybase1.LogLevel_INFO.String()+prepareString(ctx, fmt), arg...)
 }
 
-func (l *InternalLogger) Notice(fmt string, arg ...interface{}) {
+func (l *InternalLogger) Notice(fmt string, arg ...any) {
 	l.log.Printf(keybase1.LogLevel_NOTICE.String()+fmt, arg...)
 }
 
 func (l *InternalLogger) CNoticef(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	l.log.Printf(keybase1.LogLevel_NOTICE.String()+prepareString(ctx, fmt), arg...)
 }
 
-func (l *InternalLogger) Warning(fmt string, arg ...interface{}) {
+func (l *InternalLogger) Warning(fmt string, arg ...any) {
 	l.log.Printf(keybase1.LogLevel_WARN.String()+fmt, arg...)
 }
 
 func (l *InternalLogger) CWarningf(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	l.log.Printf(keybase1.LogLevel_WARN.String()+prepareString(ctx, fmt), arg...)
 }
 
-func (l *InternalLogger) Error(fmt string, arg ...interface{}) {
+func (l *InternalLogger) Error(fmt string, arg ...any) {
 	l.log.Printf(keybase1.LogLevel_ERROR.String()+fmt, arg...)
 }
 
-func (l *InternalLogger) Errorf(fmt string, arg ...interface{}) {
+func (l *InternalLogger) Errorf(fmt string, arg ...any) {
 	l.log.Printf(keybase1.LogLevel_ERROR.String()+fmt, arg...)
 }
 
 func (l *InternalLogger) CErrorf(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	l.log.Printf(keybase1.LogLevel_ERROR.String()+prepareString(ctx, fmt), arg...)
 }
 
-func (l *InternalLogger) Critical(fmt string, arg ...interface{}) {
+func (l *InternalLogger) Critical(fmt string, arg ...any) {
 	l.log.Printf(keybase1.LogLevel_CRITICAL.String()+fmt, arg...)
 }
 
 func (l *InternalLogger) CCriticalf(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	l.log.Printf(keybase1.LogLevel_CRITICAL.String()+prepareString(ctx, fmt), arg...)
 }
 
-func (l *InternalLogger) Fatalf(fmt string, arg ...interface{}) {
+func (l *InternalLogger) Fatalf(fmt string, arg ...any) {
 	l.log.Fatalf(fmt, arg...)
 }
 
 func (l *InternalLogger) CFatalf(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	l.log.Fatalf(prepareString(ctx, fmt), arg...)
 }
 
-func (l *InternalLogger) Profile(fmts string, arg ...interface{}) {
+func (l *InternalLogger) Profile(fmts string, arg ...any) {
 	l.log.Printf(keybase1.LogLevel_DEBUG.String()+fmts, arg...)
 }
 func (l *InternalLogger) Configure(style string, debug bool, filename string) {}

--- a/go/logger/null.go
+++ b/go/logger/null.go
@@ -14,23 +14,23 @@ func NewNull() *Null {
 // Verify Null fully implements the Logger interface.
 var _ Logger = (*Null)(nil)
 
-func (l *Null) Debug(format string, args ...interface{})                       {}
-func (l *Null) Info(format string, args ...interface{})                        {}
-func (l *Null) Warning(format string, args ...interface{})                     {}
-func (l *Null) Notice(format string, args ...interface{})                      {}
-func (l *Null) Errorf(format string, args ...interface{})                      {}
-func (l *Null) Critical(format string, args ...interface{})                    {}
-func (l *Null) CCriticalf(ctx context.Context, fmt string, arg ...interface{}) {}
-func (l *Null) Fatalf(fmt string, arg ...interface{})                          {}
-func (l *Null) CFatalf(ctx context.Context, fmt string, arg ...interface{})    {}
-func (l *Null) Profile(fmts string, arg ...interface{})                        {}
-func (l *Null) CDebugf(ctx context.Context, fmt string, arg ...interface{})    {}
-func (l *Null) CInfof(ctx context.Context, fmt string, arg ...interface{})     {}
-func (l *Null) CNoticef(ctx context.Context, fmt string, arg ...interface{})   {}
-func (l *Null) CWarningf(ctx context.Context, fmt string, arg ...interface{})  {}
-func (l *Null) CErrorf(ctx context.Context, fmt string, arg ...interface{})    {}
-func (l *Null) Error(fmt string, arg ...interface{})                           {}
-func (l *Null) Configure(style string, debug bool, filename string)            {}
+func (l *Null) Debug(format string, args ...any)                       {}
+func (l *Null) Info(format string, args ...any)                        {}
+func (l *Null) Warning(format string, args ...any)                     {}
+func (l *Null) Notice(format string, args ...any)                      {}
+func (l *Null) Errorf(format string, args ...any)                      {}
+func (l *Null) Critical(format string, args ...any)                    {}
+func (l *Null) CCriticalf(ctx context.Context, fmt string, arg ...any) {}
+func (l *Null) Fatalf(fmt string, arg ...any)                          {}
+func (l *Null) CFatalf(ctx context.Context, fmt string, arg ...any)    {}
+func (l *Null) Profile(fmts string, arg ...any)                        {}
+func (l *Null) CDebugf(ctx context.Context, fmt string, arg ...any)    {}
+func (l *Null) CInfof(ctx context.Context, fmt string, arg ...any)     {}
+func (l *Null) CNoticef(ctx context.Context, fmt string, arg ...any)   {}
+func (l *Null) CWarningf(ctx context.Context, fmt string, arg ...any)  {}
+func (l *Null) CErrorf(ctx context.Context, fmt string, arg ...any)    {}
+func (l *Null) Error(fmt string, arg ...any)                           {}
+func (l *Null) Configure(style string, debug bool, filename string)    {}
 
 func (l *Null) CloneWithAddedDepth(depth int) Logger { return l }
 

--- a/go/logger/output_windows.go
+++ b/go/logger/output_windows.go
@@ -305,4 +305,4 @@ func checkError(r1, r2 uintptr, err error) error {
 
 // use is a no-op, but the compiler cannot see that it is.
 // Calling use(p) ensures that p is kept live until that point.
-func use(p interface{}) {}
+func use(p any) {}

--- a/go/logger/rpc_adapter.go
+++ b/go/logger/rpc_adapter.go
@@ -20,67 +20,67 @@ func NewRPCLoggerAdapter(log rpc.LogOutput) Logger {
 	}
 }
 
-func (l RPCLoggerAdapter) Debug(format string, args ...interface{}) {
+func (l RPCLoggerAdapter) Debug(format string, args ...any) {
 	l.log.Debug(format, args)
 }
 
-func (l RPCLoggerAdapter) CDebugf(_ context.Context, format string, args ...interface{}) {
+func (l RPCLoggerAdapter) CDebugf(_ context.Context, format string, args ...any) {
 	l.log.Debug(format, args)
 }
 
-func (l RPCLoggerAdapter) Info(format string, args ...interface{}) {
+func (l RPCLoggerAdapter) Info(format string, args ...any) {
 	l.log.Info(format, args)
 }
 
-func (l RPCLoggerAdapter) CInfof(_ context.Context, format string, args ...interface{}) {
+func (l RPCLoggerAdapter) CInfof(_ context.Context, format string, args ...any) {
 	l.log.Info(format, args)
 }
 
-func (l RPCLoggerAdapter) Notice(format string, args ...interface{}) {
+func (l RPCLoggerAdapter) Notice(format string, args ...any) {
 	l.log.Warning(format, args)
 }
 
-func (l RPCLoggerAdapter) CNoticef(_ context.Context, format string, args ...interface{}) {
+func (l RPCLoggerAdapter) CNoticef(_ context.Context, format string, args ...any) {
 	l.log.Warning(format, args)
 }
 
-func (l RPCLoggerAdapter) Warning(format string, args ...interface{}) {
+func (l RPCLoggerAdapter) Warning(format string, args ...any) {
 	l.log.Warning(format, args)
 }
 
-func (l RPCLoggerAdapter) CWarningf(_ context.Context, format string, args ...interface{}) {
+func (l RPCLoggerAdapter) CWarningf(_ context.Context, format string, args ...any) {
 	l.log.Warning(format, args)
 }
 
-func (l RPCLoggerAdapter) Error(format string, args ...interface{}) {
+func (l RPCLoggerAdapter) Error(format string, args ...any) {
 	l.log.Error(format, args)
 }
 
-func (l RPCLoggerAdapter) Errorf(format string, args ...interface{}) {
+func (l RPCLoggerAdapter) Errorf(format string, args ...any) {
 	l.log.Error(format, args)
 }
 
-func (l RPCLoggerAdapter) CErrorf(_ context.Context, format string, args ...interface{}) {
+func (l RPCLoggerAdapter) CErrorf(_ context.Context, format string, args ...any) {
 	l.log.Error(format, args)
 }
 
-func (l RPCLoggerAdapter) Critical(format string, args ...interface{}) {
+func (l RPCLoggerAdapter) Critical(format string, args ...any) {
 	l.log.Error(format, args)
 }
 
-func (l RPCLoggerAdapter) CCriticalf(_ context.Context, format string, args ...interface{}) {
+func (l RPCLoggerAdapter) CCriticalf(_ context.Context, format string, args ...any) {
 	l.log.Error(format, args)
 }
 
-func (l RPCLoggerAdapter) Fatalf(format string, args ...interface{}) {
+func (l RPCLoggerAdapter) Fatalf(format string, args ...any) {
 	l.log.Error(format, args)
 }
 
-func (l RPCLoggerAdapter) CFatalf(_ context.Context, format string, args ...interface{}) {
+func (l RPCLoggerAdapter) CFatalf(_ context.Context, format string, args ...any) {
 	l.log.Error(format, args)
 }
 
-func (l RPCLoggerAdapter) Profile(format string, args ...interface{}) {
+func (l RPCLoggerAdapter) Profile(format string, args ...any) {
 	l.log.Profile(format, args)
 }
 

--- a/go/logger/single_context_logger.go
+++ b/go/logger/single_context_logger.go
@@ -17,52 +17,52 @@ func NewSingleContextLogger(ctx context.Context, l Logger) *SingleContextLogger 
 
 var _ Logger = (*SingleContextLogger)(nil)
 
-func (s *SingleContextLogger) Debug(format string, args ...interface{}) {
+func (s *SingleContextLogger) Debug(format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CDebugf(s.ctx, format, args...)
 }
-func (s *SingleContextLogger) CDebugf(ctx context.Context, format string, args ...interface{}) {
+func (s *SingleContextLogger) CDebugf(ctx context.Context, format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CDebugf(ctx, format, args...)
 }
-func (s *SingleContextLogger) Info(format string, args ...interface{}) {
+func (s *SingleContextLogger) Info(format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CInfof(s.ctx, format, args...)
 }
-func (s *SingleContextLogger) CInfof(ctx context.Context, format string, args ...interface{}) {
+func (s *SingleContextLogger) CInfof(ctx context.Context, format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CInfof(ctx, format, args...)
 }
-func (s *SingleContextLogger) Notice(format string, args ...interface{}) {
+func (s *SingleContextLogger) Notice(format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CNoticef(s.ctx, format, args...)
 }
-func (s *SingleContextLogger) CNoticef(ctx context.Context, format string, args ...interface{}) {
+func (s *SingleContextLogger) CNoticef(ctx context.Context, format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CNoticef(ctx, format, args...)
 }
-func (s *SingleContextLogger) Warning(format string, args ...interface{}) {
+func (s *SingleContextLogger) Warning(format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CWarningf(s.ctx, format, args...)
 }
-func (s *SingleContextLogger) CWarningf(ctx context.Context, format string, args ...interface{}) {
+func (s *SingleContextLogger) CWarningf(ctx context.Context, format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CWarningf(ctx, format, args...)
 }
-func (s *SingleContextLogger) Error(format string, args ...interface{}) {
+func (s *SingleContextLogger) Error(format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CErrorf(s.ctx, format, args...)
 }
-func (s *SingleContextLogger) Errorf(format string, args ...interface{}) {
+func (s *SingleContextLogger) Errorf(format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CErrorf(s.ctx, format, args...)
 }
-func (s *SingleContextLogger) CErrorf(ctx context.Context, format string, args ...interface{}) {
+func (s *SingleContextLogger) CErrorf(ctx context.Context, format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CErrorf(ctx, format, args...)
 }
-func (s *SingleContextLogger) Critical(format string, args ...interface{}) {
+func (s *SingleContextLogger) Critical(format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CCriticalf(s.ctx, format, args...)
 }
-func (s *SingleContextLogger) CCriticalf(ctx context.Context, format string, args ...interface{}) {
+func (s *SingleContextLogger) CCriticalf(ctx context.Context, format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CCriticalf(ctx, format, args...)
 }
-func (s *SingleContextLogger) Fatalf(format string, args ...interface{}) {
+func (s *SingleContextLogger) Fatalf(format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CFatalf(s.ctx, format, args...)
 }
-func (s *SingleContextLogger) CFatalf(ctx context.Context, format string, args ...interface{}) {
+func (s *SingleContextLogger) CFatalf(ctx context.Context, format string, args ...any) {
 	s.logger.CloneWithAddedDepth(1).CFatalf(ctx, format, args...)
 }
-func (s *SingleContextLogger) Profile(fmts string, arg ...interface{}) {
+func (s *SingleContextLogger) Profile(fmts string, arg ...any) {
 	s.logger.CloneWithAddedDepth(1).Profile(fmts, arg...)
 }
 func (s *SingleContextLogger) Configure(style string, debug bool, filename string) {

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -39,7 +39,7 @@ const (
 	CtxLogTagsKey CtxStandardLoggerKey = iota
 )
 
-type CtxLogTags map[interface{}]string
+type CtxLogTags map[any]string
 
 // NewContext returns a new Context that carries adds the given log
 // tag mappings (context key -> display string).
@@ -67,9 +67,9 @@ func LogTagsFromContext(ctx context.Context) (CtxLogTags, bool) {
 // LogTagsFromContextRPC is a wrapper around LogTagsFromContext
 // that simply casts the result to the type expected by
 // rpc.Connection.
-func LogTagsFromContextRPC(ctx context.Context) (map[interface{}]string, bool) {
+func LogTagsFromContextRPC(ctx context.Context) (map[any]string, bool) {
 	tags, ok := LogTagsFromContext(ctx)
-	return map[interface{}]string(tags), ok
+	return map[any]string(tags), ok
 }
 
 type rpcTagKey string
@@ -96,7 +96,7 @@ func ConvertRPCTagsToLogTags(ctx context.Context) context.Context {
 }
 
 type ExternalLogger interface {
-	Log(level keybase1.LogLevel, format string, args []interface{})
+	Log(level keybase1.LogLevel, format string, args []any)
 }
 
 type Standard struct {
@@ -159,7 +159,7 @@ func prepareString(
 	return fmts + " [tags:" + strings.Join(tags, ",") + "]"
 }
 
-func (log *Standard) Debug(fmt string, arg ...interface{}) {
+func (log *Standard) Debug(fmt string, arg ...any) {
 	log.internal.Debugf(fmt, arg...)
 	if log.externalHandler != nil {
 		log.externalHandler.Log(keybase1.LogLevel_DEBUG, fmt, arg)
@@ -167,13 +167,13 @@ func (log *Standard) Debug(fmt string, arg ...interface{}) {
 }
 
 func (log *Standard) CDebugf(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	if log.internal.IsEnabledFor(logging.DEBUG) {
 		log.CloneWithAddedDepth(1).Debug(prepareString(ctx, fmt), arg...)
 	}
 }
 
-func (log *Standard) Info(fmt string, arg ...interface{}) {
+func (log *Standard) Info(fmt string, arg ...any) {
 	log.internal.Infof(fmt, arg...)
 	if log.externalHandler != nil {
 		log.externalHandler.Log(keybase1.LogLevel_INFO, fmt, arg)
@@ -181,13 +181,13 @@ func (log *Standard) Info(fmt string, arg ...interface{}) {
 }
 
 func (log *Standard) CInfof(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	if log.internal.IsEnabledFor(logging.INFO) {
 		log.CloneWithAddedDepth(1).Info(prepareString(ctx, fmt), arg...)
 	}
 }
 
-func (log *Standard) Notice(fmt string, arg ...interface{}) {
+func (log *Standard) Notice(fmt string, arg ...any) {
 	log.internal.Noticef(fmt, arg...)
 	if log.externalHandler != nil {
 		log.externalHandler.Log(keybase1.LogLevel_NOTICE, fmt, arg)
@@ -195,13 +195,13 @@ func (log *Standard) Notice(fmt string, arg ...interface{}) {
 }
 
 func (log *Standard) CNoticef(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	if log.internal.IsEnabledFor(logging.NOTICE) {
 		log.CloneWithAddedDepth(1).Notice(prepareString(ctx, fmt), arg...)
 	}
 }
 
-func (log *Standard) Warning(fmt string, arg ...interface{}) {
+func (log *Standard) Warning(fmt string, arg ...any) {
 	log.internal.Warningf(fmt, arg...)
 	if log.externalHandler != nil {
 		log.externalHandler.Log(keybase1.LogLevel_WARN, fmt, arg)
@@ -209,31 +209,31 @@ func (log *Standard) Warning(fmt string, arg ...interface{}) {
 }
 
 func (log *Standard) CWarningf(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	if log.internal.IsEnabledFor(logging.WARNING) {
 		log.CloneWithAddedDepth(1).Warning(prepareString(ctx, fmt), arg...)
 	}
 }
 
-func (log *Standard) Error(fmt string, arg ...interface{}) {
+func (log *Standard) Error(fmt string, arg ...any) {
 	log.internal.Errorf(fmt, arg...)
 	if log.externalHandler != nil {
 		log.externalHandler.Log(keybase1.LogLevel_ERROR, fmt, arg)
 	}
 }
 
-func (log *Standard) Errorf(fmt string, arg ...interface{}) {
+func (log *Standard) Errorf(fmt string, arg ...any) {
 	log.CloneWithAddedDepth(1).Error(fmt, arg...)
 }
 
 func (log *Standard) CErrorf(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	if log.internal.IsEnabledFor(logging.ERROR) {
 		log.CloneWithAddedDepth(1).Error(prepareString(ctx, fmt), arg...)
 	}
 }
 
-func (log *Standard) Critical(fmt string, arg ...interface{}) {
+func (log *Standard) Critical(fmt string, arg ...any) {
 	log.internal.Criticalf(fmt, arg...)
 	if log.externalHandler != nil {
 		log.externalHandler.Log(keybase1.LogLevel_CRITICAL, fmt, arg)
@@ -241,13 +241,13 @@ func (log *Standard) Critical(fmt string, arg ...interface{}) {
 }
 
 func (log *Standard) CCriticalf(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	if log.internal.IsEnabledFor(logging.CRITICAL) {
 		log.CloneWithAddedDepth(1).Critical(prepareString(ctx, fmt), arg...)
 	}
 }
 
-func (log *Standard) Fatalf(fmt string, arg ...interface{}) {
+func (log *Standard) Fatalf(fmt string, arg ...any) {
 	log.internal.Fatalf(fmt, arg...)
 	if log.externalHandler != nil {
 		log.externalHandler.Log(keybase1.LogLevel_FATAL, fmt, arg)
@@ -255,11 +255,11 @@ func (log *Standard) Fatalf(fmt string, arg ...interface{}) {
 }
 
 func (log *Standard) CFatalf(ctx context.Context, fmt string,
-	arg ...interface{}) {
+	arg ...any) {
 	log.CloneWithAddedDepth(1).Fatalf(prepareString(ctx, fmt), arg...)
 }
 
-func (log *Standard) Profile(fmts string, arg ...interface{}) {
+func (log *Standard) Profile(fmts string, arg ...any) {
 	log.CloneWithAddedDepth(1).Debug(fmts, arg...)
 }
 
@@ -376,26 +376,26 @@ func (log *Standard) GetUnforwardedLogger() *UnforwardedLogger {
 	return (*UnforwardedLogger)(log)
 }
 
-func (log *UnforwardedLogger) Debug(s string, args ...interface{}) {
+func (log *UnforwardedLogger) Debug(s string, args ...any) {
 	log.internal.Debugf(s, args...)
 }
 
-func (log *UnforwardedLogger) Error(s string, args ...interface{}) {
+func (log *UnforwardedLogger) Error(s string, args ...any) {
 	log.internal.Errorf(s, args...)
 }
 
-func (log *UnforwardedLogger) Errorf(s string, args ...interface{}) {
+func (log *UnforwardedLogger) Errorf(s string, args ...any) {
 	log.internal.Errorf(s, args...)
 }
 
-func (log *UnforwardedLogger) Warning(s string, args ...interface{}) {
+func (log *UnforwardedLogger) Warning(s string, args ...any) {
 	log.internal.Warningf(s, args...)
 }
 
-func (log *UnforwardedLogger) Info(s string, args ...interface{}) {
+func (log *UnforwardedLogger) Info(s string, args ...any) {
 	log.internal.Infof(s, args...)
 }
 
-func (log *UnforwardedLogger) Profile(s string, args ...interface{}) {
+func (log *UnforwardedLogger) Profile(s string, args ...any) {
 	log.internal.Debugf(s, args...)
 }

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -20,12 +20,12 @@ import (
 // a *testing.T).  We define this in order to avoid pulling in the
 // "testing" package in exported code.
 type TestLogBackend interface {
-	Error(args ...interface{})
-	Errorf(format string, args ...interface{})
-	Fatal(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Log(args ...interface{})
-	Logf(format string, args ...interface{})
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Log(args ...any)
+	Logf(format string, args ...any)
 	Failed() bool
 	Name() string
 }
@@ -56,7 +56,7 @@ var globalFailReportedLock sync.Mutex
 var globalFailReported = make(map[string]struct{})
 
 // ctx can be `nil`
-func (log *TestLogger) common(ctx context.Context, lvl logging.Level, useFatal bool, fmts string, arg ...interface{}) {
+func (log *TestLogger) common(ctx context.Context, lvl logging.Level, useFatal bool, fmts string, arg ...any) {
 	if log.log.Failed() {
 		globalFailReportedLock.Lock()
 		name := log.log.Name()
@@ -108,74 +108,74 @@ func (log *TestLogger) prefixCaller(extraDepth int, lvl logging.Level, fmts stri
 		failed, fileLine, lvl, fmts)
 }
 
-func (log *TestLogger) Debug(fmts string, arg ...interface{}) {
+func (log *TestLogger) Debug(fmts string, arg ...any) {
 	log.common(context.TODO(), logging.DEBUG, false, fmts, arg...)
 }
 
 func (log *TestLogger) CDebugf(ctx context.Context, fmts string,
-	arg ...interface{}) {
+	arg ...any) {
 	log.common(ctx, logging.DEBUG, false, fmts, arg...)
 }
 
-func (log *TestLogger) Info(fmts string, arg ...interface{}) {
+func (log *TestLogger) Info(fmts string, arg ...any) {
 	log.common(context.TODO(), logging.INFO, false, fmts, arg...)
 }
 
 func (log *TestLogger) CInfof(ctx context.Context, fmts string,
-	arg ...interface{}) {
+	arg ...any) {
 	log.common(ctx, logging.INFO, false, fmts, arg...)
 }
 
-func (log *TestLogger) Notice(fmts string, arg ...interface{}) {
+func (log *TestLogger) Notice(fmts string, arg ...any) {
 	log.common(context.TODO(), logging.NOTICE, false, fmts, arg...)
 }
 
 func (log *TestLogger) CNoticef(ctx context.Context, fmts string,
-	arg ...interface{}) {
+	arg ...any) {
 	log.common(ctx, logging.NOTICE, false, fmts, arg...)
 }
 
-func (log *TestLogger) Warning(fmts string, arg ...interface{}) {
+func (log *TestLogger) Warning(fmts string, arg ...any) {
 	log.common(context.TODO(), logging.WARNING, false, fmts, arg...)
 }
 
 func (log *TestLogger) CWarningf(ctx context.Context, fmts string,
-	arg ...interface{}) {
+	arg ...any) {
 	log.common(ctx, logging.WARNING, false, fmts, arg...)
 }
 
-func (log *TestLogger) Error(fmts string, arg ...interface{}) {
+func (log *TestLogger) Error(fmts string, arg ...any) {
 	log.common(context.TODO(), logging.ERROR, false, fmts, arg...)
 }
 
-func (log *TestLogger) Errorf(fmts string, arg ...interface{}) {
+func (log *TestLogger) Errorf(fmts string, arg ...any) {
 	log.common(context.TODO(), logging.ERROR, false, fmts, arg...)
 }
 
 func (log *TestLogger) CErrorf(ctx context.Context, fmts string,
-	arg ...interface{}) {
+	arg ...any) {
 	log.common(ctx, logging.ERROR, false, fmts, arg...)
 }
 
-func (log *TestLogger) Critical(fmts string, arg ...interface{}) {
+func (log *TestLogger) Critical(fmts string, arg ...any) {
 	log.common(context.TODO(), logging.CRITICAL, false, fmts, arg...)
 }
 
 func (log *TestLogger) CCriticalf(ctx context.Context, fmts string,
-	arg ...interface{}) {
+	arg ...any) {
 	log.common(ctx, logging.CRITICAL, false, fmts, arg...)
 }
 
-func (log *TestLogger) Fatalf(fmts string, arg ...interface{}) {
+func (log *TestLogger) Fatalf(fmts string, arg ...any) {
 	log.common(context.TODO(), logging.CRITICAL, true, fmts, arg...)
 }
 
 func (log *TestLogger) CFatalf(ctx context.Context, fmts string,
-	arg ...interface{}) {
+	arg ...any) {
 	log.common(ctx, logging.CRITICAL, true, fmts, arg...)
 }
 
-func (log *TestLogger) Profile(fmts string, arg ...interface{}) {
+func (log *TestLogger) Profile(fmts string, arg ...any) {
 	log.common(context.TODO(), logging.CRITICAL, false, fmts, arg...)
 }
 

--- a/go/lru/disk_lru.go
+++ b/go/lru/disk_lru.go
@@ -20,7 +20,7 @@ type Pathable struct {
 
 type DiskLRUEntry struct {
 	Key          string
-	Value        interface{}
+	Value        any
 	Ctime        time.Time
 	LastAccessed time.Time
 }
@@ -160,7 +160,7 @@ func (d *DiskLRU) MaxSize() int {
 	return d.maxSize
 }
 
-func (d *DiskLRU) debug(ctx context.Context, lctx libkb.LRUContext, msg string, args ...interface{}) {
+func (d *DiskLRU) debug(ctx context.Context, lctx libkb.LRUContext, msg string, args ...any) {
 	lctx.GetLog().CDebugf(ctx, fmt.Sprintf("DiskLRU: %s(%d): ", d.name, d.version)+msg, args...)
 }
 
@@ -284,7 +284,7 @@ func (d *DiskLRU) removeEntry(ctx context.Context, lctx libkb.LRUContext, index 
 }
 
 func (d *DiskLRU) addEntry(ctx context.Context, lctx libkb.LRUContext, index *diskLRUIndex, key string,
-	value interface{}) (evicted *DiskLRUEntry, err error) {
+	value any) (evicted *DiskLRUEntry, err error) {
 
 	// Add the new item
 	index.Put(key)
@@ -324,7 +324,7 @@ func (d *DiskLRU) addEntry(ctx context.Context, lctx libkb.LRUContext, index *di
 	return evicted, nil
 }
 
-func (d *DiskLRU) Put(ctx context.Context, lctx libkb.LRUContext, key string, value interface{}) (evicted *DiskLRUEntry, err error) {
+func (d *DiskLRU) Put(ctx context.Context, lctx libkb.LRUContext, key string, value any) (evicted *DiskLRUEntry, err error) {
 	d.Lock()
 	defer d.Unlock()
 
@@ -442,7 +442,7 @@ func (d *DiskLRU) getPath(entry DiskLRUEntry) (res string, ok bool) {
 	if res, ok = entry.Value.(string); ok {
 		return res, ok
 	}
-	if _, ok = entry.Value.(map[string]interface{}); ok {
+	if _, ok = entry.Value.(map[string]any); ok {
 		var pathable Pathable
 		jstr, _ := json.Marshal(entry.Value)
 		_ = json.Unmarshal(jstr, &pathable)

--- a/go/lru/lru.go
+++ b/go/lru/lru.go
@@ -27,7 +27,7 @@ type stats struct {
 	miss      int
 }
 
-func NewLRU(ctx libkb.LRUContext, sz int, version int, exampleObj interface{}) *Cache {
+func NewLRU(ctx libkb.LRUContext, sz int, version int, exampleObj any) *Cache {
 	cache, err := lru.New(sz)
 	if err != nil {
 		ctx.GetLog().Fatalf("Bad LRU constructor: %s", err.Error())
@@ -49,7 +49,7 @@ func (c *Cache) ClearMemory() {
 	c.mem.Purge()
 }
 
-func (c *Cache) Get(ctx context.Context, lctx libkb.LRUContext, k libkb.LRUKeyer) (interface{}, error) {
+func (c *Cache) Get(ctx context.Context, lctx libkb.LRUContext, k libkb.LRUKeyer) (any, error) {
 	c.Lock()
 	defer c.Unlock()
 	val, ok := c.mem.Get(k.MemKey())
@@ -73,7 +73,7 @@ func (c *Cache) Get(ctx context.Context, lctx libkb.LRUContext, k libkb.LRUKeyer
 		lctx.GetVDebugLog().CLogf(ctx, libkb.VLog0, "lru(%v), old version: %d < %d", k.DbKey(), w.Version, c.version)
 		return nil, nil
 	}
-	var ret interface{}
+	var ret any
 	if len(w.Data) > 0 {
 		tmp := reflect.New(c.typ)
 		ret = tmp.Interface()
@@ -92,7 +92,7 @@ func (c *Cache) Get(ctx context.Context, lctx libkb.LRUContext, k libkb.LRUKeyer
 	return ret, nil
 }
 
-func (c *Cache) Put(ctx context.Context, lctx libkb.LRUContext, k libkb.LRUKeyer, v interface{}) error {
+func (c *Cache) Put(ctx context.Context, lctx libkb.LRUContext, k libkb.LRUKeyer, v any) error {
 	c.Lock()
 	defer c.Unlock()
 	var data string

--- a/go/merkle/types.go
+++ b/go/merkle/types.go
@@ -31,7 +31,7 @@ type EncodedLeaf []byte
 
 var _ merkletree.ValueConstructor = (*EncodedLeaf)(nil)
 
-func (l EncodedLeaf) Construct() interface{} {
+func (l EncodedLeaf) Construct() any {
 	return &[]byte{}
 }
 

--- a/go/merklestore/store.go
+++ b/go/merklestore/store.go
@@ -25,7 +25,7 @@ func (e MerkleStoreError) Error() string {
 	return fmt.Sprintf("MerkleStore: %s", e.msg)
 }
 
-func NewMerkleStoreError(msgf string, a ...interface{}) MerkleStoreError {
+func NewMerkleStoreError(msgf string, a ...any) MerkleStoreError {
 	return MerkleStoreError{msg: fmt.Sprintf(msgf, a...)}
 }
 

--- a/go/merkletree2/config.go
+++ b/go/merkletree2/config.go
@@ -38,7 +38,7 @@ type Config struct {
 
 	// ConstructValueContainer constructs a new empty value for the value in a KeyValuePair, so that the
 	// decoding routine has the correct type template.
-	ConstructValueContainer func() interface{}
+	ConstructValueContainer func() any
 }
 
 // NewConfig makes a new config object. It takes a a Hasher, logChildrenPerNode
@@ -47,7 +47,7 @@ type Config struct {
 // split into multiple nodes (at a lower level in the tree), keyByteLength the
 // length of the Keys which the tree will store, and a ConstructValueContainer function (so that
 // typed values can be pulled out of the Merkle Tree).
-func NewConfig(e Encoder, useBlindedValueHashes bool, logChildrenPerNode uint8, maxValuesPerLeaf int, keysByteLength int, constructValueFunc func() interface{}) (Config, error) {
+func NewConfig(e Encoder, useBlindedValueHashes bool, logChildrenPerNode uint8, maxValuesPerLeaf int, keysByteLength int, constructValueFunc func() any) (Config, error) {
 	childrenPerNode := 1 << logChildrenPerNode
 	if (keysByteLength*8)%int(logChildrenPerNode) != 0 {
 		return Config{}, NewInvalidConfigError("The key bit length does not divide logChildrenPerNode")
@@ -76,14 +76,14 @@ type KeySpecificSecret []byte
 // Encoder is an interface for cryptographically hashing MerkleTree data
 // structures. It also manages blinding secrets.
 type Encoder interface {
-	Decode(dest interface{}, src []byte) error
-	Encode(src interface{}) (dst []byte, err error)
+	Decode(dest any, src []byte) error
+	Encode(src any) (dst []byte, err error)
 	// takes as input a []byte pointer dst to avoid creating new objects
-	EncodeTo(o interface{}, dst *[]byte) (err error)
+	EncodeTo(o any, dst *[]byte) (err error)
 
-	EncodeAndHashGeneric(interface{}) (encoded []byte, hash Hash, err error)
+	EncodeAndHashGeneric(any) (encoded []byte, hash Hash, err error)
 	// takes as input an hash pointer ret to avoid creating new objects
-	HashGeneric(o interface{}, ret *Hash) error
+	HashGeneric(o any, ret *Hash) error
 
 	GenerateMasterSecret(Seqno) (MasterSecret, error)
 	ComputeKeySpecificSecret(MasterSecret, Key) KeySpecificSecret

--- a/go/merkletree2/encoders.go
+++ b/go/merkletree2/encoders.go
@@ -65,21 +65,21 @@ func NewUnsafeBlindedSHA512_256v1Encoder() *UnsafeBlindedSHA512_256v1Encoder {
 	return &UnsafeBlindedSHA512_256v1Encoder{enc: codec.NewEncoderBytes(nil, &mh), dec: codec.NewDecoderBytes(nil, &mh), sha: sha512.New512_256()}
 }
 
-func (e *UnsafeBlindedSHA512_256v1Encoder) EncodeTo(o interface{}, out *[]byte) (err error) {
+func (e *UnsafeBlindedSHA512_256v1Encoder) EncodeTo(o any, out *[]byte) (err error) {
 	e.enc.ResetBytes(out)
 	return e.enc.Encode(o)
 }
 
-func (e *UnsafeBlindedSHA512_256v1Encoder) Encode(o interface{}) (out []byte, err error) {
+func (e *UnsafeBlindedSHA512_256v1Encoder) Encode(o any) (out []byte, err error) {
 	return out, e.EncodeTo(o, &out)
 }
 
-func (e *UnsafeBlindedSHA512_256v1Encoder) Decode(dest interface{}, src []byte) error {
+func (e *UnsafeBlindedSHA512_256v1Encoder) Decode(dest any, src []byte) error {
 	e.dec.ResetBytes(src)
 	return e.dec.Decode(dest)
 }
 
-func (e *UnsafeBlindedSHA512_256v1Encoder) HashGeneric(o interface{}, ret *Hash) error {
+func (e *UnsafeBlindedSHA512_256v1Encoder) HashGeneric(o any, ret *Hash) error {
 	err := e.EncodeTo(o, &e.encBuf)
 	if err != nil {
 		return err
@@ -90,7 +90,7 @@ func (e *UnsafeBlindedSHA512_256v1Encoder) HashGeneric(o interface{}, ret *Hash)
 	return nil
 }
 
-func (e *UnsafeBlindedSHA512_256v1Encoder) EncodeAndHashGeneric(o interface{}) ([]byte, Hash, error) {
+func (e *UnsafeBlindedSHA512_256v1Encoder) EncodeAndHashGeneric(o any) ([]byte, Hash, error) {
 	enc, err := e.Encode(o)
 	if err != nil {
 		return nil, nil, err
@@ -124,19 +124,19 @@ func NewBlindedSHA512_256v1Encoder() *BlindedSHA512_256v1Encoder {
 	return &BlindedSHA512_256v1Encoder{mh: mh}
 }
 
-func (e *BlindedSHA512_256v1Encoder) EncodeTo(o interface{}, out *[]byte) (err error) {
+func (e *BlindedSHA512_256v1Encoder) EncodeTo(o any, out *[]byte) (err error) {
 	return codec.NewEncoderBytes(out, &e.mh).Encode(o)
 }
 
-func (e *BlindedSHA512_256v1Encoder) Encode(o interface{}) (out []byte, err error) {
+func (e *BlindedSHA512_256v1Encoder) Encode(o any) (out []byte, err error) {
 	return out, e.EncodeTo(o, &out)
 }
 
-func (e *BlindedSHA512_256v1Encoder) Decode(dest interface{}, src []byte) error {
+func (e *BlindedSHA512_256v1Encoder) Decode(dest any, src []byte) error {
 	return codec.NewDecoderBytes(src, &e.mh).Decode(dest)
 }
 
-func (e *BlindedSHA512_256v1Encoder) EncodeAndHashGeneric(o interface{}) ([]byte, Hash, error) {
+func (e *BlindedSHA512_256v1Encoder) EncodeAndHashGeneric(o any) ([]byte, Hash, error) {
 	enc, err := e.Encode(o)
 	if err != nil {
 		return nil, nil, err
@@ -147,7 +147,7 @@ func (e *BlindedSHA512_256v1Encoder) EncodeAndHashGeneric(o interface{}) ([]byte
 	return enc, hasher.Sum(nil), nil
 }
 
-func (e *BlindedSHA512_256v1Encoder) HashGeneric(o interface{}, ret *Hash) error {
+func (e *BlindedSHA512_256v1Encoder) HashGeneric(o any, ret *Hash) error {
 	enc, err := e.Encode(o)
 	if err != nil {
 		return err

--- a/go/merkletree2/interfaces.go
+++ b/go/merkletree2/interfaces.go
@@ -79,7 +79,7 @@ type StorageEngineWithBlinding interface {
 }
 
 // Transaction references a DB transaction.
-type Transaction interface{}
+type Transaction any
 
 type GetValueWithProofResponse struct {
 	_struct struct{}             `codec:",toarray"` //nolint

--- a/go/merkletree2/tree.go
+++ b/go/merkletree2/tree.go
@@ -99,9 +99,9 @@ type ChildIndex int
 // be of the same type returned by ValueConstructor in the TreeConfig, otherwise
 // the behavior is undefined.
 type KeyValuePair struct {
-	_struct struct{}    `codec:",toarray"` //nolint
-	Key     Key         `codec:"k"`
-	Value   interface{} `codec:"v"`
+	_struct struct{} `codec:",toarray"` //nolint
+	Key     Key      `codec:"k"`
+	Value   any      `codec:"v"`
 }
 
 type EncodedValue []byte

--- a/go/merkletree2/util_for_test.go
+++ b/go/merkletree2/util_for_test.go
@@ -108,11 +108,11 @@ type IdentityHasher struct{}
 
 var _ Encoder = IdentityHasher{}
 
-func (i IdentityHasher) Encode(o interface{}) (dst []byte, err error) {
+func (i IdentityHasher) Encode(o any) (dst []byte, err error) {
 	return dst, i.EncodeTo(o, &dst)
 }
 
-func (i IdentityHasher) EncodeTo(o interface{}, out *[]byte) (err error) {
+func (i IdentityHasher) EncodeTo(o any, out *[]byte) (err error) {
 	enc, err := msgpack.EncodeCanonical(o)
 	if err != nil {
 		return err
@@ -125,7 +125,7 @@ func (i IdentityHasher) GetEncodingType() EncodingType {
 	return EncodingTypeForTesting
 }
 
-func (i IdentityHasher) Decode(dest interface{}, src []byte) error {
+func (i IdentityHasher) Decode(dest any, src []byte) error {
 	return msgpack.Decode(dest, src)
 }
 
@@ -138,7 +138,7 @@ func (i IdentityHasher) HashKeyEncodedValuePairWithKeySpecificSecretTo(kevp KeyE
 	return err
 }
 
-func (i IdentityHasher) EncodeAndHashGeneric(o interface{}) ([]byte, Hash, error) {
+func (i IdentityHasher) EncodeAndHashGeneric(o any) ([]byte, Hash, error) {
 	enc, err := i.Encode(o)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Encoding error in IdentityHasher for %v: %v", o, err)
@@ -146,7 +146,7 @@ func (i IdentityHasher) EncodeAndHashGeneric(o interface{}) ([]byte, Hash, error
 	return enc, Hash(enc), nil
 }
 
-func (i IdentityHasher) HashGeneric(o interface{}, h *Hash) (err error) {
+func (i IdentityHasher) HashGeneric(o any, h *Hash) (err error) {
 	_, *h, err = i.EncodeAndHashGeneric(o)
 	return err
 }
@@ -179,7 +179,7 @@ func (i IdentityHasherBlinded) GetEncodingType() EncodingType {
 	return EncodingTypeForTesting
 }
 
-func (i IdentityHasherBlinded) EncodeAndHashGeneric(o interface{}) ([]byte, Hash, error) {
+func (i IdentityHasherBlinded) EncodeAndHashGeneric(o any) ([]byte, Hash, error) {
 	enc, err := msgpack.EncodeCanonical(o)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Msgpack error in IdentityHasher for %v: %v", o, err)
@@ -187,16 +187,16 @@ func (i IdentityHasherBlinded) EncodeAndHashGeneric(o interface{}) ([]byte, Hash
 	return enc, Hash(enc), nil
 }
 
-func (i IdentityHasherBlinded) HashGeneric(o interface{}, h *Hash) (err error) {
+func (i IdentityHasherBlinded) HashGeneric(o any, h *Hash) (err error) {
 	_, *h, err = i.EncodeAndHashGeneric(o)
 	return err
 }
 
-func (i IdentityHasherBlinded) Encode(o interface{}) (dst []byte, err error) {
+func (i IdentityHasherBlinded) Encode(o any) (dst []byte, err error) {
 	return dst, i.EncodeTo(o, &dst)
 }
 
-func (i IdentityHasherBlinded) EncodeTo(o interface{}, out *[]byte) (err error) {
+func (i IdentityHasherBlinded) EncodeTo(o any, out *[]byte) (err error) {
 	enc, err := msgpack.EncodeCanonical(o)
 	if err != nil {
 		return err
@@ -205,7 +205,7 @@ func (i IdentityHasherBlinded) EncodeTo(o interface{}, out *[]byte) (err error) 
 	return nil
 }
 
-func (i IdentityHasherBlinded) Decode(dest interface{}, src []byte) error {
+func (i IdentityHasherBlinded) Decode(dest any, src []byte) error {
 	return msgpack.Decode(dest, src)
 }
 
@@ -322,7 +322,7 @@ func makeRandomKVPFromKeysForTesting(keys []Key) ([]KeyValuePair, error) {
 	return kvps, nil
 }
 
-func ConstructStringValueContainer() interface{} {
+func ConstructStringValueContainer() any {
 	return ""
 }
 
@@ -334,11 +334,11 @@ func (e SHA512_256Encoder) GetEncodingType() EncodingType {
 	return EncodingTypeForTesting
 }
 
-func (e SHA512_256Encoder) Encode(o interface{}) (dst []byte, err error) {
+func (e SHA512_256Encoder) Encode(o any) (dst []byte, err error) {
 	return dst, e.EncodeTo(o, &dst)
 }
 
-func (e SHA512_256Encoder) EncodeTo(o interface{}, out *[]byte) (err error) {
+func (e SHA512_256Encoder) EncodeTo(o any, out *[]byte) (err error) {
 	enc, err := msgpack.EncodeCanonical(o)
 	if err != nil {
 		return err
@@ -347,11 +347,11 @@ func (e SHA512_256Encoder) EncodeTo(o interface{}, out *[]byte) (err error) {
 	return nil
 }
 
-func (e SHA512_256Encoder) Decode(dest interface{}, src []byte) error {
+func (e SHA512_256Encoder) Decode(dest any, src []byte) error {
 	return msgpack.Decode(dest, src)
 }
 
-func (e SHA512_256Encoder) EncodeAndHashGeneric(o interface{}) ([]byte, Hash, error) {
+func (e SHA512_256Encoder) EncodeAndHashGeneric(o any) ([]byte, Hash, error) {
 	enc, err := e.Encode(o)
 	if err != nil {
 		return nil, nil, err
@@ -364,7 +364,7 @@ func (e SHA512_256Encoder) EncodeAndHashGeneric(o interface{}) ([]byte, Hash, er
 	return enc, hasher.Sum(nil), nil
 }
 
-func (e SHA512_256Encoder) HashGeneric(o interface{}, h *Hash) (err error) {
+func (e SHA512_256Encoder) HashGeneric(o any, h *Hash) (err error) {
 	_, *h, err = e.EncodeAndHashGeneric(o)
 	return err
 }

--- a/go/mounter/mounter.go
+++ b/go/mounter/mounter.go
@@ -5,7 +5,7 @@ package mounter
 
 // Log is the logging interface for this package
 type Log interface {
-	Debug(s string, args ...interface{})
-	Info(s string, args ...interface{})
-	Errorf(s string, args ...interface{})
+	Debug(s string, args ...any)
+	Info(s string, args ...any)
+	Errorf(s string, args ...any)
 }

--- a/go/msgpack/msgpack.go
+++ b/go/msgpack/msgpack.go
@@ -10,19 +10,19 @@ import (
 	"github.com/keybase/go-codec/codec"
 )
 
-func EncodeCanonical(src interface{}) (dst []byte, err error) {
+func EncodeCanonical(src any) (dst []byte, err error) {
 	ch := kbcrypto.CodecHandle()
 	ch.Canonical = true
 	err = codec.NewEncoderBytes(&dst, ch).Encode(src)
 	return dst, err
 }
 
-func Decode(dst interface{}, src []byte) (err error) {
+func Decode(dst any, src []byte) (err error) {
 	ch := kbcrypto.CodecHandle()
 	return codec.NewDecoderBytes(src, ch).Decode(dst)
 }
 
-func Encode(src interface{}) (dst []byte, err error) {
+func Encode(src any) (dst []byte, err error) {
 	ch := kbcrypto.CodecHandle()
 	err = codec.NewEncoderBytes(&dst, ch).Encode(src)
 	return dst, err
@@ -30,7 +30,7 @@ func Encode(src interface{}) (dst []byte, err error) {
 
 // Decode data into out, but make sure that all bytes in data are
 // used.
-func DecodeAll(data []byte, handle *codec.MsgpackHandle, out interface{}) error {
+func DecodeAll(data []byte, handle *codec.MsgpackHandle, out any) error {
 	decoder := codec.NewDecoderBytes(data, handle)
 	err := decoder.Decode(out)
 	if err != nil {

--- a/go/offline/rpc_cache.go
+++ b/go/offline/rpc_cache.go
@@ -47,10 +47,10 @@ func NewRPCCache(g *libkb.GlobalContext) *RPCCache {
 type hashStruct struct {
 	UID     keybase1.UID
 	RPCName string
-	Arg     interface{}
+	Arg     any
 }
 
-func hash(rpcName string, uid keybase1.UID, arg interface{}) ([]byte, error) {
+func hash(rpcName string, uid keybase1.UID, arg any) ([]byte, error) {
 	h := sha256.New()
 	raw, err := msgpack.Encode(hashStruct{uid, rpcName, arg})
 	if err != nil {
@@ -63,7 +63,7 @@ func hash(rpcName string, uid keybase1.UID, arg interface{}) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-func dbKey(rpcName string, uid keybase1.UID, arg interface{}) (libkb.DbKey,
+func dbKey(rpcName string, uid keybase1.UID, arg any) (libkb.DbKey,
 	error) {
 	raw, err := hash(rpcName, uid, arg)
 	if err != nil {
@@ -83,7 +83,7 @@ type Value struct {
 	Data    []byte
 }
 
-func (c *RPCCache) get(mctx libkb.MetaContext, version Version, rpcName string, encrypted bool, arg interface{}, res interface{}) (found bool, err error) {
+func (c *RPCCache) get(mctx libkb.MetaContext, version Version, rpcName string, encrypted bool, arg any, res any) (found bool, err error) {
 	defer mctx.Trace(fmt.Sprintf("RPCCache#get(%d, %s, %v, %+v)", version, rpcName, encrypted, arg), &err)()
 	c.Lock()
 	defer c.Unlock()
@@ -116,7 +116,7 @@ func (c *RPCCache) get(mctx libkb.MetaContext, version Version, rpcName string, 
 	return true, nil
 }
 
-func (c *RPCCache) put(mctx libkb.MetaContext, version Version, rpcName string, encrypted bool, arg interface{}, res interface{}) (err error) {
+func (c *RPCCache) put(mctx libkb.MetaContext, version Version, rpcName string, encrypted bool, arg any, res any) (err error) {
 	defer mctx.Trace(fmt.Sprintf("RPCCache#put(%d, %s, %v, %+v)", version, rpcName, encrypted, arg), &err)()
 	c.Lock()
 	defer c.Unlock()
@@ -156,8 +156,8 @@ func (c *RPCCache) put(mctx libkb.MetaContext, version Version, rpcName string, 
 // If this function doesn't return an error, and the returned `res` is
 // nil, then `resPtr` will have been filled in already by the cache.
 // Otherwise, `res` should be used by the caller as the response.
-func (c *RPCCache) Serve(mctx libkb.MetaContext, oa keybase1.OfflineAvailability, version Version, rpcName string, encrypted bool, arg interface{}, resPtr interface{},
-	handler func(mctx libkb.MetaContext) (interface{}, error)) (res interface{}, err error) {
+func (c *RPCCache) Serve(mctx libkb.MetaContext, oa keybase1.OfflineAvailability, version Version, rpcName string, encrypted bool, arg any, resPtr any,
+	handler func(mctx libkb.MetaContext) (any, error)) (res any, err error) {
 
 	if oa != keybase1.OfflineAvailability_BEST_EFFORT {
 		return handler(mctx)
@@ -181,7 +181,7 @@ func (c *RPCCache) Serve(mctx libkb.MetaContext, oa keybase1.OfflineAvailability
 	}
 
 	type handlerRes struct {
-		res interface{}
+		res any
 		err error
 	}
 	resCh := make(chan handlerRes, 1)

--- a/go/offline/rpc_cache_test.go
+++ b/go/offline/rpc_cache_test.go
@@ -22,8 +22,8 @@ func TestRPCCacheBestEffort(t *testing.T) {
 	rpcCache := NewRPCCache(tc.G)
 
 	inHandlerCh := make(chan struct{}, 1)
-	handlerCh := make(chan interface{}, 1)
-	handler := func(mctx libkb.MetaContext) (interface{}, error) {
+	handlerCh := make(chan any, 1)
+	handler := func(mctx libkb.MetaContext) (any, error) {
 		inHandlerCh <- struct{}{}
 		return <-handlerCh, nil
 	}
@@ -60,7 +60,7 @@ func TestRPCCacheBestEffort(t *testing.T) {
 	t.Log("Read via the cache, when connected but the handler is slow")
 	var res3 int
 	resp3 := &res3
-	var servedRes3 interface{}
+	var servedRes3 any
 	errCh := make(chan error)
 	go func() {
 		var err error

--- a/go/profiling/timetracer.go
+++ b/go/profiling/timetracer.go
@@ -11,7 +11,7 @@ import (
 )
 
 type TimeTracer interface {
-	Stage(format string, args ...interface{})
+	Stage(format string, args ...any)
 	Finish()
 }
 
@@ -46,7 +46,7 @@ func (t *TimeTracerImpl) finishStage() {
 	t.log.CDebugf(t.ctx, "| %s:%s [time=%s]", t.label, t.stage, t.clock.Since(t.prev))
 }
 
-func (t *TimeTracerImpl) Stage(format string, args ...interface{}) {
+func (t *TimeTracerImpl) Stage(format string, args ...any) {
 	t.Lock()
 	defer t.Unlock()
 	t.finishStage()
@@ -70,6 +70,6 @@ func NewSilentTimeTracer() *SilentTimeTracer {
 	return &SilentTimeTracer{}
 }
 
-func (t *SilentTimeTracer) Stage(format string, args ...interface{}) {}
+func (t *SilentTimeTracer) Stage(format string, args ...any) {}
 
 func (t *SilentTimeTracer) Finish() {}

--- a/go/protocol/chat1/blocking.go
+++ b/go/protocol/chat1/blocking.go
@@ -25,11 +25,11 @@ func BlockingProtocol(i BlockingInterface) rpc.Protocol {
 		Name: "chat.1.blocking",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"blockConversations": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BlockConversationsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BlockConversationsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BlockConversationsArg)(nil), args)
@@ -48,6 +48,6 @@ type BlockingClient struct {
 }
 
 func (c BlockingClient) BlockConversations(ctx context.Context, __arg BlockConversationsArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.blocking.blockConversations", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.blocking.blockConversations", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -3215,11 +3215,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 		Name: "chat.1.chatUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"chatInboxLayout": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatInboxLayoutArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatInboxLayoutArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatInboxLayoutArg)(nil), args)
@@ -3230,11 +3230,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatInboxUnverified": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatInboxUnverifiedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatInboxUnverifiedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatInboxUnverifiedArg)(nil), args)
@@ -3245,11 +3245,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatInboxConversation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatInboxConversationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatInboxConversationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatInboxConversationArg)(nil), args)
@@ -3260,11 +3260,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatInboxFailed": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatInboxFailedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatInboxFailedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatInboxFailedArg)(nil), args)
@@ -3275,11 +3275,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatThreadCached": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatThreadCachedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatThreadCachedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatThreadCachedArg)(nil), args)
@@ -3290,11 +3290,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatThreadFull": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatThreadFullArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatThreadFullArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatThreadFullArg)(nil), args)
@@ -3305,11 +3305,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatThreadStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatThreadStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatThreadStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatThreadStatusArg)(nil), args)
@@ -3320,11 +3320,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatSearchHit": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSearchHitArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSearchHitArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSearchHitArg)(nil), args)
@@ -3335,11 +3335,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatSearchDone": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSearchDoneArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSearchDoneArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSearchDoneArg)(nil), args)
@@ -3350,11 +3350,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatSearchInboxStart": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSearchInboxStartArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSearchInboxStartArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSearchInboxStartArg)(nil), args)
@@ -3365,11 +3365,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatSearchInboxHit": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSearchInboxHitArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSearchInboxHitArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSearchInboxHitArg)(nil), args)
@@ -3380,11 +3380,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatSearchInboxDone": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSearchInboxDoneArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSearchInboxDoneArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSearchInboxDoneArg)(nil), args)
@@ -3395,11 +3395,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatSearchIndexStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSearchIndexStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSearchIndexStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSearchIndexStatusArg)(nil), args)
@@ -3410,11 +3410,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatSearchConvHits": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSearchConvHitsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSearchConvHitsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSearchConvHitsArg)(nil), args)
@@ -3425,11 +3425,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatSearchTeamHits": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSearchTeamHitsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSearchTeamHitsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSearchTeamHitsArg)(nil), args)
@@ -3440,11 +3440,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatSearchBotHits": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSearchBotHitsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSearchBotHitsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSearchBotHitsArg)(nil), args)
@@ -3455,11 +3455,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatConfirmChannelDelete": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatConfirmChannelDeleteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatConfirmChannelDeleteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatConfirmChannelDeleteArg)(nil), args)
@@ -3470,11 +3470,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatStellarShowConfirm": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatStellarShowConfirmArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatStellarShowConfirmArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatStellarShowConfirmArg)(nil), args)
@@ -3485,11 +3485,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatStellarDataConfirm": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatStellarDataConfirmArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatStellarDataConfirmArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatStellarDataConfirmArg)(nil), args)
@@ -3500,11 +3500,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatStellarDataError": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatStellarDataErrorArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatStellarDataErrorArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatStellarDataErrorArg)(nil), args)
@@ -3515,11 +3515,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatStellarDone": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatStellarDoneArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatStellarDoneArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatStellarDoneArg)(nil), args)
@@ -3530,11 +3530,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatGiphySearchResults": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatGiphySearchResultsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatGiphySearchResultsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatGiphySearchResultsArg)(nil), args)
@@ -3545,11 +3545,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatGiphyToggleResultWindow": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatGiphyToggleResultWindowArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatGiphyToggleResultWindowArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatGiphyToggleResultWindowArg)(nil), args)
@@ -3560,11 +3560,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatShowManageChannels": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatShowManageChannelsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatShowManageChannelsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatShowManageChannelsArg)(nil), args)
@@ -3575,11 +3575,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatCoinFlipStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatCoinFlipStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatCoinFlipStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatCoinFlipStatusArg)(nil), args)
@@ -3590,11 +3590,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatCommandMarkdown": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatCommandMarkdownArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatCommandMarkdownArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatCommandMarkdownArg)(nil), args)
@@ -3605,11 +3605,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatMaybeMentionUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatMaybeMentionUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatMaybeMentionUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatMaybeMentionUpdateArg)(nil), args)
@@ -3620,11 +3620,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatLoadGalleryHit": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatLoadGalleryHitArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatLoadGalleryHitArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatLoadGalleryHitArg)(nil), args)
@@ -3635,11 +3635,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatWatchPosition": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatWatchPositionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatWatchPositionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatWatchPositionArg)(nil), args)
@@ -3650,11 +3650,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatClearWatch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatClearWatchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatClearWatchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatClearWatchArg)(nil), args)
@@ -3665,11 +3665,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatCommandStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatCommandStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatCommandStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatCommandStatusArg)(nil), args)
@@ -3680,11 +3680,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"chatBotCommandsUpdateStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatBotCommandsUpdateStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatBotCommandsUpdateStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatBotCommandsUpdateStatusArg)(nil), args)
@@ -3695,11 +3695,11 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 			},
 			"triggerContactSync": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TriggerContactSyncArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TriggerContactSyncArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TriggerContactSyncArg)(nil), args)
@@ -3718,169 +3718,169 @@ type ChatUiClient struct {
 }
 
 func (c ChatUiClient) ChatInboxLayout(ctx context.Context, __arg ChatInboxLayoutArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxLayout", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxLayout", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatInboxUnverified(ctx context.Context, __arg ChatInboxUnverifiedArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxUnverified", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxUnverified", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatInboxConversation(ctx context.Context, __arg ChatInboxConversationArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxConversation", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxConversation", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatInboxFailed(ctx context.Context, __arg ChatInboxFailedArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxFailed", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxFailed", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatThreadCached(ctx context.Context, __arg ChatThreadCachedArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatThreadCached", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatThreadCached", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatThreadFull(ctx context.Context, __arg ChatThreadFullArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatThreadFull", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatThreadFull", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatThreadStatus(ctx context.Context, __arg ChatThreadStatusArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatThreadStatus", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatThreadStatus", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatSearchHit(ctx context.Context, __arg ChatSearchHitArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchHit", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchHit", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatSearchDone(ctx context.Context, __arg ChatSearchDoneArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchDone", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchDone", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatSearchInboxStart(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatSearchInboxStartArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchInboxStart", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchInboxStart", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatSearchInboxHit(ctx context.Context, __arg ChatSearchInboxHitArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchInboxHit", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchInboxHit", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatSearchInboxDone(ctx context.Context, __arg ChatSearchInboxDoneArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchInboxDone", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchInboxDone", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatSearchIndexStatus(ctx context.Context, __arg ChatSearchIndexStatusArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchIndexStatus", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchIndexStatus", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatSearchConvHits(ctx context.Context, __arg ChatSearchConvHitsArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchConvHits", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchConvHits", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatSearchTeamHits(ctx context.Context, __arg ChatSearchTeamHitsArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchTeamHits", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchTeamHits", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatSearchBotHits(ctx context.Context, __arg ChatSearchBotHitsArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchBotHits", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatSearchBotHits", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatConfirmChannelDelete(ctx context.Context, __arg ChatConfirmChannelDeleteArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatConfirmChannelDelete", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatConfirmChannelDelete", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatStellarShowConfirm(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatStellarShowConfirmArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatStellarShowConfirm", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatStellarShowConfirm", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatStellarDataConfirm(ctx context.Context, __arg ChatStellarDataConfirmArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatStellarDataConfirm", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatStellarDataConfirm", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatStellarDataError(ctx context.Context, __arg ChatStellarDataErrorArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatStellarDataError", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatStellarDataError", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatStellarDone(ctx context.Context, __arg ChatStellarDoneArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatStellarDone", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatStellarDone", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatGiphySearchResults(ctx context.Context, __arg ChatGiphySearchResultsArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatGiphySearchResults", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatGiphySearchResults", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatGiphyToggleResultWindow(ctx context.Context, __arg ChatGiphyToggleResultWindowArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatGiphyToggleResultWindow", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatGiphyToggleResultWindow", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatShowManageChannels(ctx context.Context, __arg ChatShowManageChannelsArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatShowManageChannels", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatShowManageChannels", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatCoinFlipStatus(ctx context.Context, __arg ChatCoinFlipStatusArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatCoinFlipStatus", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatCoinFlipStatus", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatCommandMarkdown(ctx context.Context, __arg ChatCommandMarkdownArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatCommandMarkdown", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatCommandMarkdown", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatMaybeMentionUpdate(ctx context.Context, __arg ChatMaybeMentionUpdateArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatMaybeMentionUpdate", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatMaybeMentionUpdate", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatLoadGalleryHit(ctx context.Context, __arg ChatLoadGalleryHitArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatLoadGalleryHit", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatLoadGalleryHit", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatWatchPosition(ctx context.Context, __arg ChatWatchPositionArg) (res LocationWatchID, err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatWatchPosition", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatWatchPosition", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatClearWatch(ctx context.Context, __arg ChatClearWatchArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatClearWatch", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatClearWatch", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatCommandStatus(ctx context.Context, __arg ChatCommandStatusArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatCommandStatus", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatCommandStatus", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) ChatBotCommandsUpdateStatus(ctx context.Context, __arg ChatBotCommandsUpdateStatusArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatBotCommandsUpdateStatus", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatBotCommandsUpdateStatus", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ChatUiClient) TriggerContactSync(ctx context.Context, sessionID int) (err error) {
 	__arg := TriggerContactSyncArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "chat.1.chatUi.triggerContactSync", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.chatUi.triggerContactSync", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -586,9 +586,9 @@ func (m MessageUnboxed) IsJourneycard() bool {
 }
 
 // IsValidFull returns whether the message is both:
-// 1. Valid
-// 2. Has a non-deleted body with a type matching the header
-//    (TLFNAME is an exception as it has no body)
+//  1. Valid
+//  2. Has a non-deleted body with a type matching the header
+//     (TLFNAME is an exception as it has no body)
 func (m MessageUnboxed) IsValidFull() bool {
 	if !m.IsValid() {
 		return false
@@ -1281,7 +1281,7 @@ var ConversationStatusGregorRevMap = map[string]ConversationStatus{
 }
 
 var sha256Pool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return sha256.New()
 	},
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -7373,11 +7373,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 		Name: "chat.1.local",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getThreadLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetThreadLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetThreadLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetThreadLocalArg)(nil), args)
@@ -7388,11 +7388,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getThreadNonblock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetThreadNonblockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetThreadNonblockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetThreadNonblockArg)(nil), args)
@@ -7403,11 +7403,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getUnreadline": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUnreadlineArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetUnreadlineArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetUnreadlineArg)(nil), args)
@@ -7418,11 +7418,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getInboxAndUnboxLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetInboxAndUnboxLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetInboxAndUnboxLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetInboxAndUnboxLocalArg)(nil), args)
@@ -7433,11 +7433,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getInboxAndUnboxUILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetInboxAndUnboxUILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetInboxAndUnboxUILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetInboxAndUnboxUILocalArg)(nil), args)
@@ -7448,11 +7448,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"requestInboxLayout": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RequestInboxLayoutArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RequestInboxLayoutArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RequestInboxLayoutArg)(nil), args)
@@ -7463,11 +7463,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"requestInboxUnbox": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RequestInboxUnboxArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RequestInboxUnboxArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RequestInboxUnboxArg)(nil), args)
@@ -7478,31 +7478,31 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"requestInboxSmallIncrease": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RequestInboxSmallIncreaseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RequestInboxSmallIncrease(ctx)
 					return
 				},
 			},
 			"requestInboxSmallReset": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RequestInboxSmallResetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RequestInboxSmallReset(ctx)
 					return
 				},
 			},
 			"getInboxNonblockLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetInboxNonblockLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetInboxNonblockLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetInboxNonblockLocalArg)(nil), args)
@@ -7513,11 +7513,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostLocalArg)(nil), args)
@@ -7528,21 +7528,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"generateOutboxID": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GenerateOutboxIDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GenerateOutboxID(ctx)
 					return
 				},
 			},
 			"postLocalNonblock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostLocalNonblockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostLocalNonblockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostLocalNonblockArg)(nil), args)
@@ -7553,11 +7553,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"forwardMessage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ForwardMessageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ForwardMessageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ForwardMessageArg)(nil), args)
@@ -7568,11 +7568,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"forwardMessageNonblock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ForwardMessageNonblockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ForwardMessageNonblockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ForwardMessageNonblockArg)(nil), args)
@@ -7583,11 +7583,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postTextNonblock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostTextNonblockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostTextNonblockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostTextNonblockArg)(nil), args)
@@ -7598,11 +7598,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postDeleteNonblock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostDeleteNonblockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostDeleteNonblockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostDeleteNonblockArg)(nil), args)
@@ -7613,11 +7613,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postEditNonblock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostEditNonblockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostEditNonblockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostEditNonblockArg)(nil), args)
@@ -7628,11 +7628,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postReactionNonblock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostReactionNonblockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostReactionNonblockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostReactionNonblockArg)(nil), args)
@@ -7643,11 +7643,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postHeadlineNonblock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostHeadlineNonblockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostHeadlineNonblockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostHeadlineNonblockArg)(nil), args)
@@ -7658,11 +7658,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postHeadline": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostHeadlineArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostHeadlineArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostHeadlineArg)(nil), args)
@@ -7673,11 +7673,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postMetadataNonblock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostMetadataNonblockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostMetadataNonblockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostMetadataNonblockArg)(nil), args)
@@ -7688,11 +7688,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postMetadata": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostMetadataArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostMetadataArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostMetadataArg)(nil), args)
@@ -7703,11 +7703,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postDeleteHistoryUpto": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostDeleteHistoryUptoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostDeleteHistoryUptoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostDeleteHistoryUptoArg)(nil), args)
@@ -7718,11 +7718,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postDeleteHistoryThrough": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostDeleteHistoryThroughArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostDeleteHistoryThroughArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostDeleteHistoryThroughArg)(nil), args)
@@ -7733,11 +7733,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postDeleteHistoryByAge": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostDeleteHistoryByAgeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostDeleteHistoryByAgeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostDeleteHistoryByAgeArg)(nil), args)
@@ -7748,11 +7748,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"SetConversationStatusLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetConversationStatusLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetConversationStatusLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetConversationStatusLocalArg)(nil), args)
@@ -7763,11 +7763,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"newConversationsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NewConversationsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NewConversationsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NewConversationsLocalArg)(nil), args)
@@ -7778,11 +7778,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"newConversationLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NewConversationLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NewConversationLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NewConversationLocalArg)(nil), args)
@@ -7793,11 +7793,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getInboxSummaryForCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetInboxSummaryForCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetInboxSummaryForCLILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetInboxSummaryForCLILocalArg)(nil), args)
@@ -7808,11 +7808,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getConversationForCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetConversationForCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetConversationForCLILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetConversationForCLILocalArg)(nil), args)
@@ -7823,11 +7823,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"GetMessagesLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetMessagesLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetMessagesLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetMessagesLocalArg)(nil), args)
@@ -7838,11 +7838,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postFileAttachmentLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostFileAttachmentLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostFileAttachmentLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostFileAttachmentLocalArg)(nil), args)
@@ -7853,11 +7853,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"postFileAttachmentLocalNonblock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostFileAttachmentLocalNonblockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostFileAttachmentLocalNonblockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostFileAttachmentLocalNonblockArg)(nil), args)
@@ -7868,11 +7868,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getNextAttachmentMessageLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetNextAttachmentMessageLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetNextAttachmentMessageLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetNextAttachmentMessageLocalArg)(nil), args)
@@ -7883,11 +7883,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"DownloadAttachmentLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DownloadAttachmentLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DownloadAttachmentLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DownloadAttachmentLocalArg)(nil), args)
@@ -7898,11 +7898,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"DownloadFileAttachmentLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DownloadFileAttachmentLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DownloadFileAttachmentLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DownloadFileAttachmentLocalArg)(nil), args)
@@ -7913,11 +7913,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"ConfigureFileAttachmentDownloadLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ConfigureFileAttachmentDownloadLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ConfigureFileAttachmentDownloadLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ConfigureFileAttachmentDownloadLocalArg)(nil), args)
@@ -7928,11 +7928,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"makePreview": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MakePreviewArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MakePreviewArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MakePreviewArg)(nil), args)
@@ -7943,11 +7943,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"makeAudioPreview": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MakeAudioPreviewArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MakeAudioPreviewArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MakeAudioPreviewArg)(nil), args)
@@ -7958,11 +7958,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getUploadTempFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUploadTempFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetUploadTempFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetUploadTempFileArg)(nil), args)
@@ -7973,11 +7973,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"makeUploadTempFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MakeUploadTempFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MakeUploadTempFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MakeUploadTempFileArg)(nil), args)
@@ -7988,11 +7988,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"cancelUploadTempFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CancelUploadTempFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CancelUploadTempFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CancelUploadTempFileArg)(nil), args)
@@ -8003,11 +8003,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"CancelPost": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CancelPostArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CancelPostArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CancelPostArg)(nil), args)
@@ -8018,11 +8018,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"RetryPost": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RetryPostArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RetryPostArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RetryPostArg)(nil), args)
@@ -8033,11 +8033,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"markAsReadLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MarkAsReadLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MarkAsReadLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MarkAsReadLocalArg)(nil), args)
@@ -8048,11 +8048,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"markTLFAsReadLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MarkTLFAsReadLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MarkTLFAsReadLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MarkTLFAsReadLocalArg)(nil), args)
@@ -8063,11 +8063,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"findConversationsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FindConversationsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FindConversationsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FindConversationsLocalArg)(nil), args)
@@ -8078,11 +8078,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"findGeneralConvFromTeamID": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FindGeneralConvFromTeamIDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FindGeneralConvFromTeamIDArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FindGeneralConvFromTeamIDArg)(nil), args)
@@ -8093,11 +8093,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"updateTyping": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpdateTypingArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpdateTypingArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpdateTypingArg)(nil), args)
@@ -8108,11 +8108,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"updateUnsentText": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpdateUnsentTextArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpdateUnsentTextArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpdateUnsentTextArg)(nil), args)
@@ -8123,11 +8123,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"joinConversationLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]JoinConversationLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]JoinConversationLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]JoinConversationLocalArg)(nil), args)
@@ -8138,11 +8138,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"joinConversationByIDLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]JoinConversationByIDLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]JoinConversationByIDLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]JoinConversationByIDLocalArg)(nil), args)
@@ -8153,11 +8153,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"leaveConversationLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LeaveConversationLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LeaveConversationLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LeaveConversationLocalArg)(nil), args)
@@ -8168,11 +8168,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"previewConversationByIDLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PreviewConversationByIDLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PreviewConversationByIDLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PreviewConversationByIDLocalArg)(nil), args)
@@ -8183,11 +8183,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"deleteConversationLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteConversationLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteConversationLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteConversationLocalArg)(nil), args)
@@ -8198,11 +8198,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"removeFromConversationLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RemoveFromConversationLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RemoveFromConversationLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RemoveFromConversationLocalArg)(nil), args)
@@ -8213,11 +8213,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getTLFConversationsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTLFConversationsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTLFConversationsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTLFConversationsLocalArg)(nil), args)
@@ -8228,11 +8228,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getChannelMembershipsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetChannelMembershipsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetChannelMembershipsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetChannelMembershipsLocalArg)(nil), args)
@@ -8243,11 +8243,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getMutualTeamsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetMutualTeamsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetMutualTeamsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetMutualTeamsLocalArg)(nil), args)
@@ -8258,11 +8258,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setAppNotificationSettingsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetAppNotificationSettingsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetAppNotificationSettingsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetAppNotificationSettingsLocalArg)(nil), args)
@@ -8273,11 +8273,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setGlobalAppNotificationSettingsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetGlobalAppNotificationSettingsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetGlobalAppNotificationSettingsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetGlobalAppNotificationSettingsLocalArg)(nil), args)
@@ -8288,21 +8288,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getGlobalAppNotificationSettingsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetGlobalAppNotificationSettingsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetGlobalAppNotificationSettingsLocal(ctx)
 					return
 				},
 			},
 			"unboxMobilePushNotification": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UnboxMobilePushNotificationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UnboxMobilePushNotificationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UnboxMobilePushNotificationArg)(nil), args)
@@ -8313,11 +8313,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"addTeamMemberAfterReset": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AddTeamMemberAfterResetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AddTeamMemberAfterResetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AddTeamMemberAfterResetArg)(nil), args)
@@ -8328,21 +8328,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getAllResetConvMembers": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetAllResetConvMembersArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetAllResetConvMembers(ctx)
 					return
 				},
 			},
 			"setConvRetentionLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetConvRetentionLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetConvRetentionLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetConvRetentionLocalArg)(nil), args)
@@ -8353,11 +8353,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setTeamRetentionLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetTeamRetentionLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetTeamRetentionLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetTeamRetentionLocalArg)(nil), args)
@@ -8368,11 +8368,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getTeamRetentionLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamRetentionLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamRetentionLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamRetentionLocalArg)(nil), args)
@@ -8383,11 +8383,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setConvMinWriterRoleLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetConvMinWriterRoleLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetConvMinWriterRoleLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetConvMinWriterRoleLocalArg)(nil), args)
@@ -8398,11 +8398,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"upgradeKBFSConversationToImpteam": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpgradeKBFSConversationToImpteamArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpgradeKBFSConversationToImpteamArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpgradeKBFSConversationToImpteamArg)(nil), args)
@@ -8413,11 +8413,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"searchRegexp": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SearchRegexpArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SearchRegexpArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SearchRegexpArg)(nil), args)
@@ -8428,21 +8428,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"cancelActiveInboxSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CancelActiveInboxSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.CancelActiveInboxSearch(ctx)
 					return
 				},
 			},
 			"searchInbox": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SearchInboxArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SearchInboxArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SearchInboxArg)(nil), args)
@@ -8453,11 +8453,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"simpleSearchInboxConvNames": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleSearchInboxConvNamesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleSearchInboxConvNamesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleSearchInboxConvNamesArg)(nil), args)
@@ -8468,21 +8468,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"cancelActiveSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CancelActiveSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.CancelActiveSearch(ctx)
 					return
 				},
 			},
 			"profileChatSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ProfileChatSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ProfileChatSearchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ProfileChatSearchArg)(nil), args)
@@ -8493,21 +8493,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getStaticConfig": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetStaticConfigArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetStaticConfig(ctx)
 					return
 				},
 			},
 			"resolveUnfurlPrompt": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ResolveUnfurlPromptArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ResolveUnfurlPromptArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ResolveUnfurlPromptArg)(nil), args)
@@ -8518,21 +8518,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getUnfurlSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUnfurlSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetUnfurlSettings(ctx)
 					return
 				},
 			},
 			"saveUnfurlSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaveUnfurlSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaveUnfurlSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaveUnfurlSettingsArg)(nil), args)
@@ -8543,11 +8543,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"toggleMessageCollapse": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ToggleMessageCollapseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ToggleMessageCollapseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ToggleMessageCollapseArg)(nil), args)
@@ -8558,11 +8558,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"bulkAddToConv": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BulkAddToConvArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BulkAddToConvArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BulkAddToConvArg)(nil), args)
@@ -8573,11 +8573,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"bulkAddToManyConvs": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BulkAddToManyConvsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BulkAddToManyConvsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BulkAddToManyConvsArg)(nil), args)
@@ -8588,11 +8588,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"putReacjiSkinTone": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PutReacjiSkinToneArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PutReacjiSkinToneArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PutReacjiSkinToneArg)(nil), args)
@@ -8603,11 +8603,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"resolveMaybeMention": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ResolveMaybeMentionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ResolveMaybeMentionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ResolveMaybeMentionArg)(nil), args)
@@ -8618,11 +8618,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"loadGallery": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadGalleryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadGalleryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadGalleryArg)(nil), args)
@@ -8633,11 +8633,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"loadFlip": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadFlipArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadFlipArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadFlipArg)(nil), args)
@@ -8648,11 +8648,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"locationUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LocationUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LocationUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LocationUpdateArg)(nil), args)
@@ -8663,11 +8663,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"advertiseBotCommandsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AdvertiseBotCommandsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AdvertiseBotCommandsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AdvertiseBotCommandsLocalArg)(nil), args)
@@ -8678,11 +8678,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"listBotCommandsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListBotCommandsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ListBotCommandsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ListBotCommandsLocalArg)(nil), args)
@@ -8693,11 +8693,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"listPublicBotCommandsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListPublicBotCommandsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ListPublicBotCommandsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ListPublicBotCommandsLocalArg)(nil), args)
@@ -8708,11 +8708,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"clearBotCommandsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ClearBotCommandsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ClearBotCommandsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ClearBotCommandsLocalArg)(nil), args)
@@ -8723,11 +8723,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"pinMessage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PinMessageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PinMessageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PinMessageArg)(nil), args)
@@ -8738,11 +8738,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"unpinMessage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UnpinMessageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UnpinMessageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UnpinMessageArg)(nil), args)
@@ -8753,11 +8753,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"ignorePinnedMessage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]IgnorePinnedMessageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]IgnorePinnedMessageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]IgnorePinnedMessageArg)(nil), args)
@@ -8768,11 +8768,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"addBotMember": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AddBotMemberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AddBotMemberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AddBotMemberArg)(nil), args)
@@ -8783,11 +8783,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"editBotMember": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]EditBotMemberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]EditBotMemberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]EditBotMemberArg)(nil), args)
@@ -8798,11 +8798,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"removeBotMember": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RemoveBotMemberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RemoveBotMemberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RemoveBotMemberArg)(nil), args)
@@ -8813,11 +8813,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setBotMemberSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetBotMemberSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetBotMemberSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetBotMemberSettingsArg)(nil), args)
@@ -8828,11 +8828,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getBotMemberSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetBotMemberSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetBotMemberSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetBotMemberSettingsArg)(nil), args)
@@ -8843,11 +8843,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getTeamRoleInConversation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamRoleInConversationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamRoleInConversationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamRoleInConversationArg)(nil), args)
@@ -8858,11 +8858,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"addBotConvSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AddBotConvSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AddBotConvSearchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AddBotConvSearchArg)(nil), args)
@@ -8873,11 +8873,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"forwardMessageConvSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ForwardMessageConvSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ForwardMessageConvSearchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ForwardMessageConvSearchArg)(nil), args)
@@ -8888,11 +8888,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"teamIDFromTLFName": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamIDFromTLFNameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamIDFromTLFNameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamIDFromTLFNameArg)(nil), args)
@@ -8903,11 +8903,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"dismissJourneycard": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DismissJourneycardArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DismissJourneycardArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DismissJourneycardArg)(nil), args)
@@ -8918,11 +8918,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setWelcomeMessage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetWelcomeMessageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetWelcomeMessageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetWelcomeMessageArg)(nil), args)
@@ -8933,11 +8933,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getWelcomeMessage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetWelcomeMessageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetWelcomeMessageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetWelcomeMessageArg)(nil), args)
@@ -8948,11 +8948,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getDefaultTeamChannelsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetDefaultTeamChannelsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetDefaultTeamChannelsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetDefaultTeamChannelsLocalArg)(nil), args)
@@ -8963,11 +8963,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setDefaultTeamChannelsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetDefaultTeamChannelsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetDefaultTeamChannelsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetDefaultTeamChannelsLocalArg)(nil), args)
@@ -8978,11 +8978,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getLastActiveForTLF": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetLastActiveForTLFArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetLastActiveForTLFArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetLastActiveForTLFArg)(nil), args)
@@ -8993,21 +8993,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getLastActiveForTeams": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetLastActiveForTeamsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetLastActiveForTeams(ctx)
 					return
 				},
 			},
 			"getRecentJoinsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetRecentJoinsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetRecentJoinsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetRecentJoinsLocalArg)(nil), args)
@@ -9018,11 +9018,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"refreshParticipants": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RefreshParticipantsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RefreshParticipantsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RefreshParticipantsArg)(nil), args)
@@ -9033,11 +9033,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getLastActiveAtLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetLastActiveAtLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetLastActiveAtLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetLastActiveAtLocalArg)(nil), args)
@@ -9048,11 +9048,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getLastActiveAtMultiLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetLastActiveAtMultiLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetLastActiveAtMultiLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetLastActiveAtMultiLocalArg)(nil), args)
@@ -9063,11 +9063,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getParticipants": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetParticipantsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetParticipantsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetParticipantsArg)(nil), args)
@@ -9078,11 +9078,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"addEmoji": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AddEmojiArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AddEmojiArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AddEmojiArg)(nil), args)
@@ -9093,11 +9093,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"addEmojis": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AddEmojisArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AddEmojisArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AddEmojisArg)(nil), args)
@@ -9108,11 +9108,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"addEmojiAlias": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AddEmojiAliasArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AddEmojiAliasArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AddEmojiAliasArg)(nil), args)
@@ -9123,11 +9123,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"removeEmoji": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RemoveEmojiArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RemoveEmojiArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RemoveEmojiArg)(nil), args)
@@ -9138,11 +9138,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"userEmojis": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UserEmojisArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UserEmojisArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UserEmojisArg)(nil), args)
@@ -9153,11 +9153,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"toggleEmojiAnimations": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ToggleEmojiAnimationsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ToggleEmojiAnimationsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ToggleEmojiAnimationsArg)(nil), args)
@@ -9176,649 +9176,649 @@ type LocalClient struct {
 }
 
 func (c LocalClient) GetThreadLocal(ctx context.Context, __arg GetThreadLocalArg) (res GetThreadLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getThreadLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getThreadLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetThreadNonblock(ctx context.Context, __arg GetThreadNonblockArg) (res NonblockFetchRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getThreadNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getThreadNonblock", []any{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetUnreadline(ctx context.Context, __arg GetUnreadlineArg) (res UnreadlineRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getUnreadline", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getUnreadline", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetInboxAndUnboxLocal(ctx context.Context, __arg GetInboxAndUnboxLocalArg) (res GetInboxAndUnboxLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getInboxAndUnboxLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getInboxAndUnboxLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetInboxAndUnboxUILocal(ctx context.Context, __arg GetInboxAndUnboxUILocalArg) (res GetInboxAndUnboxUILocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getInboxAndUnboxUILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getInboxAndUnboxUILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) RequestInboxLayout(ctx context.Context, reselectMode InboxLayoutReselectMode) (err error) {
 	__arg := RequestInboxLayoutArg{ReselectMode: reselectMode}
-	err = c.Cli.Call(ctx, "chat.1.local.requestInboxLayout", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.requestInboxLayout", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) RequestInboxUnbox(ctx context.Context, convIDs []ConversationID) (err error) {
 	__arg := RequestInboxUnboxArg{ConvIDs: convIDs}
-	err = c.Cli.Call(ctx, "chat.1.local.requestInboxUnbox", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.requestInboxUnbox", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) RequestInboxSmallIncrease(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.requestInboxSmallIncrease", []interface{}{RequestInboxSmallIncreaseArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.requestInboxSmallIncrease", []any{RequestInboxSmallIncreaseArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) RequestInboxSmallReset(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.requestInboxSmallReset", []interface{}{RequestInboxSmallResetArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.requestInboxSmallReset", []any{RequestInboxSmallResetArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetInboxNonblockLocal(ctx context.Context, __arg GetInboxNonblockLocalArg) (res NonblockFetchRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getInboxNonblockLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getInboxNonblockLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostLocal(ctx context.Context, __arg PostLocalArg) (res PostLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GenerateOutboxID(ctx context.Context) (res OutboxID, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.generateOutboxID", []interface{}{GenerateOutboxIDArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.generateOutboxID", []any{GenerateOutboxIDArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostLocalNonblock(ctx context.Context, __arg PostLocalNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postLocalNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postLocalNonblock", []any{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ForwardMessage(ctx context.Context, __arg ForwardMessageArg) (res PostLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.forwardMessage", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.forwardMessage", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ForwardMessageNonblock(ctx context.Context, __arg ForwardMessageNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.forwardMessageNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.forwardMessageNonblock", []any{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostTextNonblock(ctx context.Context, __arg PostTextNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postTextNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postTextNonblock", []any{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostDeleteNonblock(ctx context.Context, __arg PostDeleteNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postDeleteNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postDeleteNonblock", []any{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostEditNonblock(ctx context.Context, __arg PostEditNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postEditNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postEditNonblock", []any{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostReactionNonblock(ctx context.Context, __arg PostReactionNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postReactionNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postReactionNonblock", []any{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostHeadlineNonblock(ctx context.Context, __arg PostHeadlineNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postHeadlineNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postHeadlineNonblock", []any{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostHeadline(ctx context.Context, __arg PostHeadlineArg) (res PostLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postHeadline", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postHeadline", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostMetadataNonblock(ctx context.Context, __arg PostMetadataNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postMetadataNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postMetadataNonblock", []any{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostMetadata(ctx context.Context, __arg PostMetadataArg) (res PostLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postMetadata", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postMetadata", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostDeleteHistoryUpto(ctx context.Context, __arg PostDeleteHistoryUptoArg) (res PostLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistoryUpto", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistoryUpto", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostDeleteHistoryThrough(ctx context.Context, __arg PostDeleteHistoryThroughArg) (res PostLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistoryThrough", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistoryThrough", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostDeleteHistoryByAge(ctx context.Context, __arg PostDeleteHistoryByAgeArg) (res PostLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistoryByAge", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistoryByAge", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetConversationStatusLocal(ctx context.Context, __arg SetConversationStatusLocalArg) (res SetConversationStatusLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.SetConversationStatusLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.SetConversationStatusLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) NewConversationsLocal(ctx context.Context, __arg NewConversationsLocalArg) (res NewConversationsLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.newConversationsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.newConversationsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) NewConversationLocal(ctx context.Context, __arg NewConversationLocalArg) (res NewConversationLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.newConversationLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.newConversationLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetInboxSummaryForCLILocal(ctx context.Context, query GetInboxSummaryForCLILocalQuery) (res GetInboxSummaryForCLILocalRes, err error) {
 	__arg := GetInboxSummaryForCLILocalArg{Query: query}
-	err = c.Cli.Call(ctx, "chat.1.local.getInboxSummaryForCLILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getInboxSummaryForCLILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetConversationForCLILocal(ctx context.Context, query GetConversationForCLILocalQuery) (res GetConversationForCLILocalRes, err error) {
 	__arg := GetConversationForCLILocalArg{Query: query}
-	err = c.Cli.Call(ctx, "chat.1.local.getConversationForCLILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getConversationForCLILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetMessagesLocal(ctx context.Context, __arg GetMessagesLocalArg) (res GetMessagesLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.GetMessagesLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.GetMessagesLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostFileAttachmentLocal(ctx context.Context, __arg PostFileAttachmentLocalArg) (res PostLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postFileAttachmentLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postFileAttachmentLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostFileAttachmentLocalNonblock(ctx context.Context, __arg PostFileAttachmentLocalNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postFileAttachmentLocalNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postFileAttachmentLocalNonblock", []any{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetNextAttachmentMessageLocal(ctx context.Context, __arg GetNextAttachmentMessageLocalArg) (res GetNextAttachmentMessageLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getNextAttachmentMessageLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getNextAttachmentMessageLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) DownloadAttachmentLocal(ctx context.Context, __arg DownloadAttachmentLocalArg) (res DownloadAttachmentLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.DownloadAttachmentLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.DownloadAttachmentLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) DownloadFileAttachmentLocal(ctx context.Context, __arg DownloadFileAttachmentLocalArg) (res DownloadFileAttachmentLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.DownloadFileAttachmentLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.DownloadFileAttachmentLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ConfigureFileAttachmentDownloadLocal(ctx context.Context, __arg ConfigureFileAttachmentDownloadLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.ConfigureFileAttachmentDownloadLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.ConfigureFileAttachmentDownloadLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) MakePreview(ctx context.Context, __arg MakePreviewArg) (res MakePreviewRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.makePreview", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.makePreview", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) MakeAudioPreview(ctx context.Context, __arg MakeAudioPreviewArg) (res MakePreviewRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.makeAudioPreview", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.makeAudioPreview", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetUploadTempFile(ctx context.Context, __arg GetUploadTempFileArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getUploadTempFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getUploadTempFile", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) MakeUploadTempFile(ctx context.Context, __arg MakeUploadTempFileArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.makeUploadTempFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.makeUploadTempFile", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) CancelUploadTempFile(ctx context.Context, outboxID OutboxID) (err error) {
 	__arg := CancelUploadTempFileArg{OutboxID: outboxID}
-	err = c.Cli.Call(ctx, "chat.1.local.cancelUploadTempFile", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.cancelUploadTempFile", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) CancelPost(ctx context.Context, outboxID OutboxID) (err error) {
 	__arg := CancelPostArg{OutboxID: outboxID}
-	err = c.Cli.Call(ctx, "chat.1.local.CancelPost", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.CancelPost", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) RetryPost(ctx context.Context, __arg RetryPostArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.RetryPost", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.RetryPost", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) MarkAsReadLocal(ctx context.Context, __arg MarkAsReadLocalArg) (res MarkAsReadLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.markAsReadLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.markAsReadLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) MarkTLFAsReadLocal(ctx context.Context, __arg MarkTLFAsReadLocalArg) (res MarkTLFAsReadLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.markTLFAsReadLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.markTLFAsReadLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) FindConversationsLocal(ctx context.Context, __arg FindConversationsLocalArg) (res FindConversationsLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.findConversationsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.findConversationsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) FindGeneralConvFromTeamID(ctx context.Context, teamID keybase1.TeamID) (res InboxUIItem, err error) {
 	__arg := FindGeneralConvFromTeamIDArg{TeamID: teamID}
-	err = c.Cli.Call(ctx, "chat.1.local.findGeneralConvFromTeamID", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.findGeneralConvFromTeamID", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) UpdateTyping(ctx context.Context, __arg UpdateTypingArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.updateTyping", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.updateTyping", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) UpdateUnsentText(ctx context.Context, __arg UpdateUnsentTextArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.updateUnsentText", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.updateUnsentText", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) JoinConversationLocal(ctx context.Context, __arg JoinConversationLocalArg) (res JoinLeaveConversationLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.joinConversationLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.joinConversationLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) JoinConversationByIDLocal(ctx context.Context, convID ConversationID) (res JoinLeaveConversationLocalRes, err error) {
 	__arg := JoinConversationByIDLocalArg{ConvID: convID}
-	err = c.Cli.Call(ctx, "chat.1.local.joinConversationByIDLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.joinConversationByIDLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) LeaveConversationLocal(ctx context.Context, convID ConversationID) (res JoinLeaveConversationLocalRes, err error) {
 	__arg := LeaveConversationLocalArg{ConvID: convID}
-	err = c.Cli.Call(ctx, "chat.1.local.leaveConversationLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.leaveConversationLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PreviewConversationByIDLocal(ctx context.Context, convID ConversationID) (res PreviewConversationLocalRes, err error) {
 	__arg := PreviewConversationByIDLocalArg{ConvID: convID}
-	err = c.Cli.Call(ctx, "chat.1.local.previewConversationByIDLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.previewConversationByIDLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) DeleteConversationLocal(ctx context.Context, __arg DeleteConversationLocalArg) (res DeleteConversationLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.deleteConversationLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.deleteConversationLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) RemoveFromConversationLocal(ctx context.Context, __arg RemoveFromConversationLocalArg) (res RemoveFromConversationLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.removeFromConversationLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.removeFromConversationLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetTLFConversationsLocal(ctx context.Context, __arg GetTLFConversationsLocalArg) (res GetTLFConversationsLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getTLFConversationsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getTLFConversationsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetChannelMembershipsLocal(ctx context.Context, __arg GetChannelMembershipsLocalArg) (res GetChannelMembershipsLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getChannelMembershipsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getChannelMembershipsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetMutualTeamsLocal(ctx context.Context, usernames []string) (res GetMutualTeamsLocalRes, err error) {
 	__arg := GetMutualTeamsLocalArg{Usernames: usernames}
-	err = c.Cli.Call(ctx, "chat.1.local.getMutualTeamsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getMutualTeamsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetAppNotificationSettingsLocal(ctx context.Context, __arg SetAppNotificationSettingsLocalArg) (res SetAppNotificationSettingsLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.setAppNotificationSettingsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.setAppNotificationSettingsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetGlobalAppNotificationSettingsLocal(ctx context.Context, settings map[string]bool) (err error) {
 	__arg := SetGlobalAppNotificationSettingsLocalArg{Settings: settings}
-	err = c.Cli.Call(ctx, "chat.1.local.setGlobalAppNotificationSettingsLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.setGlobalAppNotificationSettingsLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetGlobalAppNotificationSettingsLocal(ctx context.Context) (res GlobalAppNotificationSettings, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getGlobalAppNotificationSettingsLocal", []interface{}{GetGlobalAppNotificationSettingsLocalArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getGlobalAppNotificationSettingsLocal", []any{GetGlobalAppNotificationSettingsLocalArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) UnboxMobilePushNotification(ctx context.Context, __arg UnboxMobilePushNotificationArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.unboxMobilePushNotification", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.unboxMobilePushNotification", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AddTeamMemberAfterReset(ctx context.Context, __arg AddTeamMemberAfterResetArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.addTeamMemberAfterReset", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.addTeamMemberAfterReset", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetAllResetConvMembers(ctx context.Context) (res GetAllResetConvMembersRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getAllResetConvMembers", []interface{}{GetAllResetConvMembersArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getAllResetConvMembers", []any{GetAllResetConvMembersArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetConvRetentionLocal(ctx context.Context, __arg SetConvRetentionLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.setConvRetentionLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.setConvRetentionLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetTeamRetentionLocal(ctx context.Context, __arg SetTeamRetentionLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.setTeamRetentionLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.setTeamRetentionLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetTeamRetentionLocal(ctx context.Context, teamID keybase1.TeamID) (res *RetentionPolicy, err error) {
 	__arg := GetTeamRetentionLocalArg{TeamID: teamID}
-	err = c.Cli.Call(ctx, "chat.1.local.getTeamRetentionLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getTeamRetentionLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetConvMinWriterRoleLocal(ctx context.Context, __arg SetConvMinWriterRoleLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.setConvMinWriterRoleLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.setConvMinWriterRoleLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) UpgradeKBFSConversationToImpteam(ctx context.Context, convID ConversationID) (err error) {
 	__arg := UpgradeKBFSConversationToImpteamArg{ConvID: convID}
-	err = c.Cli.Call(ctx, "chat.1.local.upgradeKBFSConversationToImpteam", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.upgradeKBFSConversationToImpteam", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SearchRegexp(ctx context.Context, __arg SearchRegexpArg) (res SearchRegexpRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.searchRegexp", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.searchRegexp", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) CancelActiveInboxSearch(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.cancelActiveInboxSearch", []interface{}{CancelActiveInboxSearchArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.cancelActiveInboxSearch", []any{CancelActiveInboxSearchArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SearchInbox(ctx context.Context, __arg SearchInboxArg) (res SearchInboxRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.searchInbox", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.searchInbox", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SimpleSearchInboxConvNames(ctx context.Context, query string) (res []SimpleSearchInboxConvNamesHit, err error) {
 	__arg := SimpleSearchInboxConvNamesArg{Query: query}
-	err = c.Cli.Call(ctx, "chat.1.local.simpleSearchInboxConvNames", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.simpleSearchInboxConvNames", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) CancelActiveSearch(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.cancelActiveSearch", []interface{}{CancelActiveSearchArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.cancelActiveSearch", []any{CancelActiveSearchArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ProfileChatSearch(ctx context.Context, identifyBehavior keybase1.TLFIdentifyBehavior) (res map[ConvIDStr]ProfileSearchConvStats, err error) {
 	__arg := ProfileChatSearchArg{IdentifyBehavior: identifyBehavior}
-	err = c.Cli.Call(ctx, "chat.1.local.profileChatSearch", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.profileChatSearch", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetStaticConfig(ctx context.Context) (res StaticConfig, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getStaticConfig", []interface{}{GetStaticConfigArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getStaticConfig", []any{GetStaticConfigArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ResolveUnfurlPrompt(ctx context.Context, __arg ResolveUnfurlPromptArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.resolveUnfurlPrompt", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.resolveUnfurlPrompt", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetUnfurlSettings(ctx context.Context) (res UnfurlSettingsDisplay, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getUnfurlSettings", []interface{}{GetUnfurlSettingsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getUnfurlSettings", []any{GetUnfurlSettingsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SaveUnfurlSettings(ctx context.Context, __arg SaveUnfurlSettingsArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.saveUnfurlSettings", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.saveUnfurlSettings", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ToggleMessageCollapse(ctx context.Context, __arg ToggleMessageCollapseArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.toggleMessageCollapse", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.toggleMessageCollapse", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) BulkAddToConv(ctx context.Context, __arg BulkAddToConvArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.bulkAddToConv", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.bulkAddToConv", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) BulkAddToManyConvs(ctx context.Context, __arg BulkAddToManyConvsArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.bulkAddToManyConvs", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.bulkAddToManyConvs", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PutReacjiSkinTone(ctx context.Context, skinTone keybase1.ReacjiSkinTone) (res keybase1.UserReacjis, err error) {
 	__arg := PutReacjiSkinToneArg{SkinTone: skinTone}
-	err = c.Cli.Call(ctx, "chat.1.local.putReacjiSkinTone", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.putReacjiSkinTone", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ResolveMaybeMention(ctx context.Context, mention MaybeMention) (err error) {
 	__arg := ResolveMaybeMentionArg{Mention: mention}
-	err = c.Cli.Call(ctx, "chat.1.local.resolveMaybeMention", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.resolveMaybeMention", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) LoadGallery(ctx context.Context, __arg LoadGalleryArg) (res LoadGalleryRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.loadGallery", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.loadGallery", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) LoadFlip(ctx context.Context, __arg LoadFlipArg) (res LoadFlipRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.loadFlip", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.loadFlip", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) LocationUpdate(ctx context.Context, coord Coordinate) (err error) {
 	__arg := LocationUpdateArg{Coord: coord}
-	err = c.Cli.Call(ctx, "chat.1.local.locationUpdate", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.locationUpdate", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AdvertiseBotCommandsLocal(ctx context.Context, __arg AdvertiseBotCommandsLocalArg) (res AdvertiseBotCommandsLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.advertiseBotCommandsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.advertiseBotCommandsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ListBotCommandsLocal(ctx context.Context, convID ConversationID) (res ListBotCommandsLocalRes, err error) {
 	__arg := ListBotCommandsLocalArg{ConvID: convID}
-	err = c.Cli.Call(ctx, "chat.1.local.listBotCommandsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.listBotCommandsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ListPublicBotCommandsLocal(ctx context.Context, username string) (res ListBotCommandsLocalRes, err error) {
 	__arg := ListPublicBotCommandsLocalArg{Username: username}
-	err = c.Cli.Call(ctx, "chat.1.local.listPublicBotCommandsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.listPublicBotCommandsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ClearBotCommandsLocal(ctx context.Context, filter *ClearBotCommandsFilter) (res ClearBotCommandsLocalRes, err error) {
 	__arg := ClearBotCommandsLocalArg{Filter: filter}
-	err = c.Cli.Call(ctx, "chat.1.local.clearBotCommandsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.clearBotCommandsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PinMessage(ctx context.Context, __arg PinMessageArg) (res PinMessageRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.pinMessage", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.pinMessage", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) UnpinMessage(ctx context.Context, convID ConversationID) (res PinMessageRes, err error) {
 	__arg := UnpinMessageArg{ConvID: convID}
-	err = c.Cli.Call(ctx, "chat.1.local.unpinMessage", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.unpinMessage", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) IgnorePinnedMessage(ctx context.Context, convID ConversationID) (err error) {
 	__arg := IgnorePinnedMessageArg{ConvID: convID}
-	err = c.Cli.Call(ctx, "chat.1.local.ignorePinnedMessage", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.ignorePinnedMessage", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AddBotMember(ctx context.Context, __arg AddBotMemberArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.addBotMember", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.addBotMember", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) EditBotMember(ctx context.Context, __arg EditBotMemberArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.editBotMember", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.editBotMember", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) RemoveBotMember(ctx context.Context, __arg RemoveBotMemberArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.removeBotMember", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.removeBotMember", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetBotMemberSettings(ctx context.Context, __arg SetBotMemberSettingsArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.setBotMemberSettings", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.setBotMemberSettings", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetBotMemberSettings(ctx context.Context, __arg GetBotMemberSettingsArg) (res keybase1.TeamBotSettings, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getBotMemberSettings", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getBotMemberSettings", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetTeamRoleInConversation(ctx context.Context, __arg GetTeamRoleInConversationArg) (res keybase1.TeamRole, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getTeamRoleInConversation", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getTeamRoleInConversation", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AddBotConvSearch(ctx context.Context, term string) (res []ConvSearchHit, err error) {
 	__arg := AddBotConvSearchArg{Term: term}
-	err = c.Cli.Call(ctx, "chat.1.local.addBotConvSearch", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.addBotConvSearch", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ForwardMessageConvSearch(ctx context.Context, term string) (res []ConvSearchHit, err error) {
 	__arg := ForwardMessageConvSearchArg{Term: term}
-	err = c.Cli.Call(ctx, "chat.1.local.forwardMessageConvSearch", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.forwardMessageConvSearch", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) TeamIDFromTLFName(ctx context.Context, __arg TeamIDFromTLFNameArg) (res keybase1.TeamID, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.teamIDFromTLFName", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.teamIDFromTLFName", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) DismissJourneycard(ctx context.Context, __arg DismissJourneycardArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.dismissJourneycard", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.dismissJourneycard", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetWelcomeMessage(ctx context.Context, __arg SetWelcomeMessageArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.setWelcomeMessage", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.setWelcomeMessage", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetWelcomeMessage(ctx context.Context, teamID keybase1.TeamID) (res WelcomeMessageDisplay, err error) {
 	__arg := GetWelcomeMessageArg{TeamID: teamID}
-	err = c.Cli.Call(ctx, "chat.1.local.getWelcomeMessage", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getWelcomeMessage", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetDefaultTeamChannelsLocal(ctx context.Context, teamID keybase1.TeamID) (res GetDefaultTeamChannelsLocalRes, err error) {
 	__arg := GetDefaultTeamChannelsLocalArg{TeamID: teamID}
-	err = c.Cli.Call(ctx, "chat.1.local.getDefaultTeamChannelsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getDefaultTeamChannelsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetDefaultTeamChannelsLocal(ctx context.Context, __arg SetDefaultTeamChannelsLocalArg) (res SetDefaultTeamChannelsLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.setDefaultTeamChannelsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.setDefaultTeamChannelsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetLastActiveForTLF(ctx context.Context, tlfID TLFIDStr) (res LastActiveStatus, err error) {
 	__arg := GetLastActiveForTLFArg{TlfID: tlfID}
-	err = c.Cli.Call(ctx, "chat.1.local.getLastActiveForTLF", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getLastActiveForTLF", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetLastActiveForTeams(ctx context.Context) (res LastActiveStatusAll, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getLastActiveForTeams", []interface{}{GetLastActiveForTeamsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getLastActiveForTeams", []any{GetLastActiveForTeamsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetRecentJoinsLocal(ctx context.Context, convID ConversationID) (res int, err error) {
 	__arg := GetRecentJoinsLocalArg{ConvID: convID}
-	err = c.Cli.Call(ctx, "chat.1.local.getRecentJoinsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getRecentJoinsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) RefreshParticipants(ctx context.Context, convID ConversationID) (err error) {
 	__arg := RefreshParticipantsArg{ConvID: convID}
-	err = c.Cli.Call(ctx, "chat.1.local.refreshParticipants", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.refreshParticipants", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetLastActiveAtLocal(ctx context.Context, __arg GetLastActiveAtLocalArg) (res gregor1.Time, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getLastActiveAtLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getLastActiveAtLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetLastActiveAtMultiLocal(ctx context.Context, __arg GetLastActiveAtMultiLocalArg) (res map[keybase1.TeamID]gregor1.Time, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getLastActiveAtMultiLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getLastActiveAtMultiLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetParticipants(ctx context.Context, convID ConversationID) (res []ConversationLocalParticipant, err error) {
 	__arg := GetParticipantsArg{ConvID: convID}
-	err = c.Cli.Call(ctx, "chat.1.local.getParticipants", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getParticipants", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AddEmoji(ctx context.Context, __arg AddEmojiArg) (res AddEmojiRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.addEmoji", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.addEmoji", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AddEmojis(ctx context.Context, __arg AddEmojisArg) (res AddEmojisRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.addEmojis", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.addEmojis", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AddEmojiAlias(ctx context.Context, __arg AddEmojiAliasArg) (res AddEmojiAliasRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.addEmojiAlias", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.addEmojiAlias", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) RemoveEmoji(ctx context.Context, __arg RemoveEmojiArg) (res RemoveEmojiRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.removeEmoji", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.removeEmoji", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) UserEmojis(ctx context.Context, __arg UserEmojisArg) (res UserEmojiRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.userEmojis", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.userEmojis", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ToggleEmojiAnimations(ctx context.Context, enabled bool) (err error) {
 	__arg := ToggleEmojiAnimationsArg{Enabled: enabled}
-	err = c.Cli.Call(ctx, "chat.1.local.toggleEmojiAnimations", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.toggleEmojiAnimations", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -1123,11 +1123,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 		Name: "chat.1.NotifyChat",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"NewChatActivity": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NewChatActivityArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NewChatActivityArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NewChatActivityArg)(nil), args)
@@ -1138,11 +1138,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatIdentifyUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatIdentifyUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatIdentifyUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatIdentifyUpdateArg)(nil), args)
@@ -1153,11 +1153,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatTLFFinalize": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatTLFFinalizeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatTLFFinalizeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatTLFFinalizeArg)(nil), args)
@@ -1168,11 +1168,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatTLFResolve": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatTLFResolveArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatTLFResolveArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatTLFResolveArg)(nil), args)
@@ -1183,11 +1183,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatInboxStale": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatInboxStaleArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatInboxStaleArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatInboxStaleArg)(nil), args)
@@ -1198,11 +1198,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatThreadsStale": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatThreadsStaleArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatThreadsStaleArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatThreadsStaleArg)(nil), args)
@@ -1213,11 +1213,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatTypingUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatTypingUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatTypingUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatTypingUpdateArg)(nil), args)
@@ -1228,11 +1228,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatJoinedConversation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatJoinedConversationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatJoinedConversationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatJoinedConversationArg)(nil), args)
@@ -1243,11 +1243,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatLeftConversation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatLeftConversationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatLeftConversationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatLeftConversationArg)(nil), args)
@@ -1258,11 +1258,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatResetConversation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatResetConversationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatResetConversationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatResetConversationArg)(nil), args)
@@ -1273,11 +1273,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatInboxSyncStarted": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatInboxSyncStartedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatInboxSyncStartedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatInboxSyncStartedArg)(nil), args)
@@ -1288,11 +1288,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatInboxSynced": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatInboxSyncedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatInboxSyncedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatInboxSyncedArg)(nil), args)
@@ -1303,11 +1303,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatSetConvRetention": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSetConvRetentionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSetConvRetentionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSetConvRetentionArg)(nil), args)
@@ -1318,11 +1318,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatSetTeamRetention": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSetTeamRetentionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSetTeamRetentionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSetTeamRetentionArg)(nil), args)
@@ -1333,11 +1333,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatSetConvSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSetConvSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSetConvSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSetConvSettingsArg)(nil), args)
@@ -1348,11 +1348,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatSubteamRename": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatSubteamRenameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatSubteamRenameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatSubteamRenameArg)(nil), args)
@@ -1363,11 +1363,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatKBFSToImpteamUpgrade": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatKBFSToImpteamUpgradeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatKBFSToImpteamUpgradeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatKBFSToImpteamUpgradeArg)(nil), args)
@@ -1378,11 +1378,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatAttachmentUploadStart": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatAttachmentUploadStartArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatAttachmentUploadStartArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatAttachmentUploadStartArg)(nil), args)
@@ -1393,11 +1393,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatAttachmentUploadProgress": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatAttachmentUploadProgressArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatAttachmentUploadProgressArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatAttachmentUploadProgressArg)(nil), args)
@@ -1408,11 +1408,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatAttachmentDownloadProgress": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatAttachmentDownloadProgressArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatAttachmentDownloadProgressArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatAttachmentDownloadProgressArg)(nil), args)
@@ -1423,11 +1423,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatAttachmentDownloadComplete": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatAttachmentDownloadCompleteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatAttachmentDownloadCompleteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatAttachmentDownloadCompleteArg)(nil), args)
@@ -1438,11 +1438,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatPaymentInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatPaymentInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatPaymentInfoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatPaymentInfoArg)(nil), args)
@@ -1453,11 +1453,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatRequestInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatRequestInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatRequestInfoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatRequestInfoArg)(nil), args)
@@ -1468,11 +1468,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatPromptUnfurl": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatPromptUnfurlArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatPromptUnfurlArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatPromptUnfurlArg)(nil), args)
@@ -1483,11 +1483,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatConvUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatConvUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatConvUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatConvUpdateArg)(nil), args)
@@ -1498,11 +1498,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatWelcomeMessageLoaded": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatWelcomeMessageLoadedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatWelcomeMessageLoadedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatWelcomeMessageLoadedArg)(nil), args)
@@ -1513,11 +1513,11 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 			},
 			"ChatParticipantsInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChatParticipantsInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChatParticipantsInfoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChatParticipantsInfoArg)(nil), args)
@@ -1536,141 +1536,141 @@ type NotifyChatClient struct {
 }
 
 func (c NotifyChatClient) NewChatActivity(ctx context.Context, __arg NewChatActivityArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.NewChatActivity", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.NewChatActivity", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatIdentifyUpdate(ctx context.Context, update keybase1.CanonicalTLFNameAndIDWithBreaks) (err error) {
 	__arg := ChatIdentifyUpdateArg{Update: update}
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatIdentifyUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatIdentifyUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatTLFFinalize(ctx context.Context, __arg ChatTLFFinalizeArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTLFFinalize", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTLFFinalize", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatTLFResolve(ctx context.Context, __arg ChatTLFResolveArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTLFResolve", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTLFResolve", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatInboxStale(ctx context.Context, uid keybase1.UID) (err error) {
 	__arg := ChatInboxStaleArg{Uid: uid}
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatInboxStale", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatInboxStale", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatThreadsStale(ctx context.Context, __arg ChatThreadsStaleArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatThreadsStale", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatThreadsStale", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatTypingUpdate(ctx context.Context, typingUpdates []ConvTypingUpdate) (err error) {
 	__arg := ChatTypingUpdateArg{TypingUpdates: typingUpdates}
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTypingUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTypingUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatJoinedConversation(ctx context.Context, __arg ChatJoinedConversationArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatJoinedConversation", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatJoinedConversation", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatLeftConversation(ctx context.Context, __arg ChatLeftConversationArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatLeftConversation", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatLeftConversation", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatResetConversation(ctx context.Context, __arg ChatResetConversationArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatResetConversation", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatResetConversation", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatInboxSyncStarted(ctx context.Context, uid keybase1.UID) (err error) {
 	__arg := ChatInboxSyncStartedArg{Uid: uid}
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatInboxSyncStarted", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatInboxSyncStarted", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatInboxSynced(ctx context.Context, __arg ChatInboxSyncedArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatInboxSynced", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatInboxSynced", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatSetConvRetention(ctx context.Context, __arg ChatSetConvRetentionArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatSetConvRetention", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatSetConvRetention", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatSetTeamRetention(ctx context.Context, __arg ChatSetTeamRetentionArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatSetTeamRetention", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatSetTeamRetention", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatSetConvSettings(ctx context.Context, __arg ChatSetConvSettingsArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatSetConvSettings", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatSetConvSettings", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatSubteamRename(ctx context.Context, __arg ChatSubteamRenameArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatSubteamRename", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatSubteamRename", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatKBFSToImpteamUpgrade(ctx context.Context, __arg ChatKBFSToImpteamUpgradeArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatKBFSToImpteamUpgrade", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatKBFSToImpteamUpgrade", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatAttachmentUploadStart(ctx context.Context, __arg ChatAttachmentUploadStartArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatAttachmentUploadStart", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatAttachmentUploadStart", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatAttachmentUploadProgress(ctx context.Context, __arg ChatAttachmentUploadProgressArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatAttachmentUploadProgress", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatAttachmentUploadProgress", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatAttachmentDownloadProgress(ctx context.Context, __arg ChatAttachmentDownloadProgressArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatAttachmentDownloadProgress", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatAttachmentDownloadProgress", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatAttachmentDownloadComplete(ctx context.Context, __arg ChatAttachmentDownloadCompleteArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatAttachmentDownloadComplete", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatAttachmentDownloadComplete", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatPaymentInfo(ctx context.Context, __arg ChatPaymentInfoArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatPaymentInfo", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatPaymentInfo", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatRequestInfo(ctx context.Context, __arg ChatRequestInfoArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatRequestInfo", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatRequestInfo", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatPromptUnfurl(ctx context.Context, __arg ChatPromptUnfurlArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatPromptUnfurl", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatPromptUnfurl", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatConvUpdate(ctx context.Context, __arg ChatConvUpdateArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatConvUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatConvUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatWelcomeMessageLoaded(ctx context.Context, __arg ChatWelcomeMessageLoadedArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatWelcomeMessageLoaded", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatWelcomeMessageLoaded", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyChatClient) ChatParticipantsInfo(ctx context.Context, participants map[ConvIDStr][]UIParticipant) (err error) {
 	__arg := ChatParticipantsInfoArg{Participants: participants}
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatParticipantsInfo", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatParticipantsInfo", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -1956,11 +1956,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 		Name: "chat.1.remote",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getInboxRemote": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetInboxRemoteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetInboxRemoteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetInboxRemoteArg)(nil), args)
@@ -1971,11 +1971,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getThreadRemote": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetThreadRemoteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetThreadRemoteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetThreadRemoteArg)(nil), args)
@@ -1986,11 +1986,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getUnreadlineRemote": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUnreadlineRemoteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetUnreadlineRemoteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetUnreadlineRemoteArg)(nil), args)
@@ -2001,11 +2001,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getPublicConversations": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPublicConversationsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPublicConversationsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPublicConversationsArg)(nil), args)
@@ -2016,11 +2016,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"postRemote": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostRemoteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostRemoteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostRemoteArg)(nil), args)
@@ -2031,11 +2031,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"newConversationRemote": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NewConversationRemoteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NewConversationRemoteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NewConversationRemoteArg)(nil), args)
@@ -2046,11 +2046,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"newConversationRemote2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NewConversationRemote2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NewConversationRemote2Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NewConversationRemote2Arg)(nil), args)
@@ -2061,11 +2061,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getMessagesRemote": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetMessagesRemoteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetMessagesRemoteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetMessagesRemoteArg)(nil), args)
@@ -2076,11 +2076,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"markAsRead": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MarkAsReadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MarkAsReadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MarkAsReadArg)(nil), args)
@@ -2091,11 +2091,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"SetConversationStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetConversationStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetConversationStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetConversationStatusArg)(nil), args)
@@ -2106,11 +2106,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"GetUnreadUpdateFull": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUnreadUpdateFullArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetUnreadUpdateFullArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetUnreadUpdateFullArg)(nil), args)
@@ -2121,11 +2121,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getS3Params": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetS3ParamsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetS3ParamsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetS3ParamsArg)(nil), args)
@@ -2136,11 +2136,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"s3Sign": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]S3SignArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]S3SignArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]S3SignArg)(nil), args)
@@ -2151,11 +2151,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getInboxVersion": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetInboxVersionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetInboxVersionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetInboxVersionArg)(nil), args)
@@ -2166,11 +2166,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"syncInbox": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SyncInboxArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SyncInboxArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SyncInboxArg)(nil), args)
@@ -2181,11 +2181,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"syncChat": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SyncChatArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SyncChatArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SyncChatArg)(nil), args)
@@ -2196,11 +2196,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"syncAll": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SyncAllArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SyncAllArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SyncAllArg)(nil), args)
@@ -2211,11 +2211,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"tlfFinalize": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TlfFinalizeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TlfFinalizeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TlfFinalizeArg)(nil), args)
@@ -2226,11 +2226,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"tlfResolve": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TlfResolveArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TlfResolveArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TlfResolveArg)(nil), args)
@@ -2241,11 +2241,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"updateTypingRemote": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpdateTypingRemoteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpdateTypingRemoteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpdateTypingRemoteArg)(nil), args)
@@ -2256,11 +2256,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"joinConversation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]JoinConversationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]JoinConversationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]JoinConversationArg)(nil), args)
@@ -2271,11 +2271,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"leaveConversation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LeaveConversationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LeaveConversationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LeaveConversationArg)(nil), args)
@@ -2286,11 +2286,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"previewConversation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PreviewConversationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PreviewConversationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PreviewConversationArg)(nil), args)
@@ -2301,11 +2301,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"deleteConversation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteConversationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteConversationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteConversationArg)(nil), args)
@@ -2316,11 +2316,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"removeFromConversation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RemoveFromConversationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RemoveFromConversationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RemoveFromConversationArg)(nil), args)
@@ -2331,11 +2331,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getMessageBefore": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetMessageBeforeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetMessageBeforeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetMessageBeforeArg)(nil), args)
@@ -2346,11 +2346,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getTLFConversations": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTLFConversationsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTLFConversationsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTLFConversationsArg)(nil), args)
@@ -2361,11 +2361,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"setAppNotificationSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetAppNotificationSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetAppNotificationSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetAppNotificationSettingsArg)(nil), args)
@@ -2376,11 +2376,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"setGlobalAppNotificationSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetGlobalAppNotificationSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetGlobalAppNotificationSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetGlobalAppNotificationSettingsArg)(nil), args)
@@ -2391,21 +2391,21 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getGlobalAppNotificationSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetGlobalAppNotificationSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetGlobalAppNotificationSettings(ctx)
 					return
 				},
 			},
 			"remoteNotificationSuccessful": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RemoteNotificationSuccessfulArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RemoteNotificationSuccessfulArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RemoteNotificationSuccessfulArg)(nil), args)
@@ -2416,11 +2416,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"setConvRetention": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetConvRetentionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetConvRetentionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetConvRetentionArg)(nil), args)
@@ -2431,11 +2431,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"setTeamRetention": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetTeamRetentionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetTeamRetentionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetTeamRetentionArg)(nil), args)
@@ -2446,11 +2446,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"setConvMinWriterRole": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetConvMinWriterRoleArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetConvMinWriterRoleArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetConvMinWriterRoleArg)(nil), args)
@@ -2461,11 +2461,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"retentionSweepConv": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RetentionSweepConvArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RetentionSweepConvArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RetentionSweepConvArg)(nil), args)
@@ -2476,11 +2476,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"upgradeKBFSToImpteam": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpgradeKBFSToImpteamArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpgradeKBFSToImpteamArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpgradeKBFSToImpteamArg)(nil), args)
@@ -2491,11 +2491,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"registerSharePost": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterSharePostArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RegisterSharePostArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RegisterSharePostArg)(nil), args)
@@ -2506,11 +2506,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"failSharePost": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FailSharePostArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FailSharePostArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FailSharePostArg)(nil), args)
@@ -2521,11 +2521,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"broadcastGregorMessageToConv": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BroadcastGregorMessageToConvArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BroadcastGregorMessageToConvArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BroadcastGregorMessageToConvArg)(nil), args)
@@ -2536,11 +2536,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"teamIDOfConv": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamIDOfConvArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamIDOfConvArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamIDOfConvArg)(nil), args)
@@ -2551,21 +2551,21 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"serverNow": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ServerNowArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.ServerNow(ctx)
 					return
 				},
 			},
 			"getExternalAPIKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetExternalAPIKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetExternalAPIKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetExternalAPIKeysArg)(nil), args)
@@ -2576,11 +2576,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"advertiseBotCommands": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AdvertiseBotCommandsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AdvertiseBotCommandsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AdvertiseBotCommandsArg)(nil), args)
@@ -2591,11 +2591,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"clearBotCommands": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ClearBotCommandsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ClearBotCommandsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ClearBotCommandsArg)(nil), args)
@@ -2606,11 +2606,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getBotInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetBotInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetBotInfoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetBotInfoArg)(nil), args)
@@ -2621,11 +2621,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getDefaultTeamChannels": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetDefaultTeamChannelsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetDefaultTeamChannelsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetDefaultTeamChannelsArg)(nil), args)
@@ -2636,11 +2636,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"setDefaultTeamChannels": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetDefaultTeamChannelsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetDefaultTeamChannelsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetDefaultTeamChannelsArg)(nil), args)
@@ -2651,11 +2651,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getRecentJoins": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetRecentJoinsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetRecentJoinsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetRecentJoinsArg)(nil), args)
@@ -2666,11 +2666,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"refreshParticipantsRemote": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RefreshParticipantsRemoteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RefreshParticipantsRemoteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RefreshParticipantsRemoteArg)(nil), args)
@@ -2681,11 +2681,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getLastActiveAt": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetLastActiveAtArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetLastActiveAtArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetLastActiveAtArg)(nil), args)
@@ -2696,11 +2696,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"getResetConversations": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetResetConversationsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetResetConversations(ctx)
 					return
 				},
@@ -2714,273 +2714,273 @@ type RemoteClient struct {
 }
 
 func (c RemoteClient) GetInboxRemote(ctx context.Context, __arg GetInboxRemoteArg) (res GetInboxRemoteRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getInboxRemote", []interface{}{__arg}, &res, rpc.CompressionGzip, 1200000*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getInboxRemote", []any{__arg}, &res, rpc.CompressionGzip, 1200000*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetThreadRemote(ctx context.Context, __arg GetThreadRemoteArg) (res GetThreadRemoteRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getThreadRemote", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getThreadRemote", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetUnreadlineRemote(ctx context.Context, __arg GetUnreadlineRemoteArg) (res GetUnreadlineRemoteRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getUnreadlineRemote", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getUnreadlineRemote", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetPublicConversations(ctx context.Context, __arg GetPublicConversationsArg) (res GetPublicConversationsRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getPublicConversations", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getPublicConversations", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) PostRemote(ctx context.Context, __arg PostRemoteArg) (res PostRemoteRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.postRemote", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.postRemote", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) NewConversationRemote(ctx context.Context, idTriple ConversationIDTriple) (res NewConversationRemoteRes, err error) {
 	__arg := NewConversationRemoteArg{IdTriple: idTriple}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.newConversationRemote", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.newConversationRemote", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) NewConversationRemote2(ctx context.Context, __arg NewConversationRemote2Arg) (res NewConversationRemoteRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.newConversationRemote2", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.newConversationRemote2", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetMessagesRemote(ctx context.Context, __arg GetMessagesRemoteArg) (res GetMessagesRemoteRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getMessagesRemote", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getMessagesRemote", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) MarkAsRead(ctx context.Context, __arg MarkAsReadArg) (res MarkAsReadRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.markAsRead", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.markAsRead", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SetConversationStatus(ctx context.Context, __arg SetConversationStatusArg) (res SetConversationStatusRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.SetConversationStatus", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.SetConversationStatus", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetUnreadUpdateFull(ctx context.Context, inboxVers InboxVers) (res UnreadUpdateFull, err error) {
 	__arg := GetUnreadUpdateFullArg{InboxVers: inboxVers}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.GetUnreadUpdateFull", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.GetUnreadUpdateFull", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetS3Params(ctx context.Context, conversationID ConversationID) (res S3Params, err error) {
 	__arg := GetS3ParamsArg{ConversationID: conversationID}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getS3Params", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getS3Params", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) S3Sign(ctx context.Context, __arg S3SignArg) (res []byte, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.s3Sign", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.s3Sign", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetInboxVersion(ctx context.Context, uid gregor1.UID) (res InboxVers, err error) {
 	__arg := GetInboxVersionArg{Uid: uid}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getInboxVersion", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getInboxVersion", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SyncInbox(ctx context.Context, vers InboxVers) (res SyncInboxRes, err error) {
 	__arg := SyncInboxArg{Vers: vers}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.syncInbox", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.syncInbox", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SyncChat(ctx context.Context, __arg SyncChatArg) (res SyncChatRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.syncChat", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.syncChat", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SyncAll(ctx context.Context, __arg SyncAllArg) (res SyncAllResult, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.syncAll", []interface{}{__arg}, &res, rpc.CompressionMsgpackzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.syncAll", []any{__arg}, &res, rpc.CompressionMsgpackzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) TlfFinalize(ctx context.Context, __arg TlfFinalizeArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.tlfFinalize", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.tlfFinalize", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) TlfResolve(ctx context.Context, __arg TlfResolveArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.tlfResolve", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.tlfResolve", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) UpdateTypingRemote(ctx context.Context, __arg UpdateTypingRemoteArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.updateTypingRemote", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.updateTypingRemote", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) JoinConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes, err error) {
 	__arg := JoinConversationArg{ConvID: convID}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.joinConversation", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.joinConversation", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) LeaveConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes, err error) {
 	__arg := LeaveConversationArg{ConvID: convID}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.leaveConversation", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.leaveConversation", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) PreviewConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes, err error) {
 	__arg := PreviewConversationArg{ConvID: convID}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.previewConversation", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.previewConversation", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) DeleteConversation(ctx context.Context, convID ConversationID) (res DeleteConversationRemoteRes, err error) {
 	__arg := DeleteConversationArg{ConvID: convID}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.deleteConversation", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.deleteConversation", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) RemoveFromConversation(ctx context.Context, __arg RemoveFromConversationArg) (res RemoveFromConversationRemoteRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.removeFromConversation", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.removeFromConversation", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetMessageBefore(ctx context.Context, __arg GetMessageBeforeArg) (res GetMessageBeforeRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getMessageBefore", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getMessageBefore", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetTLFConversations(ctx context.Context, __arg GetTLFConversationsArg) (res GetTLFConversationsRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getTLFConversations", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getTLFConversations", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SetAppNotificationSettings(ctx context.Context, __arg SetAppNotificationSettingsArg) (res SetAppNotificationSettingsRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setAppNotificationSettings", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setAppNotificationSettings", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SetGlobalAppNotificationSettings(ctx context.Context, settings GlobalAppNotificationSettings) (err error) {
 	__arg := SetGlobalAppNotificationSettingsArg{Settings: settings}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setGlobalAppNotificationSettings", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setGlobalAppNotificationSettings", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetGlobalAppNotificationSettings(ctx context.Context) (res GlobalAppNotificationSettings, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getGlobalAppNotificationSettings", []interface{}{GetGlobalAppNotificationSettingsArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getGlobalAppNotificationSettings", []any{GetGlobalAppNotificationSettingsArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) RemoteNotificationSuccessful(ctx context.Context, __arg RemoteNotificationSuccessfulArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.remote.remoteNotificationSuccessful", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.remote.remoteNotificationSuccessful", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SetConvRetention(ctx context.Context, __arg SetConvRetentionArg) (res SetRetentionRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setConvRetention", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setConvRetention", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SetTeamRetention(ctx context.Context, __arg SetTeamRetentionArg) (res SetRetentionRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setTeamRetention", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setTeamRetention", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SetConvMinWriterRole(ctx context.Context, __arg SetConvMinWriterRoleArg) (res SetConvMinWriterRoleRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setConvMinWriterRole", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setConvMinWriterRole", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) RetentionSweepConv(ctx context.Context, convID ConversationID) (res SweepRes, err error) {
 	__arg := RetentionSweepConvArg{ConvID: convID}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.retentionSweepConv", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.retentionSweepConv", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) UpgradeKBFSToImpteam(ctx context.Context, __arg UpgradeKBFSToImpteamArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.upgradeKBFSToImpteam", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.upgradeKBFSToImpteam", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) RegisterSharePost(ctx context.Context, __arg RegisterSharePostArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.registerSharePost", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.registerSharePost", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) FailSharePost(ctx context.Context, __arg FailSharePostArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.failSharePost", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.failSharePost", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) BroadcastGregorMessageToConv(ctx context.Context, __arg BroadcastGregorMessageToConvArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.broadcastGregorMessageToConv", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.broadcastGregorMessageToConv", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) TeamIDOfConv(ctx context.Context, convID ConversationID) (res *keybase1.TeamID, err error) {
 	__arg := TeamIDOfConvArg{ConvID: convID}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.teamIDOfConv", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.teamIDOfConv", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) ServerNow(ctx context.Context) (res ServerNowRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.serverNow", []interface{}{ServerNowArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.serverNow", []any{ServerNowArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetExternalAPIKeys(ctx context.Context, typs []ExternalAPIKeyTyp) (res []ExternalAPIKey, err error) {
 	__arg := GetExternalAPIKeysArg{Typs: typs}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getExternalAPIKeys", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getExternalAPIKeys", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) AdvertiseBotCommands(ctx context.Context, ads []RemoteBotCommandsAdvertisement) (res AdvertiseBotCommandsRes, err error) {
 	__arg := AdvertiseBotCommandsArg{Ads: ads}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.advertiseBotCommands", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.advertiseBotCommands", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) ClearBotCommands(ctx context.Context, filter *RemoteClearBotCommandsFilter) (res ClearBotCommandsRes, err error) {
 	__arg := ClearBotCommandsArg{Filter: filter}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.clearBotCommands", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.clearBotCommands", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetBotInfo(ctx context.Context, __arg GetBotInfoArg) (res GetBotInfoRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getBotInfo", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getBotInfo", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetDefaultTeamChannels(ctx context.Context, teamID keybase1.TeamID) (res GetDefaultTeamChannelsRes, err error) {
 	__arg := GetDefaultTeamChannelsArg{TeamID: teamID}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getDefaultTeamChannels", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getDefaultTeamChannels", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SetDefaultTeamChannels(ctx context.Context, __arg SetDefaultTeamChannelsArg) (res SetDefaultTeamChannelsRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setDefaultTeamChannels", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.setDefaultTeamChannels", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetRecentJoins(ctx context.Context, convID ConversationID) (res GetRecentJoinsRes, err error) {
 	__arg := GetRecentJoinsArg{ConvID: convID}
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getRecentJoins", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getRecentJoins", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) RefreshParticipantsRemote(ctx context.Context, __arg RefreshParticipantsRemoteArg) (res RefreshParticipantsRemoteRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.refreshParticipantsRemote", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.refreshParticipantsRemote", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetLastActiveAt(ctx context.Context, __arg GetLastActiveAtArg) (res GetLastActiveAtRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getLastActiveAt", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getLastActiveAt", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) GetResetConversations(ctx context.Context) (res GetResetConversationsRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getResetConversations", []interface{}{GetResetConversationsArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getResetConversations", []any{GetResetConversationsArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/gregor1/auth.go
+++ b/go/protocol/gregor1/auth.go
@@ -38,11 +38,11 @@ func AuthProtocol(i AuthInterface) rpc.Protocol {
 		Name: "gregor.1.auth",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"authenticateSessionToken": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AuthenticateSessionTokenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AuthenticateSessionTokenArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AuthenticateSessionTokenArg)(nil), args)
@@ -62,6 +62,6 @@ type AuthClient struct {
 
 func (c AuthClient) AuthenticateSessionToken(ctx context.Context, session SessionToken) (res AuthResult, err error) {
 	__arg := AuthenticateSessionTokenArg{Session: session}
-	err = c.Cli.Call(ctx, "gregor.1.auth.authenticateSessionToken", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "gregor.1.auth.authenticateSessionToken", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/gregor1/auth_internal.go
+++ b/go/protocol/gregor1/auth_internal.go
@@ -21,11 +21,11 @@ func AuthInternalProtocol(i AuthInternalInterface) rpc.Protocol {
 		Name: "gregor.1.authInternal",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"createGregorSuperUserSessionToken": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CreateGregorSuperUserSessionTokenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.CreateGregorSuperUserSessionToken(ctx)
 					return
 				},
@@ -39,6 +39,6 @@ type AuthInternalClient struct {
 }
 
 func (c AuthInternalClient) CreateGregorSuperUserSessionToken(ctx context.Context) (res SessionToken, err error) {
-	err = c.Cli.Call(ctx, "gregor.1.authInternal.createGregorSuperUserSessionToken", []interface{}{CreateGregorSuperUserSessionTokenArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "gregor.1.authInternal.createGregorSuperUserSessionToken", []any{CreateGregorSuperUserSessionTokenArg{}}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/gregor1/auth_update.go
+++ b/go/protocol/gregor1/auth_update.go
@@ -22,11 +22,11 @@ func AuthUpdateProtocol(i AuthUpdateInterface) rpc.Protocol {
 		Name: "gregor.1.authUpdate",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"revokeSessionIDs": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RevokeSessionIDsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RevokeSessionIDsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RevokeSessionIDsArg)(nil), args)
@@ -46,6 +46,6 @@ type AuthUpdateClient struct {
 
 func (c AuthUpdateClient) RevokeSessionIDs(ctx context.Context, sessionIDs []SessionID) (err error) {
 	__arg := RevokeSessionIDsArg{SessionIDs: sessionIDs}
-	err = c.Cli.Call(ctx, "gregor.1.authUpdate.revokeSessionIDs", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "gregor.1.authUpdate.revokeSessionIDs", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/gregor1/incoming.go
+++ b/go/protocol/gregor1/incoming.go
@@ -147,11 +147,11 @@ func IncomingProtocol(i IncomingInterface) rpc.Protocol {
 		Name: "gregor.1.incoming",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"sync": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SyncArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SyncArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SyncArg)(nil), args)
@@ -162,11 +162,11 @@ func IncomingProtocol(i IncomingInterface) rpc.Protocol {
 				},
 			},
 			"consumeMessage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ConsumeMessageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ConsumeMessageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ConsumeMessageArg)(nil), args)
@@ -177,11 +177,11 @@ func IncomingProtocol(i IncomingInterface) rpc.Protocol {
 				},
 			},
 			"consumePublishMessage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ConsumePublishMessageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ConsumePublishMessageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ConsumePublishMessageArg)(nil), args)
@@ -192,11 +192,11 @@ func IncomingProtocol(i IncomingInterface) rpc.Protocol {
 				},
 			},
 			"consumeMessageMulti": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ConsumeMessageMultiArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ConsumeMessageMultiArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ConsumeMessageMultiArg)(nil), args)
@@ -207,21 +207,21 @@ func IncomingProtocol(i IncomingInterface) rpc.Protocol {
 				},
 			},
 			"ping": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PingArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.Ping(ctx)
 					return
 				},
 			},
 			"version": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]VersionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]VersionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]VersionArg)(nil), args)
@@ -232,11 +232,11 @@ func IncomingProtocol(i IncomingInterface) rpc.Protocol {
 				},
 			},
 			"state": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]StateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]StateArg)(nil), args)
@@ -247,11 +247,11 @@ func IncomingProtocol(i IncomingInterface) rpc.Protocol {
 				},
 			},
 			"stateByCategoryPrefix": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StateByCategoryPrefixArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]StateByCategoryPrefixArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]StateByCategoryPrefixArg)(nil), args)
@@ -262,11 +262,11 @@ func IncomingProtocol(i IncomingInterface) rpc.Protocol {
 				},
 			},
 			"describeConnectedUsers": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DescribeConnectedUsersArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DescribeConnectedUsersArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DescribeConnectedUsersArg)(nil), args)
@@ -277,11 +277,11 @@ func IncomingProtocol(i IncomingInterface) rpc.Protocol {
 				},
 			},
 			"describeConnectedUsersInternal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DescribeConnectedUsersInternalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DescribeConnectedUsersInternalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DescribeConnectedUsersInternalArg)(nil), args)
@@ -300,19 +300,19 @@ type IncomingClient struct {
 }
 
 func (c IncomingClient) Sync(ctx context.Context, __arg SyncArg) (res SyncResult, err error) {
-	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.sync", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.sync", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c IncomingClient) ConsumeMessage(ctx context.Context, m Message) (err error) {
 	__arg := ConsumeMessageArg{M: m}
-	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.consumeMessage", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.consumeMessage", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c IncomingClient) ConsumePublishMessage(ctx context.Context, m Message) (err error) {
 	__arg := ConsumePublishMessageArg{M: m}
-	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.consumePublishMessage", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.consumePublishMessage", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
@@ -320,41 +320,41 @@ func (c IncomingClient) ConsumePublishMessage(ctx context.Context, m Message) (e
 // in uids. This is so a gregor client can send the same message to many UIDs
 // with one call, as opposed to calling consumeMessage for each UID.
 func (c IncomingClient) ConsumeMessageMulti(ctx context.Context, __arg ConsumeMessageMultiArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.consumeMessageMulti", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.consumeMessageMulti", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c IncomingClient) Ping(ctx context.Context) (res string, err error) {
-	err = c.Cli.Call(ctx, "gregor.1.incoming.ping", []interface{}{PingArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "gregor.1.incoming.ping", []any{PingArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c IncomingClient) Version(ctx context.Context, uid UID) (res string, err error) {
 	__arg := VersionArg{Uid: uid}
-	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.version", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.version", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c IncomingClient) State(ctx context.Context, __arg StateArg) (res State, err error) {
-	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.state", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.state", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 // StateByCategoryPrefix loads the messages of the user's state whose
 // categories are prefixed by the given prefix
 func (c IncomingClient) StateByCategoryPrefix(ctx context.Context, __arg StateByCategoryPrefixArg) (res State, err error) {
-	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.stateByCategoryPrefix", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.stateByCategoryPrefix", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c IncomingClient) DescribeConnectedUsers(ctx context.Context, uids []UID) (res []ConnectedUser, err error) {
 	__arg := DescribeConnectedUsersArg{Uids: uids}
-	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.describeConnectedUsers", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.describeConnectedUsers", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c IncomingClient) DescribeConnectedUsersInternal(ctx context.Context, uids []UID) (res []ConnectedUser, err error) {
 	__arg := DescribeConnectedUsersInternalArg{Uids: uids}
-	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.describeConnectedUsersInternal", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "gregor.1.incoming.describeConnectedUsersInternal", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/gregor1/outgoing.go
+++ b/go/protocol/gregor1/outgoing.go
@@ -22,11 +22,11 @@ func OutgoingProtocol(i OutgoingInterface) rpc.Protocol {
 		Name: "gregor.1.outgoing",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"broadcastMessage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BroadcastMessageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BroadcastMessageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BroadcastMessageArg)(nil), args)
@@ -46,6 +46,6 @@ type OutgoingClient struct {
 
 func (c OutgoingClient) BroadcastMessage(ctx context.Context, m Message) (err error) {
 	__arg := BroadcastMessageArg{M: m}
-	err = c.Cli.CallCompressed(ctx, "gregor.1.outgoing.broadcastMessage", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "gregor.1.outgoing.broadcastMessage", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/gregor1/remind.go
+++ b/go/protocol/gregor1/remind.go
@@ -30,11 +30,11 @@ func RemindProtocol(i RemindInterface) rpc.Protocol {
 		Name: "gregor.1.remind",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getReminders": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetRemindersArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetRemindersArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetRemindersArg)(nil), args)
@@ -45,11 +45,11 @@ func RemindProtocol(i RemindInterface) rpc.Protocol {
 				},
 			},
 			"deleteReminders": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteRemindersArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteRemindersArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteRemindersArg)(nil), args)
@@ -71,13 +71,13 @@ type RemindClient struct {
 // maxReminders back.
 func (c RemindClient) GetReminders(ctx context.Context, maxReminders int) (res ReminderSet, err error) {
 	__arg := GetRemindersArg{MaxReminders: maxReminders}
-	err = c.Cli.Call(ctx, "gregor.1.remind.getReminders", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "gregor.1.remind.getReminders", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // deleteReminders deletes all of the reminders by ReminderID
 func (c RemindClient) DeleteReminders(ctx context.Context, reminderIDs []ReminderID) (err error) {
 	__arg := DeleteRemindersArg{ReminderIDs: reminderIDs}
-	err = c.Cli.Call(ctx, "gregor.1.remind.deleteReminders", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "gregor.1.remind.deleteReminders", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/kbgitkbfs1/disk_block_cache.go
+++ b/go/protocol/kbgitkbfs1/disk_block_cache.go
@@ -123,11 +123,11 @@ func DiskBlockCacheProtocol(i DiskBlockCacheInterface) rpc.Protocol {
 		Name: "kbgitkbfs.1.DiskBlockCache",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"GetBlock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetBlockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetBlockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetBlockArg)(nil), args)
@@ -138,11 +138,11 @@ func DiskBlockCacheProtocol(i DiskBlockCacheInterface) rpc.Protocol {
 				},
 			},
 			"GetPrefetchStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPrefetchStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPrefetchStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPrefetchStatusArg)(nil), args)
@@ -153,11 +153,11 @@ func DiskBlockCacheProtocol(i DiskBlockCacheInterface) rpc.Protocol {
 				},
 			},
 			"PutBlock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PutBlockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PutBlockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PutBlockArg)(nil), args)
@@ -168,11 +168,11 @@ func DiskBlockCacheProtocol(i DiskBlockCacheInterface) rpc.Protocol {
 				},
 			},
 			"DeleteBlocks": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteBlocksArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteBlocksArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteBlocksArg)(nil), args)
@@ -183,11 +183,11 @@ func DiskBlockCacheProtocol(i DiskBlockCacheInterface) rpc.Protocol {
 				},
 			},
 			"UpdateBlockMetadata": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpdateBlockMetadataArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpdateBlockMetadataArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpdateBlockMetadataArg)(nil), args)
@@ -207,31 +207,31 @@ type DiskBlockCacheClient struct {
 
 // GetBlock gets a block from the disk cache.
 func (c DiskBlockCacheClient) GetBlock(ctx context.Context, __arg GetBlockArg) (res GetBlockRes, err error) {
-	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.GetBlock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.GetBlock", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // GetPrefetchStatus gets the prefetch status from the disk cache.
 func (c DiskBlockCacheClient) GetPrefetchStatus(ctx context.Context, __arg GetPrefetchStatusArg) (res PrefetchStatus, err error) {
-	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.GetPrefetchStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.GetPrefetchStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // PutBlock puts a block into the disk cache.
 func (c DiskBlockCacheClient) PutBlock(ctx context.Context, __arg PutBlockArg) (err error) {
-	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.PutBlock", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.PutBlock", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // DeleteBlocks deletes a set of blocks from the disk cache.
 func (c DiskBlockCacheClient) DeleteBlocks(ctx context.Context, blockIDs [][]byte) (res DeleteBlocksRes, err error) {
 	__arg := DeleteBlocksArg{BlockIDs: blockIDs}
-	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.DeleteBlocks", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.DeleteBlocks", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // UpdateBlockMetadata updates the metadata for a block in the disk cache.
 func (c DiskBlockCacheClient) UpdateBlockMetadata(ctx context.Context, __arg UpdateBlockMetadataArg) (err error) {
-	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.UpdateBlockMetadata", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.UpdateBlockMetadata", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/account.go
+++ b/go/protocol/keybase1/account.go
@@ -223,11 +223,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 		Name: "keybase.1.account",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"passphraseChange": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PassphraseChangeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PassphraseChangeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PassphraseChangeArg)(nil), args)
@@ -238,11 +238,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"passphrasePrompt": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PassphrasePromptArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PassphrasePromptArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PassphrasePromptArg)(nil), args)
@@ -253,11 +253,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"passphraseCheck": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PassphraseCheckArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PassphraseCheckArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PassphraseCheckArg)(nil), args)
@@ -268,11 +268,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"emailChange": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]EmailChangeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]EmailChangeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]EmailChangeArg)(nil), args)
@@ -283,11 +283,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"hasServerKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HasServerKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]HasServerKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]HasServerKeysArg)(nil), args)
@@ -298,11 +298,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"resetAccount": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ResetAccountArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ResetAccountArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ResetAccountArg)(nil), args)
@@ -313,11 +313,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"getLockdownMode": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetLockdownModeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetLockdownModeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetLockdownModeArg)(nil), args)
@@ -328,11 +328,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"setLockdownMode": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetLockdownModeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetLockdownModeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetLockdownModeArg)(nil), args)
@@ -343,11 +343,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"recoverUsernameWithEmail": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RecoverUsernameWithEmailArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RecoverUsernameWithEmailArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RecoverUsernameWithEmailArg)(nil), args)
@@ -358,11 +358,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"recoverUsernameWithPhone": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RecoverUsernameWithPhoneArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RecoverUsernameWithPhoneArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RecoverUsernameWithPhoneArg)(nil), args)
@@ -373,11 +373,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"enterResetPipeline": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]EnterResetPipelineArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]EnterResetPipelineArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]EnterResetPipelineArg)(nil), args)
@@ -388,11 +388,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"cancelReset": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CancelResetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CancelResetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CancelResetArg)(nil), args)
@@ -403,11 +403,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"timeTravelReset": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TimeTravelResetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TimeTravelResetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TimeTravelResetArg)(nil), args)
@@ -418,11 +418,11 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"guessCurrentLocation": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GuessCurrentLocationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GuessCurrentLocationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GuessCurrentLocationArg)(nil), args)
@@ -433,21 +433,21 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 				},
 			},
 			"userGetContactSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UserGetContactSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.UserGetContactSettings(ctx)
 					return
 				},
 			},
 			"userSetContactSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UserSetContactSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UserSetContactSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UserSetContactSettingsArg)(nil), args)
@@ -469,12 +469,12 @@ type AccountClient struct {
 // then prompt at the UI for it. If old isn't set and force is true, then
 // we'll try to force a passphrase change.
 func (c AccountClient) PassphraseChange(ctx context.Context, __arg PassphraseChangeArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.passphraseChange", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.passphraseChange", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c AccountClient) PassphrasePrompt(ctx context.Context, __arg PassphrasePromptArg) (res GetPassphraseRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.passphrasePrompt", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.passphrasePrompt", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -482,13 +482,13 @@ func (c AccountClient) PassphrasePrompt(ctx context.Context, __arg PassphrasePro
 // * passphrase argument is empty. Returns `true` if passphrase is correct,
 // * false if not, or an error if something else went wrong.
 func (c AccountClient) PassphraseCheck(ctx context.Context, __arg PassphraseCheckArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.passphraseCheck", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.passphraseCheck", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // * change email to the new given email by signing a statement.
 func (c AccountClient) EmailChange(ctx context.Context, __arg EmailChangeArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.emailChange", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.emailChange", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -496,35 +496,35 @@ func (c AccountClient) EmailChange(ctx context.Context, __arg EmailChangeArg) (e
 // * Will error if not logged in.
 func (c AccountClient) HasServerKeys(ctx context.Context, sessionID int) (res HasServerKeysRes, err error) {
 	__arg := HasServerKeysArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.account.hasServerKeys", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.hasServerKeys", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // resetAccount resets the user's account. It is used in the CLI.
 // passphrase is optional and will be prompted for if not supplied.
 func (c AccountClient) ResetAccount(ctx context.Context, __arg ResetAccountArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.resetAccount", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.resetAccount", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c AccountClient) GetLockdownMode(ctx context.Context, sessionID int) (res GetLockdownResponse, err error) {
 	__arg := GetLockdownModeArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.account.getLockdownMode", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.getLockdownMode", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c AccountClient) SetLockdownMode(ctx context.Context, __arg SetLockdownModeArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.setLockdownMode", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.setLockdownMode", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c AccountClient) RecoverUsernameWithEmail(ctx context.Context, __arg RecoverUsernameWithEmailArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.recoverUsernameWithEmail", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.recoverUsernameWithEmail", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c AccountClient) RecoverUsernameWithPhone(ctx context.Context, __arg RecoverUsernameWithPhoneArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.recoverUsernameWithPhone", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.recoverUsernameWithPhone", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -533,34 +533,34 @@ func (c AccountClient) RecoverUsernameWithPhone(ctx context.Context, __arg Recov
 // the process.
 // TODO: change this to just username
 func (c AccountClient) EnterResetPipeline(ctx context.Context, __arg EnterResetPipelineArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.enterResetPipeline", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.enterResetPipeline", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Aborts the reset process
 func (c AccountClient) CancelReset(ctx context.Context, sessionID int) (err error) {
 	__arg := CancelResetArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.account.cancelReset", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.cancelReset", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c AccountClient) TimeTravelReset(ctx context.Context, __arg TimeTravelResetArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.timeTravelReset", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.timeTravelReset", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c AccountClient) GuessCurrentLocation(ctx context.Context, __arg GuessCurrentLocationArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.guessCurrentLocation", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.guessCurrentLocation", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c AccountClient) UserGetContactSettings(ctx context.Context) (res ContactSettings, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.account.userGetContactSettings", []interface{}{UserGetContactSettingsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.userGetContactSettings", []any{UserGetContactSettingsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c AccountClient) UserSetContactSettings(ctx context.Context, settings ContactSettings) (err error) {
 	__arg := UserSetContactSettingsArg{Settings: settings}
-	err = c.Cli.Call(ctx, "keybase.1.account.userSetContactSettings", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.account.userSetContactSettings", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/airdrop.go
+++ b/go/protocol/keybase1/airdrop.go
@@ -46,11 +46,11 @@ func AirdropProtocol(i AirdropInterface) rpc.Protocol {
 		Name: "keybase.1.airdrop",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"reg1": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Reg1Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Reg1Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Reg1Arg)(nil), args)
@@ -61,11 +61,11 @@ func AirdropProtocol(i AirdropInterface) rpc.Protocol {
 				},
 			},
 			"reg2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Reg2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Reg2Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Reg2Arg)(nil), args)
@@ -84,12 +84,12 @@ type AirdropClient struct {
 }
 
 func (c AirdropClient) Reg1(ctx context.Context, __arg Reg1Arg) (res BinaryKID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.airdrop.reg1", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.airdrop.reg1", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c AirdropClient) Reg2(ctx context.Context, ctext []byte) (err error) {
 	__arg := Reg2Arg{Ctext: ctext}
-	err = c.Cli.Call(ctx, "keybase.1.airdrop.reg2", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.airdrop.reg2", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/apiserver.go
+++ b/go/protocol/keybase1/apiserver.go
@@ -75,11 +75,11 @@ func ApiserverProtocol(i ApiserverInterface) rpc.Protocol {
 		Name: "keybase.1.apiserver",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"Get": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetArg)(nil), args)
@@ -90,11 +90,11 @@ func ApiserverProtocol(i ApiserverInterface) rpc.Protocol {
 				},
 			},
 			"Delete": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteArg)(nil), args)
@@ -105,11 +105,11 @@ func ApiserverProtocol(i ApiserverInterface) rpc.Protocol {
 				},
 			},
 			"GetWithSession": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetWithSessionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetWithSessionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetWithSessionArg)(nil), args)
@@ -120,11 +120,11 @@ func ApiserverProtocol(i ApiserverInterface) rpc.Protocol {
 				},
 			},
 			"Post": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostArg)(nil), args)
@@ -135,11 +135,11 @@ func ApiserverProtocol(i ApiserverInterface) rpc.Protocol {
 				},
 			},
 			"PostJSON": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostJSONArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostJSONArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostJSONArg)(nil), args)
@@ -158,26 +158,26 @@ type ApiserverClient struct {
 }
 
 func (c ApiserverClient) Get(ctx context.Context, __arg GetArg) (res APIRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.apiserver.Get", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.apiserver.Get", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ApiserverClient) Delete(ctx context.Context, __arg DeleteArg) (res APIRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.apiserver.Delete", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.apiserver.Delete", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ApiserverClient) GetWithSession(ctx context.Context, __arg GetWithSessionArg) (res APIRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.apiserver.GetWithSession", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.apiserver.GetWithSession", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ApiserverClient) Post(ctx context.Context, __arg PostArg) (res APIRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.apiserver.Post", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.apiserver.Post", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ApiserverClient) PostJSON(ctx context.Context, __arg PostJSONArg) (res APIRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.apiserver.PostJSON", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.apiserver.PostJSON", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/appstate.go
+++ b/go/protocol/keybase1/appstate.go
@@ -95,11 +95,11 @@ func AppStateProtocol(i AppStateInterface) rpc.Protocol {
 		Name: "keybase.1.appState",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"updateMobileNetState": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpdateMobileNetStateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpdateMobileNetStateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpdateMobileNetStateArg)(nil), args)
@@ -110,11 +110,11 @@ func AppStateProtocol(i AppStateInterface) rpc.Protocol {
 				},
 			},
 			"powerMonitorEvent": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PowerMonitorEventArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PowerMonitorEventArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PowerMonitorEventArg)(nil), args)
@@ -134,12 +134,12 @@ type AppStateClient struct {
 
 func (c AppStateClient) UpdateMobileNetState(ctx context.Context, state string) (err error) {
 	__arg := UpdateMobileNetStateArg{State: state}
-	err = c.Cli.Call(ctx, "keybase.1.appState.updateMobileNetState", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.appState.updateMobileNetState", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c AppStateClient) PowerMonitorEvent(ctx context.Context, event string) (err error) {
 	__arg := PowerMonitorEventArg{Event: event}
-	err = c.Cli.Call(ctx, "keybase.1.appState.powerMonitorEvent", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.appState.powerMonitorEvent", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/audit.go
+++ b/go/protocol/keybase1/audit.go
@@ -110,11 +110,11 @@ func AuditProtocol(i AuditInterface) rpc.Protocol {
 		Name: "keybase.1.audit",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"isInJail": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]IsInJailArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]IsInJailArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]IsInJailArg)(nil), args)
@@ -125,11 +125,11 @@ func AuditProtocol(i AuditInterface) rpc.Protocol {
 				},
 			},
 			"boxAuditTeam": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BoxAuditTeamArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BoxAuditTeamArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BoxAuditTeamArg)(nil), args)
@@ -140,11 +140,11 @@ func AuditProtocol(i AuditInterface) rpc.Protocol {
 				},
 			},
 			"attemptBoxAudit": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AttemptBoxAuditArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AttemptBoxAuditArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AttemptBoxAuditArg)(nil), args)
@@ -155,11 +155,11 @@ func AuditProtocol(i AuditInterface) rpc.Protocol {
 				},
 			},
 			"knownTeamIDs": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]KnownTeamIDsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]KnownTeamIDsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]KnownTeamIDsArg)(nil), args)
@@ -178,22 +178,22 @@ type AuditClient struct {
 }
 
 func (c AuditClient) IsInJail(ctx context.Context, __arg IsInJailArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.audit.isInJail", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.audit.isInJail", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c AuditClient) BoxAuditTeam(ctx context.Context, __arg BoxAuditTeamArg) (res *BoxAuditAttempt, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.audit.boxAuditTeam", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.audit.boxAuditTeam", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c AuditClient) AttemptBoxAudit(ctx context.Context, __arg AttemptBoxAuditArg) (res BoxAuditAttempt, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.audit.attemptBoxAudit", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.audit.attemptBoxAudit", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c AuditClient) KnownTeamIDs(ctx context.Context, sessionID int) (res []TeamID, err error) {
 	__arg := KnownTeamIDsArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.audit.knownTeamIDs", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.audit.knownTeamIDs", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/avatars.go
+++ b/go/protocol/keybase1/avatars.go
@@ -97,11 +97,11 @@ func AvatarsProtocol(i AvatarsInterface) rpc.Protocol {
 		Name: "keybase.1.avatars",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"loadUserAvatars": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadUserAvatarsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadUserAvatarsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadUserAvatarsArg)(nil), args)
@@ -112,11 +112,11 @@ func AvatarsProtocol(i AvatarsInterface) rpc.Protocol {
 				},
 			},
 			"loadTeamAvatars": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadTeamAvatarsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadTeamAvatarsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadTeamAvatarsArg)(nil), args)
@@ -135,11 +135,11 @@ type AvatarsClient struct {
 }
 
 func (c AvatarsClient) LoadUserAvatars(ctx context.Context, __arg LoadUserAvatarsArg) (res LoadAvatarsRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.avatars.loadUserAvatars", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.avatars.loadUserAvatars", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c AvatarsClient) LoadTeamAvatars(ctx context.Context, __arg LoadTeamAvatarsArg) (res LoadAvatarsRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.avatars.loadTeamAvatars", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.avatars.loadTeamAvatars", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/badger.go
+++ b/go/protocol/keybase1/badger.go
@@ -21,11 +21,11 @@ func BadgerProtocol(i BadgerInterface) rpc.Protocol {
 		Name: "keybase.1.badger",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getBadgeState": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetBadgeStateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetBadgeState(ctx)
 					return
 				},
@@ -39,6 +39,6 @@ type BadgerClient struct {
 }
 
 func (c BadgerClient) GetBadgeState(ctx context.Context) (res BadgeState, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.badger.getBadgeState", []interface{}{GetBadgeStateArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.badger.getBadgeState", []any{GetBadgeStateArg{}}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/block.go
+++ b/go/protocol/keybase1/block.go
@@ -366,21 +366,21 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 		Name: "keybase.1.block",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getSessionChallenge": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetSessionChallengeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetSessionChallenge(ctx)
 					return
 				},
 			},
 			"authenticateSession": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AuthenticateSessionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AuthenticateSessionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AuthenticateSessionArg)(nil), args)
@@ -391,11 +391,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"putBlock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PutBlockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PutBlockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PutBlockArg)(nil), args)
@@ -406,11 +406,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"putBlockAgain": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PutBlockAgainArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PutBlockAgainArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PutBlockAgainArg)(nil), args)
@@ -421,11 +421,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"getBlock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetBlockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetBlockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetBlockArg)(nil), args)
@@ -436,11 +436,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"getBlockSizes": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetBlockSizesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetBlockSizesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetBlockSizesArg)(nil), args)
@@ -451,11 +451,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"addReference": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AddReferenceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AddReferenceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AddReferenceArg)(nil), args)
@@ -466,11 +466,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"delReference": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DelReferenceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DelReferenceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DelReferenceArg)(nil), args)
@@ -481,11 +481,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"archiveReference": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ArchiveReferenceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ArchiveReferenceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ArchiveReferenceArg)(nil), args)
@@ -496,11 +496,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"delReferenceWithCount": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DelReferenceWithCountArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DelReferenceWithCountArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DelReferenceWithCountArg)(nil), args)
@@ -511,11 +511,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"archiveReferenceWithCount": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ArchiveReferenceWithCountArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ArchiveReferenceWithCountArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ArchiveReferenceWithCountArg)(nil), args)
@@ -526,11 +526,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"getReferenceCount": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetReferenceCountArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetReferenceCountArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetReferenceCountArg)(nil), args)
@@ -541,21 +541,21 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"getUserQuotaInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUserQuotaInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetUserQuotaInfo(ctx)
 					return
 				},
 			},
 			"getTeamQuotaInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamQuotaInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamQuotaInfoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamQuotaInfoArg)(nil), args)
@@ -566,11 +566,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"getUserQuotaInfo2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUserQuotaInfo2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetUserQuotaInfo2Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetUserQuotaInfo2Arg)(nil), args)
@@ -581,11 +581,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"getTeamQuotaInfo2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamQuotaInfo2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamQuotaInfo2Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamQuotaInfo2Arg)(nil), args)
@@ -596,11 +596,11 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 			},
 			"blockPing": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BlockPingArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.BlockPing(ctx)
 					return
 				},
@@ -614,89 +614,89 @@ type BlockClient struct {
 }
 
 func (c BlockClient) GetSessionChallenge(ctx context.Context) (res ChallengeInfo, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getSessionChallenge", []interface{}{GetSessionChallengeArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getSessionChallenge", []any{GetSessionChallengeArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) AuthenticateSession(ctx context.Context, signature string) (err error) {
 	__arg := AuthenticateSessionArg{Signature: signature}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.authenticateSession", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.authenticateSession", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) PutBlock(ctx context.Context, __arg PutBlockArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.block.putBlock", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.block.putBlock", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) PutBlockAgain(ctx context.Context, __arg PutBlockAgainArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.block.putBlockAgain", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.block.putBlockAgain", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) GetBlock(ctx context.Context, __arg GetBlockArg) (res GetBlockRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.block.getBlock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.block.getBlock", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) GetBlockSizes(ctx context.Context, __arg GetBlockSizesArg) (res GetBlockSizesRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getBlockSizes", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getBlockSizes", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) AddReference(ctx context.Context, __arg AddReferenceArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.addReference", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.addReference", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) DelReference(ctx context.Context, __arg DelReferenceArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.delReference", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.delReference", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) ArchiveReference(ctx context.Context, __arg ArchiveReferenceArg) (res []BlockReference, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.archiveReference", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.archiveReference", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) DelReferenceWithCount(ctx context.Context, __arg DelReferenceWithCountArg) (res DowngradeReferenceRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.delReferenceWithCount", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.delReferenceWithCount", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) ArchiveReferenceWithCount(ctx context.Context, __arg ArchiveReferenceWithCountArg) (res DowngradeReferenceRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.archiveReferenceWithCount", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.archiveReferenceWithCount", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) GetReferenceCount(ctx context.Context, __arg GetReferenceCountArg) (res ReferenceCountRes, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getReferenceCount", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getReferenceCount", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) GetUserQuotaInfo(ctx context.Context) (res []byte, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getUserQuotaInfo", []interface{}{GetUserQuotaInfoArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getUserQuotaInfo", []any{GetUserQuotaInfoArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) GetTeamQuotaInfo(ctx context.Context, tid TeamID) (res []byte, err error) {
 	__arg := GetTeamQuotaInfoArg{Tid: tid}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getTeamQuotaInfo", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getTeamQuotaInfo", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) GetUserQuotaInfo2(ctx context.Context, includeFolders bool) (res BlockQuotaInfo, err error) {
 	__arg := GetUserQuotaInfo2Arg{IncludeFolders: includeFolders}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getUserQuotaInfo2", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getUserQuotaInfo2", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) GetTeamQuotaInfo2(ctx context.Context, __arg GetTeamQuotaInfo2Arg) (res BlockQuotaInfo, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getTeamQuotaInfo2", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getTeamQuotaInfo2", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c BlockClient) BlockPing(ctx context.Context) (res BlockPingResponse, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.block.blockPing", []interface{}{BlockPingArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.blockPing", []any{BlockPingArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/bot.go
+++ b/go/protocol/keybase1/bot.go
@@ -48,31 +48,31 @@ func BotProtocol(i BotInterface) rpc.Protocol {
 		Name: "keybase.1.bot",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"botTokenList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BotTokenListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.BotTokenList(ctx)
 					return
 				},
 			},
 			"botTokenCreate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BotTokenCreateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.BotTokenCreate(ctx)
 					return
 				},
 			},
 			"botTokenDelete": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BotTokenDeleteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BotTokenDeleteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BotTokenDeleteArg)(nil), args)
@@ -91,17 +91,17 @@ type BotClient struct {
 }
 
 func (c BotClient) BotTokenList(ctx context.Context) (res []BotTokenInfo, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.bot.botTokenList", []interface{}{BotTokenListArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.bot.botTokenList", []any{BotTokenListArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c BotClient) BotTokenCreate(ctx context.Context) (res BotToken, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.bot.botTokenCreate", []interface{}{BotTokenCreateArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.bot.botTokenCreate", []any{BotTokenCreateArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c BotClient) BotTokenDelete(ctx context.Context, token BotToken) (err error) {
 	__arg := BotTokenDeleteArg{Token: token}
-	err = c.Cli.Call(ctx, "keybase.1.bot.botTokenDelete", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.bot.botTokenDelete", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/btc.go
+++ b/go/protocol/keybase1/btc.go
@@ -24,11 +24,11 @@ func BTCProtocol(i BTCInterface) rpc.Protocol {
 		Name: "keybase.1.BTC",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"registerBTC": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterBTCArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RegisterBTCArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RegisterBTCArg)(nil), args)
@@ -47,6 +47,6 @@ type BTCClient struct {
 }
 
 func (c BTCClient) RegisterBTC(ctx context.Context, __arg RegisterBTCArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.BTC.registerBTC", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.BTC.registerBTC", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -1040,11 +1040,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 		Name: "keybase.1.config",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getCurrentStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetCurrentStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetCurrentStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetCurrentStatusArg)(nil), args)
@@ -1055,11 +1055,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"getClientStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetClientStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetClientStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetClientStatusArg)(nil), args)
@@ -1070,11 +1070,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"getFullStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetFullStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetFullStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetFullStatusArg)(nil), args)
@@ -1085,11 +1085,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"isServiceRunning": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]IsServiceRunningArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]IsServiceRunningArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]IsServiceRunningArg)(nil), args)
@@ -1100,11 +1100,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"isKBFSRunning": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]IsKBFSRunningArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]IsKBFSRunningArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]IsKBFSRunningArg)(nil), args)
@@ -1115,11 +1115,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"getNetworkStats": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetNetworkStatsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetNetworkStatsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetNetworkStatsArg)(nil), args)
@@ -1130,11 +1130,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"logSend": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LogSendArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LogSendArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LogSendArg)(nil), args)
@@ -1145,11 +1145,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"getAllProvisionedUsernames": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetAllProvisionedUsernamesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetAllProvisionedUsernamesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetAllProvisionedUsernamesArg)(nil), args)
@@ -1160,11 +1160,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"getConfig": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetConfigArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetConfigArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetConfigArg)(nil), args)
@@ -1175,11 +1175,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"setUserConfig": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetUserConfigArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetUserConfigArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetUserConfigArg)(nil), args)
@@ -1190,11 +1190,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"setPath": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetPathArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetPathArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetPathArg)(nil), args)
@@ -1205,11 +1205,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"helloIAm": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HelloIAmArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]HelloIAmArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]HelloIAmArg)(nil), args)
@@ -1220,11 +1220,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"setValue": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetValueArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetValueArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetValueArg)(nil), args)
@@ -1235,11 +1235,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"clearValue": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ClearValueArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ClearValueArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ClearValueArg)(nil), args)
@@ -1250,11 +1250,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"getValue": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetValueArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetValueArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetValueArg)(nil), args)
@@ -1265,11 +1265,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"guiSetValue": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GuiSetValueArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GuiSetValueArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GuiSetValueArg)(nil), args)
@@ -1280,11 +1280,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"guiClearValue": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GuiClearValueArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GuiClearValueArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GuiClearValueArg)(nil), args)
@@ -1295,11 +1295,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"guiGetValue": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GuiGetValueArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GuiGetValueArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GuiGetValueArg)(nil), args)
@@ -1310,41 +1310,41 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"checkAPIServerOutOfDateWarning": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CheckAPIServerOutOfDateWarningArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.CheckAPIServerOutOfDateWarning(ctx)
 					return
 				},
 			},
 			"getUpdateInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUpdateInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetUpdateInfo(ctx)
 					return
 				},
 			},
 			"startUpdateIfNeeded": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StartUpdateIfNeededArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.StartUpdateIfNeeded(ctx)
 					return
 				},
 			},
 			"waitForClient": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WaitForClientArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]WaitForClientArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]WaitForClientArg)(nil), args)
@@ -1355,11 +1355,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"getBootstrapStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetBootstrapStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetBootstrapStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetBootstrapStatusArg)(nil), args)
@@ -1370,11 +1370,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"requestFollowingAndUnverifiedFollowers": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RequestFollowingAndUnverifiedFollowersArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RequestFollowingAndUnverifiedFollowersArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RequestFollowingAndUnverifiedFollowersArg)(nil), args)
@@ -1385,11 +1385,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"getRememberPassphrase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetRememberPassphraseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetRememberPassphraseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetRememberPassphraseArg)(nil), args)
@@ -1400,11 +1400,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"setRememberPassphrase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetRememberPassphraseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetRememberPassphraseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetRememberPassphraseArg)(nil), args)
@@ -1415,11 +1415,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"getUpdateInfo2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUpdateInfo2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetUpdateInfo2Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetUpdateInfo2Arg)(nil), args)
@@ -1430,11 +1430,11 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"setProxyData": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetProxyDataArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetProxyDataArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetProxyDataArg)(nil), args)
@@ -1445,31 +1445,31 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"getProxyData": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetProxyDataArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetProxyData(ctx)
 					return
 				},
 			},
 			"toggleRuntimeStats": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ToggleRuntimeStatsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.ToggleRuntimeStats(ctx)
 					return
 				},
 			},
 			"appendGUILogs": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AppendGUILogsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AppendGUILogsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AppendGUILogsArg)(nil), args)
@@ -1480,21 +1480,21 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 			},
 			"generateWebAuthToken": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GenerateWebAuthTokenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GenerateWebAuthToken(ctx)
 					return
 				},
 			},
 			"updateLastLoggedInAndServerConfig": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpdateLastLoggedInAndServerConfigArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpdateLastLoggedInAndServerConfigArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpdateLastLoggedInAndServerConfigArg)(nil), args)
@@ -1514,53 +1514,53 @@ type ConfigClient struct {
 
 func (c ConfigClient) GetCurrentStatus(ctx context.Context, sessionID int) (res CurrentStatus, err error) {
 	__arg := GetCurrentStatusArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.config.getCurrentStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getCurrentStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GetClientStatus(ctx context.Context, sessionID int) (res []ClientStatus, err error) {
 	__arg := GetClientStatusArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.config.getClientStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getClientStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GetFullStatus(ctx context.Context, sessionID int) (res *FullStatus, err error) {
 	__arg := GetFullStatusArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.config.getFullStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getFullStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) IsServiceRunning(ctx context.Context, sessionID int) (res bool, err error) {
 	__arg := IsServiceRunningArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.config.isServiceRunning", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.isServiceRunning", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) IsKBFSRunning(ctx context.Context, sessionID int) (res bool, err error) {
 	__arg := IsKBFSRunningArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.config.isKBFSRunning", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.isKBFSRunning", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GetNetworkStats(ctx context.Context, __arg GetNetworkStatsArg) (res []InstrumentationStat, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.getNetworkStats", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getNetworkStats", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) LogSend(ctx context.Context, __arg LogSendArg) (res LogSendID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.logSend", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.logSend", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GetAllProvisionedUsernames(ctx context.Context, sessionID int) (res AllProvisionedUsernames, err error) {
 	__arg := GetAllProvisionedUsernamesArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.config.getAllProvisionedUsernames", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getAllProvisionedUsernames", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GetConfig(ctx context.Context, sessionID int) (res Config, err error) {
 	__arg := GetConfigArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.config.getConfig", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getConfig", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -1568,136 +1568,136 @@ func (c ConfigClient) GetConfig(ctx context.Context, sessionID int) (res Config,
 // For example, to update primary picture source:
 // key=picture.source, value=twitter (or github)
 func (c ConfigClient) SetUserConfig(ctx context.Context, __arg SetUserConfigArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.setUserConfig", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.setUserConfig", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) SetPath(ctx context.Context, __arg SetPathArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.setPath", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.setPath", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) HelloIAm(ctx context.Context, details ClientDetails) (err error) {
 	__arg := HelloIAmArg{Details: details}
-	err = c.Cli.Call(ctx, "keybase.1.config.helloIAm", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.helloIAm", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) SetValue(ctx context.Context, __arg SetValueArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.setValue", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.setValue", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) ClearValue(ctx context.Context, path string) (err error) {
 	__arg := ClearValueArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.config.clearValue", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.clearValue", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GetValue(ctx context.Context, path string) (res ConfigValue, err error) {
 	__arg := GetValueArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.config.getValue", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getValue", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GuiSetValue(ctx context.Context, __arg GuiSetValueArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.guiSetValue", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.guiSetValue", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GuiClearValue(ctx context.Context, path string) (err error) {
 	__arg := GuiClearValueArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.config.guiClearValue", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.guiClearValue", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GuiGetValue(ctx context.Context, path string) (res ConfigValue, err error) {
 	__arg := GuiGetValueArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.config.guiGetValue", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.guiGetValue", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Check whether the API server has told us we're out of date.
 func (c ConfigClient) CheckAPIServerOutOfDateWarning(ctx context.Context) (res OutOfDateInfo, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.checkAPIServerOutOfDateWarning", []interface{}{CheckAPIServerOutOfDateWarningArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.checkAPIServerOutOfDateWarning", []any{CheckAPIServerOutOfDateWarningArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GetUpdateInfo(ctx context.Context) (res UpdateInfo, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.getUpdateInfo", []interface{}{GetUpdateInfoArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getUpdateInfo", []any{GetUpdateInfoArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) StartUpdateIfNeeded(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.startUpdateIfNeeded", []interface{}{StartUpdateIfNeededArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.startUpdateIfNeeded", []any{StartUpdateIfNeededArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 // Wait for client type to connect to service.
 func (c ConfigClient) WaitForClient(ctx context.Context, __arg WaitForClientArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.waitForClient", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.waitForClient", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GetBootstrapStatus(ctx context.Context, sessionID int) (res BootstrapStatus, err error) {
 	__arg := GetBootstrapStatusArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.config.getBootstrapStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getBootstrapStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) RequestFollowingAndUnverifiedFollowers(ctx context.Context, sessionID int) (err error) {
 	__arg := RequestFollowingAndUnverifiedFollowersArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.config.requestFollowingAndUnverifiedFollowers", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.requestFollowingAndUnverifiedFollowers", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GetRememberPassphrase(ctx context.Context, sessionID int) (res bool, err error) {
 	__arg := GetRememberPassphraseArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.config.getRememberPassphrase", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getRememberPassphrase", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) SetRememberPassphrase(ctx context.Context, __arg SetRememberPassphraseArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.setRememberPassphrase", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.setRememberPassphrase", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // getUpdateInfo2 is to drive the redbar on mobile and desktop apps. The redbar tells you if
 // you are critically out of date.
 func (c ConfigClient) GetUpdateInfo2(ctx context.Context, __arg GetUpdateInfo2Arg) (res UpdateInfo2, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.getUpdateInfo2", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getUpdateInfo2", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) SetProxyData(ctx context.Context, proxyData ProxyData) (err error) {
 	__arg := SetProxyDataArg{ProxyData: proxyData}
-	err = c.Cli.Call(ctx, "keybase.1.config.setProxyData", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.setProxyData", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GetProxyData(ctx context.Context) (res ProxyData, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.getProxyData", []interface{}{GetProxyDataArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.getProxyData", []any{GetProxyDataArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) ToggleRuntimeStats(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.toggleRuntimeStats", []interface{}{ToggleRuntimeStatsArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.toggleRuntimeStats", []any{ToggleRuntimeStatsArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) AppendGUILogs(ctx context.Context, content string) (err error) {
 	__arg := AppendGUILogsArg{Content: content}
-	err = c.Cli.Call(ctx, "keybase.1.config.appendGUILogs", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.appendGUILogs", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) GenerateWebAuthToken(ctx context.Context) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.config.generateWebAuthToken", []interface{}{GenerateWebAuthTokenArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.generateWebAuthToken", []any{GenerateWebAuthTokenArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ConfigClient) UpdateLastLoggedInAndServerConfig(ctx context.Context, serverConfigPath string) (err error) {
 	__arg := UpdateLastLoggedInAndServerConfigArg{ServerConfigPath: serverConfigPath}
-	err = c.Cli.Call(ctx, "keybase.1.config.updateLastLoggedInAndServerConfig", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.config.updateLastLoggedInAndServerConfig", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/contacts.go
+++ b/go/protocol/keybase1/contacts.go
@@ -162,11 +162,11 @@ func ContactsProtocol(i ContactsInterface) rpc.Protocol {
 		Name: "keybase.1.contacts",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"lookupContactList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LookupContactListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LookupContactListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LookupContactListArg)(nil), args)
@@ -177,11 +177,11 @@ func ContactsProtocol(i ContactsInterface) rpc.Protocol {
 				},
 			},
 			"saveContactList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaveContactListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaveContactListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaveContactListArg)(nil), args)
@@ -192,11 +192,11 @@ func ContactsProtocol(i ContactsInterface) rpc.Protocol {
 				},
 			},
 			"lookupSavedContactsList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LookupSavedContactsListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LookupSavedContactsListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LookupSavedContactsListArg)(nil), args)
@@ -207,11 +207,11 @@ func ContactsProtocol(i ContactsInterface) rpc.Protocol {
 				},
 			},
 			"getContactsForUserRecommendations": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetContactsForUserRecommendationsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetContactsForUserRecommendationsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetContactsForUserRecommendationsArg)(nil), args)
@@ -230,23 +230,23 @@ type ContactsClient struct {
 }
 
 func (c ContactsClient) LookupContactList(ctx context.Context, __arg LookupContactListArg) (res []ProcessedContact, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.contacts.lookupContactList", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.contacts.lookupContactList", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ContactsClient) SaveContactList(ctx context.Context, __arg SaveContactListArg) (res ContactListResolutionResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.contacts.saveContactList", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.contacts.saveContactList", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ContactsClient) LookupSavedContactsList(ctx context.Context, sessionID int) (res []ProcessedContact, err error) {
 	__arg := LookupSavedContactsListArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.contacts.lookupSavedContactsList", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.contacts.lookupSavedContactsList", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ContactsClient) GetContactsForUserRecommendations(ctx context.Context, sessionID int) (res []ProcessedContact, err error) {
 	__arg := GetContactsForUserRecommendationsArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.contacts.getContactsForUserRecommendations", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.contacts.getContactsForUserRecommendations", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/crypto.go
+++ b/go/protocol/keybase1/crypto.go
@@ -148,11 +148,11 @@ func CryptoProtocol(i CryptoInterface) rpc.Protocol {
 		Name: "keybase.1.crypto",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"signED25519": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SignED25519Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SignED25519Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SignED25519Arg)(nil), args)
@@ -163,11 +163,11 @@ func CryptoProtocol(i CryptoInterface) rpc.Protocol {
 				},
 			},
 			"signED25519ForKBFS": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SignED25519ForKBFSArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SignED25519ForKBFSArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SignED25519ForKBFSArg)(nil), args)
@@ -178,11 +178,11 @@ func CryptoProtocol(i CryptoInterface) rpc.Protocol {
 				},
 			},
 			"signToString": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SignToStringArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SignToStringArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SignToStringArg)(nil), args)
@@ -193,11 +193,11 @@ func CryptoProtocol(i CryptoInterface) rpc.Protocol {
 				},
 			},
 			"unboxBytes32": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UnboxBytes32Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UnboxBytes32Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UnboxBytes32Arg)(nil), args)
@@ -208,11 +208,11 @@ func CryptoProtocol(i CryptoInterface) rpc.Protocol {
 				},
 			},
 			"unboxBytes32Any": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UnboxBytes32AnyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UnboxBytes32AnyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UnboxBytes32AnyArg)(nil), args)
@@ -236,19 +236,19 @@ type CryptoClient struct {
 // is used as part of the SecretEntryArg object passed into
 // secretUi.getSecret().
 func (c CryptoClient) SignED25519(ctx context.Context, __arg SignED25519Arg) (res ED25519SignatureInfo, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.crypto.signED25519", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.crypto.signED25519", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Same as the above except a KBFS-specific prefix is added to the payload to be signed.
 func (c CryptoClient) SignED25519ForKBFS(ctx context.Context, __arg SignED25519ForKBFSArg) (res ED25519SignatureInfo, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.crypto.signED25519ForKBFS", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.crypto.signED25519ForKBFS", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Same as the above except the full marshaled and encoded NaclSigInfo.
 func (c CryptoClient) SignToString(ctx context.Context, __arg SignToStringArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.crypto.signToString", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.crypto.signToString", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -257,11 +257,11 @@ func (c CryptoClient) SignToString(ctx context.Context, __arg SignToStringArg) (
 // decrypted data. The 'reason' parameter is used as part of the
 // SecretEntryArg object passed into secretUi.getSecret().
 func (c CryptoClient) UnboxBytes32(ctx context.Context, __arg UnboxBytes32Arg) (res Bytes32, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.crypto.unboxBytes32", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.crypto.unboxBytes32", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c CryptoClient) UnboxBytes32Any(ctx context.Context, __arg UnboxBytes32AnyArg) (res UnboxAnyRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.crypto.unboxBytes32Any", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.crypto.unboxBytes32Any", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/cryptocurrency.go
+++ b/go/protocol/keybase1/cryptocurrency.go
@@ -38,11 +38,11 @@ func CryptocurrencyProtocol(i CryptocurrencyInterface) rpc.Protocol {
 		Name: "keybase.1.cryptocurrency",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"registerAddress": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterAddressArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RegisterAddressArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RegisterAddressArg)(nil), args)
@@ -61,6 +61,6 @@ type CryptocurrencyClient struct {
 }
 
 func (c CryptocurrencyClient) RegisterAddress(ctx context.Context, __arg RegisterAddressArg) (res RegisterAddressRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.cryptocurrency.registerAddress", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.cryptocurrency.registerAddress", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/ctl.go
+++ b/go/protocol/keybase1/ctl.go
@@ -212,11 +212,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 		Name: "keybase.1.ctl",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"stop": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StopArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]StopArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]StopArg)(nil), args)
@@ -227,11 +227,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"stopService": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StopServiceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]StopServiceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]StopServiceArg)(nil), args)
@@ -242,11 +242,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"logRotate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LogRotateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LogRotateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LogRotateArg)(nil), args)
@@ -257,11 +257,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"reload": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ReloadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ReloadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ReloadArg)(nil), args)
@@ -272,11 +272,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"dbNuke": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DbNukeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DbNukeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DbNukeArg)(nil), args)
@@ -287,11 +287,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"dbClean": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DbCleanArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DbCleanArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DbCleanArg)(nil), args)
@@ -302,11 +302,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"appExit": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AppExitArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AppExitArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AppExitArg)(nil), args)
@@ -317,11 +317,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"dbDelete": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DbDeleteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DbDeleteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DbDeleteArg)(nil), args)
@@ -332,11 +332,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"dbPut": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DbPutArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DbPutArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DbPutArg)(nil), args)
@@ -347,11 +347,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"dbGet": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DbGetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DbGetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DbGetArg)(nil), args)
@@ -362,11 +362,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"dbKeysWithPrefixes": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DbKeysWithPrefixesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DbKeysWithPrefixesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DbKeysWithPrefixesArg)(nil), args)
@@ -377,11 +377,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"setOnLoginStartup": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetOnLoginStartupArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetOnLoginStartupArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetOnLoginStartupArg)(nil), args)
@@ -392,11 +392,11 @@ func CtlProtocol(i CtlInterface) rpc.Protocol {
 				},
 			},
 			"getOnLoginStartup": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetOnLoginStartupArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetOnLoginStartup(ctx)
 					return
 				},
@@ -410,71 +410,71 @@ type CtlClient struct {
 }
 
 func (c CtlClient) Stop(ctx context.Context, __arg StopArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.ctl.stop", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.stop", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) StopService(ctx context.Context, __arg StopServiceArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.ctl.stopService", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.stopService", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) LogRotate(ctx context.Context, sessionID int) (err error) {
 	__arg := LogRotateArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.ctl.logRotate", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.logRotate", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) Reload(ctx context.Context, sessionID int) (err error) {
 	__arg := ReloadArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.ctl.reload", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.reload", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) DbNuke(ctx context.Context, sessionID int) (err error) {
 	__arg := DbNukeArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.ctl.dbNuke", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.dbNuke", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) DbClean(ctx context.Context, __arg DbCleanArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.ctl.dbClean", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.dbClean", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) AppExit(ctx context.Context, sessionID int) (err error) {
 	__arg := AppExitArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.ctl.appExit", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.appExit", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) DbDelete(ctx context.Context, __arg DbDeleteArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.ctl.dbDelete", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.dbDelete", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) DbPut(ctx context.Context, __arg DbPutArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.ctl.dbPut", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.dbPut", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) DbGet(ctx context.Context, __arg DbGetArg) (res *DbValue, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.ctl.dbGet", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.dbGet", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) DbKeysWithPrefixes(ctx context.Context, __arg DbKeysWithPrefixesArg) (res []DbKey, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.ctl.dbKeysWithPrefixes", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.dbKeysWithPrefixes", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) SetOnLoginStartup(ctx context.Context, enabled bool) (err error) {
 	__arg := SetOnLoginStartupArg{Enabled: enabled}
-	err = c.Cli.Call(ctx, "keybase.1.ctl.setOnLoginStartup", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.setOnLoginStartup", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c CtlClient) GetOnLoginStartup(ctx context.Context) (res OnLoginStartupStatus, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.ctl.getOnLoginStartup", []interface{}{GetOnLoginStartupArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ctl.getOnLoginStartup", []any{GetOnLoginStartupArg{}}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/debugging.go
+++ b/go/protocol/keybase1/debugging.go
@@ -51,11 +51,11 @@ func DebuggingProtocol(i DebuggingInterface) rpc.Protocol {
 		Name: "keybase.1.debugging",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"firstStep": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FirstStepArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FirstStepArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FirstStepArg)(nil), args)
@@ -66,11 +66,11 @@ func DebuggingProtocol(i DebuggingInterface) rpc.Protocol {
 				},
 			},
 			"secondStep": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SecondStepArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SecondStepArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SecondStepArg)(nil), args)
@@ -81,11 +81,11 @@ func DebuggingProtocol(i DebuggingInterface) rpc.Protocol {
 				},
 			},
 			"increment": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]IncrementArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]IncrementArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]IncrementArg)(nil), args)
@@ -96,11 +96,11 @@ func DebuggingProtocol(i DebuggingInterface) rpc.Protocol {
 				},
 			},
 			"script": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ScriptArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ScriptArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ScriptArg)(nil), args)
@@ -119,21 +119,21 @@ type DebuggingClient struct {
 }
 
 func (c DebuggingClient) FirstStep(ctx context.Context, __arg FirstStepArg) (res FirstStepResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.debugging.firstStep", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.debugging.firstStep", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c DebuggingClient) SecondStep(ctx context.Context, __arg SecondStepArg) (res int, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.debugging.secondStep", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.debugging.secondStep", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c DebuggingClient) Increment(ctx context.Context, __arg IncrementArg) (res int, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.debugging.increment", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.debugging.increment", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c DebuggingClient) Script(ctx context.Context, __arg ScriptArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.debugging.script", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.debugging.script", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/delegate_ui_ctl.go
+++ b/go/protocol/keybase1/delegate_ui_ctl.go
@@ -61,101 +61,101 @@ func DelegateUiCtlProtocol(i DelegateUiCtlInterface) rpc.Protocol {
 		Name: "keybase.1.delegateUiCtl",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"registerIdentifyUI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterIdentifyUIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RegisterIdentifyUI(ctx)
 					return
 				},
 			},
 			"registerSecretUI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterSecretUIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RegisterSecretUI(ctx)
 					return
 				},
 			},
 			"registerUpdateUI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterUpdateUIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RegisterUpdateUI(ctx)
 					return
 				},
 			},
 			"registerRekeyUI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterRekeyUIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RegisterRekeyUI(ctx)
 					return
 				},
 			},
 			"registerHomeUI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterHomeUIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RegisterHomeUI(ctx)
 					return
 				},
 			},
 			"registerIdentify3UI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterIdentify3UIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RegisterIdentify3UI(ctx)
 					return
 				},
 			},
 			"registerChatUI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterChatUIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RegisterChatUI(ctx)
 					return
 				},
 			},
 			"registerLogUI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterLogUIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RegisterLogUI(ctx)
 					return
 				},
 			},
 			"registerGregorFirehose": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterGregorFirehoseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RegisterGregorFirehose(ctx)
 					return
 				},
 			},
 			"registerGregorFirehoseFiltered": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterGregorFirehoseFilteredArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RegisterGregorFirehoseFilteredArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RegisterGregorFirehoseFilteredArg)(nil), args)
@@ -174,47 +174,47 @@ type DelegateUiCtlClient struct {
 }
 
 func (c DelegateUiCtlClient) RegisterIdentifyUI(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerIdentifyUI", []interface{}{RegisterIdentifyUIArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerIdentifyUI", []any{RegisterIdentifyUIArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c DelegateUiCtlClient) RegisterSecretUI(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerSecretUI", []interface{}{RegisterSecretUIArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerSecretUI", []any{RegisterSecretUIArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c DelegateUiCtlClient) RegisterUpdateUI(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerUpdateUI", []interface{}{RegisterUpdateUIArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerUpdateUI", []any{RegisterUpdateUIArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c DelegateUiCtlClient) RegisterRekeyUI(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerRekeyUI", []interface{}{RegisterRekeyUIArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerRekeyUI", []any{RegisterRekeyUIArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c DelegateUiCtlClient) RegisterHomeUI(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerHomeUI", []interface{}{RegisterHomeUIArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerHomeUI", []any{RegisterHomeUIArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c DelegateUiCtlClient) RegisterIdentify3UI(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerIdentify3UI", []interface{}{RegisterIdentify3UIArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerIdentify3UI", []any{RegisterIdentify3UIArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c DelegateUiCtlClient) RegisterChatUI(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerChatUI", []interface{}{RegisterChatUIArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerChatUI", []any{RegisterChatUIArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c DelegateUiCtlClient) RegisterLogUI(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerLogUI", []interface{}{RegisterLogUIArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerLogUI", []any{RegisterLogUIArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c DelegateUiCtlClient) RegisterGregorFirehose(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerGregorFirehose", []interface{}{RegisterGregorFirehoseArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerGregorFirehose", []any{RegisterGregorFirehoseArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -223,6 +223,6 @@ func (c DelegateUiCtlClient) RegisterGregorFirehose(ctx context.Context) (err er
 // Like the firehose handler, but less pressure.
 func (c DelegateUiCtlClient) RegisterGregorFirehoseFiltered(ctx context.Context, systems []string) (err error) {
 	__arg := RegisterGregorFirehoseFilteredArg{Systems: systems}
-	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerGregorFirehoseFiltered", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.delegateUiCtl.registerGregorFirehoseFiltered", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/device.go
+++ b/go/protocol/keybase1/device.go
@@ -109,11 +109,11 @@ func DeviceProtocol(i DeviceInterface) rpc.Protocol {
 		Name: "keybase.1.device",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"deviceList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeviceListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeviceListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeviceListArg)(nil), args)
@@ -124,11 +124,11 @@ func DeviceProtocol(i DeviceInterface) rpc.Protocol {
 				},
 			},
 			"deviceHistoryList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeviceHistoryListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeviceHistoryListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeviceHistoryListArg)(nil), args)
@@ -139,11 +139,11 @@ func DeviceProtocol(i DeviceInterface) rpc.Protocol {
 				},
 			},
 			"deviceAdd": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeviceAddArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeviceAddArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeviceAddArg)(nil), args)
@@ -154,11 +154,11 @@ func DeviceProtocol(i DeviceInterface) rpc.Protocol {
 				},
 			},
 			"checkDeviceNameFormat": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CheckDeviceNameFormatArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CheckDeviceNameFormatArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CheckDeviceNameFormatArg)(nil), args)
@@ -169,21 +169,21 @@ func DeviceProtocol(i DeviceInterface) rpc.Protocol {
 				},
 			},
 			"dismissDeviceChangeNotifications": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DismissDeviceChangeNotificationsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.DismissDeviceChangeNotifications(ctx)
 					return
 				},
 			},
 			"checkDeviceNameForUser": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CheckDeviceNameForUserArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CheckDeviceNameForUserArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CheckDeviceNameForUserArg)(nil), args)
@@ -204,14 +204,14 @@ type DeviceClient struct {
 // List devices for the user.
 func (c DeviceClient) DeviceList(ctx context.Context, sessionID int) (res []Device, err error) {
 	__arg := DeviceListArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.device.deviceList", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.device.deviceList", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // List all devices with detailed history and status information.
 func (c DeviceClient) DeviceHistoryList(ctx context.Context, sessionID int) (res []DeviceDetail, err error) {
 	__arg := DeviceHistoryListArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.device.deviceHistoryList", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.device.deviceHistoryList", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -220,20 +220,20 @@ func (c DeviceClient) DeviceHistoryList(ctx context.Context, sessionID int) (res
 // This is for kex2.
 func (c DeviceClient) DeviceAdd(ctx context.Context, sessionID int) (err error) {
 	__arg := DeviceAddArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.device.deviceAdd", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.device.deviceAdd", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Checks the device name format.
 func (c DeviceClient) CheckDeviceNameFormat(ctx context.Context, __arg CheckDeviceNameFormatArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.device.checkDeviceNameFormat", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.device.checkDeviceNameFormat", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Dismisses the notifications for a new or revoked device
 // assuming this is not that device.
 func (c DeviceClient) DismissDeviceChangeNotifications(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.device.dismissDeviceChangeNotifications", []interface{}{DismissDeviceChangeNotificationsArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.device.dismissDeviceChangeNotifications", []any{DismissDeviceChangeNotificationsArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -242,6 +242,6 @@ func (c DeviceClient) DismissDeviceChangeNotifications(ctx context.Context) (err
 // for proper formatting. Return null error on success, and a non-null
 // error otherwise.
 func (c DeviceClient) CheckDeviceNameForUser(ctx context.Context, __arg CheckDeviceNameForUserArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.device.checkDeviceNameForUser", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.device.checkDeviceNameForUser", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/emails.go
+++ b/go/protocol/keybase1/emails.go
@@ -106,11 +106,11 @@ func EmailsProtocol(i EmailsInterface) rpc.Protocol {
 		Name: "keybase.1.emails",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"addEmail": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AddEmailArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AddEmailArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AddEmailArg)(nil), args)
@@ -121,11 +121,11 @@ func EmailsProtocol(i EmailsInterface) rpc.Protocol {
 				},
 			},
 			"deleteEmail": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteEmailArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteEmailArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteEmailArg)(nil), args)
@@ -136,11 +136,11 @@ func EmailsProtocol(i EmailsInterface) rpc.Protocol {
 				},
 			},
 			"editEmail": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]EditEmailArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]EditEmailArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]EditEmailArg)(nil), args)
@@ -151,11 +151,11 @@ func EmailsProtocol(i EmailsInterface) rpc.Protocol {
 				},
 			},
 			"setPrimaryEmail": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetPrimaryEmailArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetPrimaryEmailArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetPrimaryEmailArg)(nil), args)
@@ -166,11 +166,11 @@ func EmailsProtocol(i EmailsInterface) rpc.Protocol {
 				},
 			},
 			"sendVerificationEmail": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SendVerificationEmailArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SendVerificationEmailArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SendVerificationEmailArg)(nil), args)
@@ -181,11 +181,11 @@ func EmailsProtocol(i EmailsInterface) rpc.Protocol {
 				},
 			},
 			"setVisibilityEmail": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetVisibilityEmailArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetVisibilityEmailArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetVisibilityEmailArg)(nil), args)
@@ -196,11 +196,11 @@ func EmailsProtocol(i EmailsInterface) rpc.Protocol {
 				},
 			},
 			"setVisibilityAllEmail": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetVisibilityAllEmailArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetVisibilityAllEmailArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetVisibilityAllEmailArg)(nil), args)
@@ -211,11 +211,11 @@ func EmailsProtocol(i EmailsInterface) rpc.Protocol {
 				},
 			},
 			"getEmails": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetEmailsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetEmailsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetEmailsArg)(nil), args)
@@ -234,42 +234,42 @@ type EmailsClient struct {
 }
 
 func (c EmailsClient) AddEmail(ctx context.Context, __arg AddEmailArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.emails.addEmail", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.emails.addEmail", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c EmailsClient) DeleteEmail(ctx context.Context, __arg DeleteEmailArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.emails.deleteEmail", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.emails.deleteEmail", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c EmailsClient) EditEmail(ctx context.Context, __arg EditEmailArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.emails.editEmail", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.emails.editEmail", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c EmailsClient) SetPrimaryEmail(ctx context.Context, __arg SetPrimaryEmailArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.emails.setPrimaryEmail", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.emails.setPrimaryEmail", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c EmailsClient) SendVerificationEmail(ctx context.Context, __arg SendVerificationEmailArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.emails.sendVerificationEmail", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.emails.sendVerificationEmail", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c EmailsClient) SetVisibilityEmail(ctx context.Context, __arg SetVisibilityEmailArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.emails.setVisibilityEmail", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.emails.setVisibilityEmail", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c EmailsClient) SetVisibilityAllEmail(ctx context.Context, __arg SetVisibilityAllEmailArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.emails.setVisibilityAllEmail", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.emails.setVisibilityAllEmail", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c EmailsClient) GetEmails(ctx context.Context, sessionID int) (res []Email, err error) {
 	__arg := GetEmailsArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.emails.getEmails", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.emails.getEmails", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1270,7 +1270,7 @@ type ToStatusAble interface {
 // status object. If it is something that can be made into a Status object via the
 // ToStatusAble interface, then we'll try that. Otherwise, we'll just make a generic
 // Error type.
-func WrapError(e error) interface{} {
+func WrapError(e error) any {
 
 	if e == nil {
 		return nil
@@ -1311,13 +1311,13 @@ type ErrorUnwrapper struct {
 
 // MakeArg just makes a dummy object that we can unmarshal into, as needed by the
 // underlying RPC library.
-func (eu ErrorUnwrapper) MakeArg() interface{} {
+func (eu ErrorUnwrapper) MakeArg() any {
 	return &Status{}
 }
 
 // UnwrapError takes an incoming RPC object, attempts to coerce it into a Status
 // object, and then Upcasts via the Upcaster or just returns if not was provided.
-func (eu ErrorUnwrapper) UnwrapError(arg interface{}) (appError, dispatchError error) {
+func (eu ErrorUnwrapper) UnwrapError(arg any) (appError, dispatchError error) {
 	targ, ok := arg.(*Status)
 	if !ok {
 		dispatchError = errors.New("Error converting status to keybase1.Status object")
@@ -1907,10 +1907,12 @@ func (ut UserOrTeamID) IsValidID() bool {
 }
 
 // Preconditions:
-// 	-first four bits (in Little Endian) of UserOrTeamID are
-// 	 	independent and uniformly distributed
-//	-UserOrTeamID must have an even number of bits, or this will always
-//   	return 0
+//
+//		-first four bits (in Little Endian) of UserOrTeamID are
+//		 	independent and uniformly distributed
+//		-UserOrTeamID must have an even number of bits, or this will always
+//	  	return 0
+//
 // Returns a number in [0, shardCount) which can be treated as roughly
 // uniformly distributed. Used for things that need to shard by user.
 func (ut UserOrTeamID) GetShard(shardCount int) (int, error) {

--- a/go/protocol/keybase1/favorite.go
+++ b/go/protocol/keybase1/favorite.go
@@ -360,11 +360,11 @@ func FavoriteProtocol(i FavoriteInterface) rpc.Protocol {
 		Name: "keybase.1.favorite",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"favoriteAdd": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FavoriteAddArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FavoriteAddArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FavoriteAddArg)(nil), args)
@@ -375,11 +375,11 @@ func FavoriteProtocol(i FavoriteInterface) rpc.Protocol {
 				},
 			},
 			"favoriteIgnore": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FavoriteIgnoreArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FavoriteIgnoreArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FavoriteIgnoreArg)(nil), args)
@@ -390,11 +390,11 @@ func FavoriteProtocol(i FavoriteInterface) rpc.Protocol {
 				},
 			},
 			"getFavorites": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetFavoritesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetFavoritesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetFavoritesArg)(nil), args)
@@ -414,19 +414,19 @@ type FavoriteClient struct {
 
 // Adds a folder to a user's list of favorite folders.
 func (c FavoriteClient) FavoriteAdd(ctx context.Context, __arg FavoriteAddArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.favorite.favoriteAdd", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.favorite.favoriteAdd", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Removes a folder from a user's list of favorite folders.
 func (c FavoriteClient) FavoriteIgnore(ctx context.Context, __arg FavoriteIgnoreArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.favorite.favoriteIgnore", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.favorite.favoriteIgnore", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Returns all of a user's favorite folders.
 func (c FavoriteClient) GetFavorites(ctx context.Context, sessionID int) (res FavoritesResult, err error) {
 	__arg := GetFavoritesArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.favorite.getFavorites", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.favorite.getFavorites", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/featured_bot.go
+++ b/go/protocol/keybase1/featured_bot.go
@@ -120,11 +120,11 @@ func FeaturedBotProtocol(i FeaturedBotInterface) rpc.Protocol {
 		Name: "keybase.1.featuredBot",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"featuredBots": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FeaturedBotsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FeaturedBotsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FeaturedBotsArg)(nil), args)
@@ -135,11 +135,11 @@ func FeaturedBotProtocol(i FeaturedBotInterface) rpc.Protocol {
 				},
 			},
 			"search": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SearchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SearchArg)(nil), args)
@@ -150,11 +150,11 @@ func FeaturedBotProtocol(i FeaturedBotInterface) rpc.Protocol {
 				},
 			},
 			"searchLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SearchLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SearchLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SearchLocalArg)(nil), args)
@@ -173,16 +173,16 @@ type FeaturedBotClient struct {
 }
 
 func (c FeaturedBotClient) FeaturedBots(ctx context.Context, __arg FeaturedBotsArg) (res FeaturedBotsRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.featuredBot.featuredBots", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.featuredBot.featuredBots", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c FeaturedBotClient) Search(ctx context.Context, __arg SearchArg) (res SearchRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.featuredBot.search", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.featuredBot.search", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c FeaturedBotClient) SearchLocal(ctx context.Context, __arg SearchLocalArg) (res SearchRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.featuredBot.searchLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.featuredBot.searchLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/fs.go
+++ b/go/protocol/keybase1/fs.go
@@ -54,11 +54,11 @@ func FsProtocol(i FsInterface) rpc.Protocol {
 		Name: "keybase.1.fs",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"List": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ListArg)(nil), args)
@@ -78,6 +78,6 @@ type FsClient struct {
 
 // List files in a path. Implemented by KBFS service.
 func (c FsClient) List(ctx context.Context, __arg ListArg) (res ListResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.fs.List", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.fs.List", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/git.go
+++ b/go/protocol/keybase1/git.go
@@ -466,11 +466,11 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 		Name: "keybase.1.git",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"putGitMetadata": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PutGitMetadataArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PutGitMetadataArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PutGitMetadataArg)(nil), args)
@@ -481,11 +481,11 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 			},
 			"deleteGitMetadata": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteGitMetadataArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteGitMetadataArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteGitMetadataArg)(nil), args)
@@ -496,11 +496,11 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 			},
 			"getGitMetadata": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetGitMetadataArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetGitMetadataArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetGitMetadataArg)(nil), args)
@@ -511,21 +511,21 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 			},
 			"getAllGitMetadata": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetAllGitMetadataArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetAllGitMetadata(ctx)
 					return
 				},
 			},
 			"createPersonalRepo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CreatePersonalRepoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CreatePersonalRepoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CreatePersonalRepoArg)(nil), args)
@@ -536,11 +536,11 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 			},
 			"createTeamRepo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CreateTeamRepoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CreateTeamRepoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CreateTeamRepoArg)(nil), args)
@@ -551,11 +551,11 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 			},
 			"deletePersonalRepo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeletePersonalRepoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeletePersonalRepoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeletePersonalRepoArg)(nil), args)
@@ -566,11 +566,11 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 			},
 			"deleteTeamRepo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteTeamRepoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteTeamRepoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteTeamRepoArg)(nil), args)
@@ -581,11 +581,11 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 			},
 			"gcPersonalRepo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GcPersonalRepoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GcPersonalRepoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GcPersonalRepoArg)(nil), args)
@@ -596,11 +596,11 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 			},
 			"gcTeamRepo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GcTeamRepoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GcTeamRepoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GcTeamRepoArg)(nil), args)
@@ -611,11 +611,11 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 			},
 			"getTeamRepoSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamRepoSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamRepoSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamRepoSettingsArg)(nil), args)
@@ -626,11 +626,11 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 			},
 			"setTeamRepoSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetTeamRepoSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetTeamRepoSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetTeamRepoSettingsArg)(nil), args)
@@ -649,64 +649,64 @@ type GitClient struct {
 }
 
 func (c GitClient) PutGitMetadata(ctx context.Context, __arg PutGitMetadataArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.git.putGitMetadata", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.putGitMetadata", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) DeleteGitMetadata(ctx context.Context, __arg DeleteGitMetadataArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.git.deleteGitMetadata", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.deleteGitMetadata", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) GetGitMetadata(ctx context.Context, folder FolderHandle) (res []GitRepoResult, err error) {
 	__arg := GetGitMetadataArg{Folder: folder}
-	err = c.Cli.Call(ctx, "keybase.1.git.getGitMetadata", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.getGitMetadata", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) GetAllGitMetadata(ctx context.Context) (res []GitRepoResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.git.getAllGitMetadata", []interface{}{GetAllGitMetadataArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.getAllGitMetadata", []any{GetAllGitMetadataArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) CreatePersonalRepo(ctx context.Context, repoName GitRepoName) (res RepoID, err error) {
 	__arg := CreatePersonalRepoArg{RepoName: repoName}
-	err = c.Cli.Call(ctx, "keybase.1.git.createPersonalRepo", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.createPersonalRepo", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) CreateTeamRepo(ctx context.Context, __arg CreateTeamRepoArg) (res RepoID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.git.createTeamRepo", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.createTeamRepo", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) DeletePersonalRepo(ctx context.Context, repoName GitRepoName) (err error) {
 	__arg := DeletePersonalRepoArg{RepoName: repoName}
-	err = c.Cli.Call(ctx, "keybase.1.git.deletePersonalRepo", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.deletePersonalRepo", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) DeleteTeamRepo(ctx context.Context, __arg DeleteTeamRepoArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.git.deleteTeamRepo", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.deleteTeamRepo", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) GcPersonalRepo(ctx context.Context, __arg GcPersonalRepoArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.git.gcPersonalRepo", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.gcPersonalRepo", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) GcTeamRepo(ctx context.Context, __arg GcTeamRepoArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.git.gcTeamRepo", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.gcTeamRepo", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) GetTeamRepoSettings(ctx context.Context, __arg GetTeamRepoSettingsArg) (res GitTeamRepoSettings, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.git.getTeamRepoSettings", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.getTeamRepoSettings", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GitClient) SetTeamRepoSettings(ctx context.Context, __arg SetTeamRepoSettingsArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.git.setTeamRepoSettings", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.git.setTeamRepoSettings", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/gpg_ui.go
+++ b/go/protocol/keybase1/gpg_ui.go
@@ -66,11 +66,11 @@ func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
 		Name: "keybase.1.gpgUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"wantToAddGPGKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WantToAddGPGKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]WantToAddGPGKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]WantToAddGPGKeyArg)(nil), args)
@@ -81,11 +81,11 @@ func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
 				},
 			},
 			"confirmDuplicateKeyChosen": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ConfirmDuplicateKeyChosenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ConfirmDuplicateKeyChosenArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ConfirmDuplicateKeyChosenArg)(nil), args)
@@ -96,11 +96,11 @@ func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
 				},
 			},
 			"confirmImportSecretToExistingKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ConfirmImportSecretToExistingKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ConfirmImportSecretToExistingKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ConfirmImportSecretToExistingKeyArg)(nil), args)
@@ -111,11 +111,11 @@ func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
 				},
 			},
 			"selectKeyAndPushOption": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SelectKeyAndPushOptionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SelectKeyAndPushOptionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SelectKeyAndPushOptionArg)(nil), args)
@@ -126,11 +126,11 @@ func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
 				},
 			},
 			"selectKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SelectKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SelectKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SelectKeyArg)(nil), args)
@@ -141,11 +141,11 @@ func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
 				},
 			},
 			"sign": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SignArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SignArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SignArg)(nil), args)
@@ -156,11 +156,11 @@ func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
 				},
 			},
 			"getTTY": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTTYArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetTTY(ctx)
 					return
 				},
@@ -175,38 +175,38 @@ type GpgUiClient struct {
 
 func (c GpgUiClient) WantToAddGPGKey(ctx context.Context, sessionID int) (res bool, err error) {
 	__arg := WantToAddGPGKeyArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.gpgUi.wantToAddGPGKey", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gpgUi.wantToAddGPGKey", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GpgUiClient) ConfirmDuplicateKeyChosen(ctx context.Context, sessionID int) (res bool, err error) {
 	__arg := ConfirmDuplicateKeyChosenArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.gpgUi.confirmDuplicateKeyChosen", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gpgUi.confirmDuplicateKeyChosen", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GpgUiClient) ConfirmImportSecretToExistingKey(ctx context.Context, sessionID int) (res bool, err error) {
 	__arg := ConfirmImportSecretToExistingKeyArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.gpgUi.confirmImportSecretToExistingKey", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gpgUi.confirmImportSecretToExistingKey", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GpgUiClient) SelectKeyAndPushOption(ctx context.Context, __arg SelectKeyAndPushOptionArg) (res SelectKeyRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.gpgUi.selectKeyAndPushOption", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gpgUi.selectKeyAndPushOption", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GpgUiClient) SelectKey(ctx context.Context, __arg SelectKeyArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.gpgUi.selectKey", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gpgUi.selectKey", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GpgUiClient) Sign(ctx context.Context, __arg SignArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.gpgUi.sign", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gpgUi.sign", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GpgUiClient) GetTTY(ctx context.Context) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.gpgUi.getTTY", []interface{}{GetTTYArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gpgUi.getTTY", []any{GetTTYArg{}}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/gregor.go
+++ b/go/protocol/keybase1/gregor.go
@@ -54,21 +54,21 @@ func GregorProtocol(i GregorInterface) rpc.Protocol {
 		Name: "keybase.1.gregor",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getState": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetStateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetState(ctx)
 					return
 				},
 			},
 			"injectItem": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]InjectItemArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]InjectItemArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]InjectItemArg)(nil), args)
@@ -79,11 +79,11 @@ func GregorProtocol(i GregorInterface) rpc.Protocol {
 				},
 			},
 			"dismissCategory": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DismissCategoryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DismissCategoryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DismissCategoryArg)(nil), args)
@@ -94,11 +94,11 @@ func GregorProtocol(i GregorInterface) rpc.Protocol {
 				},
 			},
 			"dismissItem": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DismissItemArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DismissItemArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DismissItemArg)(nil), args)
@@ -109,11 +109,11 @@ func GregorProtocol(i GregorInterface) rpc.Protocol {
 				},
 			},
 			"updateItem": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpdateItemArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpdateItemArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpdateItemArg)(nil), args)
@@ -124,11 +124,11 @@ func GregorProtocol(i GregorInterface) rpc.Protocol {
 				},
 			},
 			"updateCategory": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpdateCategoryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpdateCategoryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpdateCategoryArg)(nil), args)
@@ -147,33 +147,33 @@ type GregorClient struct {
 }
 
 func (c GregorClient) GetState(ctx context.Context) (res gregor1.State, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.gregor.getState", []interface{}{GetStateArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gregor.getState", []any{GetStateArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GregorClient) InjectItem(ctx context.Context, __arg InjectItemArg) (res gregor1.MsgID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.gregor.injectItem", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gregor.injectItem", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GregorClient) DismissCategory(ctx context.Context, category gregor1.Category) (err error) {
 	__arg := DismissCategoryArg{Category: category}
-	err = c.Cli.Call(ctx, "keybase.1.gregor.dismissCategory", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gregor.dismissCategory", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c GregorClient) DismissItem(ctx context.Context, id gregor1.MsgID) (err error) {
 	__arg := DismissItemArg{Id: id}
-	err = c.Cli.Call(ctx, "keybase.1.gregor.dismissItem", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gregor.dismissItem", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c GregorClient) UpdateItem(ctx context.Context, __arg UpdateItemArg) (res gregor1.MsgID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.gregor.updateItem", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gregor.updateItem", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c GregorClient) UpdateCategory(ctx context.Context, __arg UpdateCategoryArg) (res gregor1.MsgID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.gregor.updateCategory", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.gregor.updateCategory", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/gregor_ui.go
+++ b/go/protocol/keybase1/gregor_ui.go
@@ -59,11 +59,11 @@ func GregorUIProtocol(i GregorUIInterface) rpc.Protocol {
 		Name: "keybase.1.gregorUI",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"pushState": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PushStateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PushStateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PushStateArg)(nil), args)
@@ -74,11 +74,11 @@ func GregorUIProtocol(i GregorUIInterface) rpc.Protocol {
 				},
 			},
 			"pushOutOfBandMessages": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PushOutOfBandMessagesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PushOutOfBandMessagesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PushOutOfBandMessagesArg)(nil), args)
@@ -97,12 +97,12 @@ type GregorUIClient struct {
 }
 
 func (c GregorUIClient) PushState(ctx context.Context, __arg PushStateArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.gregorUI.pushState", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.gregorUI.pushState", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c GregorUIClient) PushOutOfBandMessages(ctx context.Context, oobm []gregor1.OutOfBandMessage) (err error) {
 	__arg := PushOutOfBandMessagesArg{Oobm: oobm}
-	err = c.Cli.Notify(ctx, "keybase.1.gregorUI.pushOutOfBandMessages", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.gregorUI.pushOutOfBandMessages", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/home.go
+++ b/go/protocol/keybase1/home.go
@@ -925,11 +925,11 @@ func HomeProtocol(i HomeInterface) rpc.Protocol {
 		Name: "keybase.1.home",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"homeGetScreen": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HomeGetScreenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]HomeGetScreenArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]HomeGetScreenArg)(nil), args)
@@ -940,11 +940,11 @@ func HomeProtocol(i HomeInterface) rpc.Protocol {
 				},
 			},
 			"homeSkipTodoType": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HomeSkipTodoTypeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]HomeSkipTodoTypeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]HomeSkipTodoTypeArg)(nil), args)
@@ -955,11 +955,11 @@ func HomeProtocol(i HomeInterface) rpc.Protocol {
 				},
 			},
 			"homeDismissAnnouncement": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HomeDismissAnnouncementArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]HomeDismissAnnouncementArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]HomeDismissAnnouncementArg)(nil), args)
@@ -970,21 +970,21 @@ func HomeProtocol(i HomeInterface) rpc.Protocol {
 				},
 			},
 			"homeActionTaken": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HomeActionTakenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.HomeActionTaken(ctx)
 					return
 				},
 			},
 			"homeMarkViewed": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HomeMarkViewedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.HomeMarkViewed(ctx)
 					return
 				},
@@ -1005,28 +1005,28 @@ type HomeClient struct {
 // the default number will be returned (10).  Otherwise, the caller should
 // specify.
 func (c HomeClient) HomeGetScreen(ctx context.Context, __arg HomeGetScreenArg) (res HomeScreen, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.home.homeGetScreen", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.home.homeGetScreen", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c HomeClient) HomeSkipTodoType(ctx context.Context, t HomeScreenTodoType) (err error) {
 	__arg := HomeSkipTodoTypeArg{T: t}
-	err = c.Cli.Call(ctx, "keybase.1.home.homeSkipTodoType", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.home.homeSkipTodoType", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c HomeClient) HomeDismissAnnouncement(ctx context.Context, i HomeScreenAnnouncementID) (err error) {
 	__arg := HomeDismissAnnouncementArg{I: i}
-	err = c.Cli.Call(ctx, "keybase.1.home.homeDismissAnnouncement", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.home.homeDismissAnnouncement", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c HomeClient) HomeActionTaken(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.home.homeActionTaken", []interface{}{HomeActionTakenArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.home.homeActionTaken", []any{HomeActionTakenArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c HomeClient) HomeMarkViewed(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.home.homeMarkViewed", []interface{}{HomeMarkViewedArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.home.homeMarkViewed", []any{HomeMarkViewedArg{}}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/home_ui.go
+++ b/go/protocol/keybase1/home_ui.go
@@ -21,11 +21,11 @@ func HomeUIProtocol(i HomeUIInterface) rpc.Protocol {
 		Name: "keybase.1.homeUI",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"homeUIRefresh": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HomeUIRefreshArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.HomeUIRefresh(ctx)
 					return
 				},
@@ -39,6 +39,6 @@ type HomeUIClient struct {
 }
 
 func (c HomeUIClient) HomeUIRefresh(ctx context.Context) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.homeUI.homeUIRefresh", []interface{}{HomeUIRefreshArg{}}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.homeUI.homeUIRefresh", []any{HomeUIRefreshArg{}}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/identify.go
+++ b/go/protocol/keybase1/identify.go
@@ -229,11 +229,11 @@ func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
 		Name: "keybase.1.identify",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"Resolve3": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Resolve3Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Resolve3Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Resolve3Arg)(nil), args)
@@ -244,11 +244,11 @@ func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
 				},
 			},
 			"identify2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify2Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify2Arg)(nil), args)
@@ -259,11 +259,11 @@ func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
 				},
 			},
 			"identifyLite": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]IdentifyLiteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]IdentifyLiteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]IdentifyLiteArg)(nil), args)
@@ -274,11 +274,11 @@ func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
 				},
 			},
 			"resolveIdentifyImplicitTeam": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ResolveIdentifyImplicitTeamArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ResolveIdentifyImplicitTeamArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ResolveIdentifyImplicitTeamArg)(nil), args)
@@ -289,11 +289,11 @@ func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
 				},
 			},
 			"resolveImplicitTeam": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ResolveImplicitTeamArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ResolveImplicitTeamArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ResolveImplicitTeamArg)(nil), args)
@@ -304,11 +304,11 @@ func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
 				},
 			},
 			"normalizeSocialAssertion": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NormalizeSocialAssertionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NormalizeSocialAssertionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NormalizeSocialAssertionArg)(nil), args)
@@ -328,34 +328,34 @@ type IdentifyClient struct {
 
 // Resolve an assertion to a (UID,username) or (TeamID,teamname). On failure, returns an error.
 func (c IdentifyClient) Resolve3(ctx context.Context, __arg Resolve3Arg) (res UserOrTeamLite, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identify.Resolve3", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identify.Resolve3", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyClient) Identify2(ctx context.Context, __arg Identify2Arg) (res Identify2Res, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identify.identify2", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identify.identify2", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyClient) IdentifyLite(ctx context.Context, __arg IdentifyLiteArg) (res IdentifyLiteRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identify.identifyLite", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identify.identifyLite", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyClient) ResolveIdentifyImplicitTeam(ctx context.Context, __arg ResolveIdentifyImplicitTeamArg) (res ResolveIdentifyImplicitTeamRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identify.resolveIdentifyImplicitTeam", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identify.resolveIdentifyImplicitTeam", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // resolveImplicitTeam returns a TLF display name given a teamID. The publicness
 // of the team is inferred from the TeamID.
 func (c IdentifyClient) ResolveImplicitTeam(ctx context.Context, __arg ResolveImplicitTeamArg) (res Folder, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identify.resolveImplicitTeam", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identify.resolveImplicitTeam", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyClient) NormalizeSocialAssertion(ctx context.Context, assertion string) (res SocialAssertion, err error) {
 	__arg := NormalizeSocialAssertionArg{Assertion: assertion}
-	err = c.Cli.Call(ctx, "keybase.1.identify.normalizeSocialAssertion", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identify.normalizeSocialAssertion", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/identify3.go
+++ b/go/protocol/keybase1/identify3.go
@@ -35,11 +35,11 @@ func Identify3Protocol(i Identify3Interface) rpc.Protocol {
 		Name: "keybase.1.identify3",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"identify3": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify3Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify3Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify3Arg)(nil), args)
@@ -50,11 +50,11 @@ func Identify3Protocol(i Identify3Interface) rpc.Protocol {
 				},
 			},
 			"identify3FollowUser": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify3FollowUserArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify3FollowUserArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify3FollowUserArg)(nil), args)
@@ -65,11 +65,11 @@ func Identify3Protocol(i Identify3Interface) rpc.Protocol {
 				},
 			},
 			"identify3IgnoreUser": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify3IgnoreUserArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify3IgnoreUserArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify3IgnoreUserArg)(nil), args)
@@ -88,17 +88,17 @@ type Identify3Client struct {
 }
 
 func (c Identify3Client) Identify3(ctx context.Context, __arg Identify3Arg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identify3.identify3", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identify3.identify3", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c Identify3Client) Identify3FollowUser(ctx context.Context, __arg Identify3FollowUserArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identify3.identify3FollowUser", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identify3.identify3FollowUser", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c Identify3Client) Identify3IgnoreUser(ctx context.Context, guiID Identify3GUIID) (err error) {
 	__arg := Identify3IgnoreUserArg{GuiID: guiID}
-	err = c.Cli.Call(ctx, "keybase.1.identify3.identify3IgnoreUser", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identify3.identify3IgnoreUser", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/identify3_ui.go
+++ b/go/protocol/keybase1/identify3_ui.go
@@ -294,11 +294,11 @@ func Identify3UiProtocol(i Identify3UiInterface) rpc.Protocol {
 		Name: "keybase.1.identify3Ui",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"identify3ShowTracker": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify3ShowTrackerArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify3ShowTrackerArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify3ShowTrackerArg)(nil), args)
@@ -309,11 +309,11 @@ func Identify3UiProtocol(i Identify3UiInterface) rpc.Protocol {
 				},
 			},
 			"identify3Summary": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify3SummaryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify3SummaryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify3SummaryArg)(nil), args)
@@ -324,11 +324,11 @@ func Identify3UiProtocol(i Identify3UiInterface) rpc.Protocol {
 				},
 			},
 			"identify3UpdateRow": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify3UpdateRowArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify3UpdateRowArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify3UpdateRowArg)(nil), args)
@@ -339,11 +339,11 @@ func Identify3UiProtocol(i Identify3UiInterface) rpc.Protocol {
 				},
 			},
 			"identify3UserReset": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify3UserResetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify3UserResetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify3UserResetArg)(nil), args)
@@ -354,11 +354,11 @@ func Identify3UiProtocol(i Identify3UiInterface) rpc.Protocol {
 				},
 			},
 			"identify3UpdateUserCard": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify3UpdateUserCardArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify3UpdateUserCardArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify3UpdateUserCardArg)(nil), args)
@@ -369,11 +369,11 @@ func Identify3UiProtocol(i Identify3UiInterface) rpc.Protocol {
 				},
 			},
 			"identify3TrackerTimedOut": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify3TrackerTimedOutArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify3TrackerTimedOutArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify3TrackerTimedOutArg)(nil), args)
@@ -384,11 +384,11 @@ func Identify3UiProtocol(i Identify3UiInterface) rpc.Protocol {
 				},
 			},
 			"identify3Result": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Identify3ResultArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Identify3ResultArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Identify3ResultArg)(nil), args)
@@ -407,40 +407,40 @@ type Identify3UiClient struct {
 }
 
 func (c Identify3UiClient) Identify3ShowTracker(ctx context.Context, __arg Identify3ShowTrackerArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identify3Ui.identify3ShowTracker", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identify3Ui.identify3ShowTracker", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c Identify3UiClient) Identify3Summary(ctx context.Context, summary Identify3Summary) (err error) {
 	__arg := Identify3SummaryArg{Summary: summary}
-	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3Summary", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3Summary", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c Identify3UiClient) Identify3UpdateRow(ctx context.Context, row Identify3Row) (err error) {
 	__arg := Identify3UpdateRowArg{Row: row}
-	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3UpdateRow", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3UpdateRow", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c Identify3UiClient) Identify3UserReset(ctx context.Context, guiID Identify3GUIID) (err error) {
 	__arg := Identify3UserResetArg{GuiID: guiID}
-	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3UserReset", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3UserReset", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c Identify3UiClient) Identify3UpdateUserCard(ctx context.Context, __arg Identify3UpdateUserCardArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3UpdateUserCard", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3UpdateUserCard", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c Identify3UiClient) Identify3TrackerTimedOut(ctx context.Context, guiID Identify3GUIID) (err error) {
 	__arg := Identify3TrackerTimedOutArg{GuiID: guiID}
-	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3TrackerTimedOut", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3TrackerTimedOut", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c Identify3UiClient) Identify3Result(ctx context.Context, __arg Identify3ResultArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3Result", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.identify3Ui.identify3Result", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/identify_ui.go
+++ b/go/protocol/keybase1/identify_ui.go
@@ -558,11 +558,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 		Name: "keybase.1.identifyUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"displayTLFCreateWithInvite": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayTLFCreateWithInviteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayTLFCreateWithInviteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayTLFCreateWithInviteArg)(nil), args)
@@ -573,21 +573,21 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"delegateIdentifyUI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DelegateIdentifyUIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.DelegateIdentifyUI(ctx)
 					return
 				},
 			},
 			"start": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StartArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]StartArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]StartArg)(nil), args)
@@ -598,11 +598,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"displayKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayKeyArg)(nil), args)
@@ -613,11 +613,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"reportLastTrack": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ReportLastTrackArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ReportLastTrackArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ReportLastTrackArg)(nil), args)
@@ -628,11 +628,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"launchNetworkChecks": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LaunchNetworkChecksArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LaunchNetworkChecksArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LaunchNetworkChecksArg)(nil), args)
@@ -643,11 +643,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"displayTrackStatement": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayTrackStatementArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayTrackStatementArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayTrackStatementArg)(nil), args)
@@ -658,11 +658,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"finishWebProofCheck": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FinishWebProofCheckArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FinishWebProofCheckArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FinishWebProofCheckArg)(nil), args)
@@ -673,11 +673,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"finishSocialProofCheck": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FinishSocialProofCheckArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FinishSocialProofCheckArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FinishSocialProofCheckArg)(nil), args)
@@ -688,11 +688,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"displayCryptocurrency": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayCryptocurrencyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayCryptocurrencyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayCryptocurrencyArg)(nil), args)
@@ -703,11 +703,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"displayStellarAccount": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayStellarAccountArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayStellarAccountArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayStellarAccountArg)(nil), args)
@@ -718,11 +718,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"reportTrackToken": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ReportTrackTokenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ReportTrackTokenArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ReportTrackTokenArg)(nil), args)
@@ -733,11 +733,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"displayUserCard": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayUserCardArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayUserCardArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayUserCardArg)(nil), args)
@@ -748,11 +748,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"confirm": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ConfirmArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ConfirmArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ConfirmArg)(nil), args)
@@ -763,11 +763,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"cancel": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CancelArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CancelArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CancelArg)(nil), args)
@@ -778,11 +778,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"finish": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FinishArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FinishArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FinishArg)(nil), args)
@@ -793,11 +793,11 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 			},
 			"dismiss": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DismissArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DismissArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DismissArg)(nil), args)
@@ -816,88 +816,88 @@ type IdentifyUiClient struct {
 }
 
 func (c IdentifyUiClient) DisplayTLFCreateWithInvite(ctx context.Context, __arg DisplayTLFCreateWithInviteArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayTLFCreateWithInvite", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayTLFCreateWithInvite", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) DelegateIdentifyUI(ctx context.Context) (res int, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.delegateIdentifyUI", []interface{}{DelegateIdentifyUIArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.delegateIdentifyUI", []any{DelegateIdentifyUIArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) Start(ctx context.Context, __arg StartArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.start", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.start", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) DisplayKey(ctx context.Context, __arg DisplayKeyArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayKey", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayKey", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) ReportLastTrack(ctx context.Context, __arg ReportLastTrackArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.reportLastTrack", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.reportLastTrack", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) LaunchNetworkChecks(ctx context.Context, __arg LaunchNetworkChecksArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.launchNetworkChecks", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.launchNetworkChecks", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) DisplayTrackStatement(ctx context.Context, __arg DisplayTrackStatementArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayTrackStatement", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayTrackStatement", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) FinishWebProofCheck(ctx context.Context, __arg FinishWebProofCheckArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.finishWebProofCheck", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.finishWebProofCheck", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) FinishSocialProofCheck(ctx context.Context, __arg FinishSocialProofCheckArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.finishSocialProofCheck", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.finishSocialProofCheck", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) DisplayCryptocurrency(ctx context.Context, __arg DisplayCryptocurrencyArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayCryptocurrency", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayCryptocurrency", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) DisplayStellarAccount(ctx context.Context, __arg DisplayStellarAccountArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayStellarAccount", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayStellarAccount", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) ReportTrackToken(ctx context.Context, __arg ReportTrackTokenArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.reportTrackToken", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.reportTrackToken", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) DisplayUserCard(ctx context.Context, __arg DisplayUserCardArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayUserCard", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayUserCard", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) Confirm(ctx context.Context, __arg ConfirmArg) (res ConfirmResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.confirm", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.confirm", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) Cancel(ctx context.Context, sessionID int) (err error) {
 	__arg := CancelArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.cancel", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.cancel", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) Finish(ctx context.Context, sessionID int) (err error) {
 	__arg := FinishArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.finish", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.finish", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c IdentifyUiClient) Dismiss(ctx context.Context, __arg DismissArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identifyUi.dismiss", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.dismiss", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/implicit_team_migration.go
+++ b/go/protocol/keybase1/implicit_team_migration.go
@@ -27,11 +27,11 @@ func ImplicitTeamMigrationProtocol(i ImplicitTeamMigrationInterface) rpc.Protoco
 		Name: "keybase.1.implicitTeamMigration",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"startMigration": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StartMigrationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]StartMigrationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]StartMigrationArg)(nil), args)
@@ -42,11 +42,11 @@ func ImplicitTeamMigrationProtocol(i ImplicitTeamMigrationInterface) rpc.Protoco
 				},
 			},
 			"finalizeMigration": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FinalizeMigrationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FinalizeMigrationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FinalizeMigrationArg)(nil), args)
@@ -66,12 +66,12 @@ type ImplicitTeamMigrationClient struct {
 
 func (c ImplicitTeamMigrationClient) StartMigration(ctx context.Context, folder Folder) (err error) {
 	__arg := StartMigrationArg{Folder: folder}
-	err = c.Cli.Call(ctx, "keybase.1.implicitTeamMigration.startMigration", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.implicitTeamMigration.startMigration", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ImplicitTeamMigrationClient) FinalizeMigration(ctx context.Context, folder Folder) (err error) {
 	__arg := FinalizeMigrationArg{Folder: folder}
-	err = c.Cli.Call(ctx, "keybase.1.implicitTeamMigration.finalizeMigration", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.implicitTeamMigration.finalizeMigration", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/incoming-share.go
+++ b/go/protocol/keybase1/incoming-share.go
@@ -157,31 +157,31 @@ func IncomingShareProtocol(i IncomingShareInterface) rpc.Protocol {
 		Name: "keybase.1.incomingShare",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getIncomingShareItems": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetIncomingShareItemsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetIncomingShareItems(ctx)
 					return
 				},
 			},
 			"getPreference": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPreferenceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetPreference(ctx)
 					return
 				},
 			},
 			"setPreference": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetPreferenceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetPreferenceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetPreferenceArg)(nil), args)
@@ -200,17 +200,17 @@ type IncomingShareClient struct {
 }
 
 func (c IncomingShareClient) GetIncomingShareItems(ctx context.Context) (res []IncomingShareItem, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.incomingShare.getIncomingShareItems", []interface{}{GetIncomingShareItemsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.incomingShare.getIncomingShareItems", []any{GetIncomingShareItemsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c IncomingShareClient) GetPreference(ctx context.Context) (res IncomingSharePreference, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.incomingShare.getPreference", []interface{}{GetPreferenceArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.incomingShare.getPreference", []any{GetPreferenceArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c IncomingShareClient) SetPreference(ctx context.Context, preference IncomingSharePreference) (err error) {
 	__arg := SetPreferenceArg{Preference: preference}
-	err = c.Cli.Call(ctx, "keybase.1.incomingShare.setPreference", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.incomingShare.setPreference", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/install.go
+++ b/go/protocol/keybase1/install.go
@@ -271,11 +271,11 @@ func InstallProtocol(i InstallInterface) rpc.Protocol {
 		Name: "keybase.1.install",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"fuseStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FuseStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FuseStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FuseStatusArg)(nil), args)
@@ -286,41 +286,41 @@ func InstallProtocol(i InstallInterface) rpc.Protocol {
 				},
 			},
 			"installFuse": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]InstallFuseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.InstallFuse(ctx)
 					return
 				},
 			},
 			"installKBFS": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]InstallKBFSArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.InstallKBFS(ctx)
 					return
 				},
 			},
 			"uninstallKBFS": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UninstallKBFSArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.UninstallKBFS(ctx)
 					return
 				},
 			},
 			"installCommandLinePrivileged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]InstallCommandLinePrivilegedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.InstallCommandLinePrivileged(ctx)
 					return
 				},
@@ -334,26 +334,26 @@ type InstallClient struct {
 }
 
 func (c InstallClient) FuseStatus(ctx context.Context, __arg FuseStatusArg) (res FuseStatus, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.install.fuseStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.install.fuseStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c InstallClient) InstallFuse(ctx context.Context) (res InstallResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.install.installFuse", []interface{}{InstallFuseArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.install.installFuse", []any{InstallFuseArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c InstallClient) InstallKBFS(ctx context.Context) (res InstallResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.install.installKBFS", []interface{}{InstallKBFSArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.install.installKBFS", []any{InstallKBFSArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c InstallClient) UninstallKBFS(ctx context.Context) (res UninstallResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.install.uninstallKBFS", []interface{}{UninstallKBFSArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.install.uninstallKBFS", []any{UninstallKBFSArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c InstallClient) InstallCommandLinePrivileged(ctx context.Context) (res InstallResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.install.installCommandLinePrivileged", []interface{}{InstallCommandLinePrivilegedArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.install.installCommandLinePrivileged", []any{InstallCommandLinePrivilegedArg{}}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/invite_friends.go
+++ b/go/protocol/keybase1/invite_friends.go
@@ -83,11 +83,11 @@ func InviteFriendsProtocol(i InviteFriendsInterface) rpc.Protocol {
 		Name: "keybase.1.inviteFriends",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"invitePeople": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]InvitePeopleArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]InvitePeopleArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]InvitePeopleArg)(nil), args)
@@ -98,21 +98,21 @@ func InviteFriendsProtocol(i InviteFriendsInterface) rpc.Protocol {
 				},
 			},
 			"getInviteCounts": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetInviteCountsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetInviteCounts(ctx)
 					return
 				},
 			},
 			"requestInviteCounts": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RequestInviteCountsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.RequestInviteCounts(ctx)
 					return
 				},
@@ -126,16 +126,16 @@ type InviteFriendsClient struct {
 }
 
 func (c InviteFriendsClient) InvitePeople(ctx context.Context, __arg InvitePeopleArg) (res int, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.inviteFriends.invitePeople", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.inviteFriends.invitePeople", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c InviteFriendsClient) GetInviteCounts(ctx context.Context) (res InviteCounts, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.inviteFriends.getInviteCounts", []interface{}{GetInviteCountsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.inviteFriends.getInviteCounts", []any{GetInviteCountsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c InviteFriendsClient) RequestInviteCounts(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.inviteFriends.requestInviteCounts", []interface{}{RequestInviteCountsArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.inviteFriends.requestInviteCounts", []any{RequestInviteCountsArg{}}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/kbfs.go
+++ b/go/protocol/keybase1/kbfs.go
@@ -137,11 +137,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 		Name: "keybase.1.kbfs",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"FSEvent": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSEventArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSEventArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSEventArg)(nil), args)
@@ -152,11 +152,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"FSPathUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSPathUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSPathUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSPathUpdateArg)(nil), args)
@@ -167,11 +167,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"FSEditList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSEditListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSEditListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSEditListArg)(nil), args)
@@ -182,11 +182,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"FSSyncStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSSyncStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSSyncStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSSyncStatusArg)(nil), args)
@@ -197,11 +197,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"FSSyncEvent": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSSyncEventArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSSyncEventArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSSyncEventArg)(nil), args)
@@ -212,11 +212,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"FSOverallSyncEvent": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSOverallSyncEventArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSOverallSyncEventArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSOverallSyncEventArg)(nil), args)
@@ -227,11 +227,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"FSOnlineStatusChangedEvent": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSOnlineStatusChangedEventArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSOnlineStatusChangedEventArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSOnlineStatusChangedEventArg)(nil), args)
@@ -242,21 +242,21 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"FSFavoritesChangedEvent": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSFavoritesChangedEventArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.FSFavoritesChangedEvent(ctx)
 					return
 				},
 			},
 			"FSSubscriptionNotifyPathEvent": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSSubscriptionNotifyPathEventArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSSubscriptionNotifyPathEventArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSSubscriptionNotifyPathEventArg)(nil), args)
@@ -267,11 +267,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"FSSubscriptionNotifyEvent": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSSubscriptionNotifyEventArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSSubscriptionNotifyEventArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSSubscriptionNotifyEventArg)(nil), args)
@@ -282,11 +282,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"createTLF": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CreateTLFArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CreateTLFArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CreateTLFArg)(nil), args)
@@ -297,11 +297,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"getKBFSTeamSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetKBFSTeamSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetKBFSTeamSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetKBFSTeamSettingsArg)(nil), args)
@@ -312,11 +312,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"upgradeTLF": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpgradeTLFArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpgradeTLFArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpgradeTLFArg)(nil), args)
@@ -327,11 +327,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"encryptFavorites": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]EncryptFavoritesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]EncryptFavoritesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]EncryptFavoritesArg)(nil), args)
@@ -342,11 +342,11 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 				},
 			},
 			"decryptFavorites": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DecryptFavoritesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DecryptFavoritesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DecryptFavoritesArg)(nil), args)
@@ -374,7 +374,7 @@ type KbfsClient struct {
 // the clients.
 func (c KbfsClient) FSEvent(ctx context.Context, event FSNotification) (err error) {
 	__arg := FSEventArg{Event: event}
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSEvent", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSEvent", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -382,21 +382,21 @@ func (c KbfsClient) FSEvent(ctx context.Context, event FSNotification) (err erro
 // SimpleFSList[Recursive call) has been updated.
 func (c KbfsClient) FSPathUpdate(ctx context.Context, path string) (err error) {
 	__arg := FSPathUpdateArg{Path: path}
-	err = c.Cli.Notify(ctx, "keybase.1.kbfs.FSPathUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.kbfs.FSPathUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 // kbfs calls this as a response to receiving an FSEditListRequest with a
 // given requestID.
 func (c KbfsClient) FSEditList(ctx context.Context, __arg FSEditListArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSEditList", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSEditList", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // FSSyncStatus is called by KBFS as a response to receiving an
 // FSSyncStatusRequest with a given requestID.
 func (c KbfsClient) FSSyncStatus(ctx context.Context, __arg FSSyncStatusArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSSyncStatus", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSSyncStatus", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -404,7 +404,7 @@ func (c KbfsClient) FSSyncStatus(ctx context.Context, __arg FSSyncStatusArg) (er
 // changes.
 func (c KbfsClient) FSSyncEvent(ctx context.Context, event FSPathSyncStatus) (err error) {
 	__arg := FSSyncEventArg{Event: event}
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSSyncEvent", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSSyncEvent", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -412,62 +412,62 @@ func (c KbfsClient) FSSyncEvent(ctx context.Context, event FSPathSyncStatus) (er
 // changes.
 func (c KbfsClient) FSOverallSyncEvent(ctx context.Context, status FolderSyncStatus) (err error) {
 	__arg := FSOverallSyncEventArg{Status: status}
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSOverallSyncEvent", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSOverallSyncEvent", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // FSOnlineStatusChangedEvent is called by KBFS when the online status changes.
 func (c KbfsClient) FSOnlineStatusChangedEvent(ctx context.Context, online bool) (err error) {
 	__arg := FSOnlineStatusChangedEventArg{Online: online}
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSOnlineStatusChangedEvent", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSOnlineStatusChangedEvent", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // FSFavoritesChangedEvent is called by KBFS when the favorites list changes.
 func (c KbfsClient) FSFavoritesChangedEvent(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSFavoritesChangedEvent", []interface{}{FSFavoritesChangedEventArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSFavoritesChangedEvent", []any{FSFavoritesChangedEventArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c KbfsClient) FSSubscriptionNotifyPathEvent(ctx context.Context, __arg FSSubscriptionNotifyPathEventArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSSubscriptionNotifyPathEvent", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSSubscriptionNotifyPathEvent", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c KbfsClient) FSSubscriptionNotifyEvent(ctx context.Context, __arg FSSubscriptionNotifyEventArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSSubscriptionNotifyEvent", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSSubscriptionNotifyEvent", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // createTLF is called by KBFS to associate the tlfID with the given teamID,
 // using the v2 Team-based system.
 func (c KbfsClient) CreateTLF(ctx context.Context, __arg CreateTLFArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.createTLF", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.createTLF", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // getKBFSTeamSettings gets the settings written for the team in the team's sigchain.
 func (c KbfsClient) GetKBFSTeamSettings(ctx context.Context, __arg GetKBFSTeamSettingsArg) (res KBFSTeamSettings, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.getKBFSTeamSettings", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.getKBFSTeamSettings", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // upgradeTLF upgrades a TLF to use implicit team keys
 func (c KbfsClient) UpgradeTLF(ctx context.Context, __arg UpgradeTLFArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.upgradeTLF", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.upgradeTLF", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Encrypt cached favorites to store on disk.
 func (c KbfsClient) EncryptFavorites(ctx context.Context, dataToEncrypt []byte) (res []byte, err error) {
 	__arg := EncryptFavoritesArg{DataToEncrypt: dataToEncrypt}
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.encryptFavorites", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.encryptFavorites", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Decrypt cached favorites stored on disk.
 func (c KbfsClient) DecryptFavorites(ctx context.Context, dataToEncrypt []byte) (res []byte, err error) {
 	__arg := DecryptFavoritesArg{DataToEncrypt: dataToEncrypt}
-	err = c.Cli.Call(ctx, "keybase.1.kbfs.decryptFavorites", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.decryptFavorites", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/kbfs_git.go
+++ b/go/protocol/keybase1/kbfs_git.go
@@ -57,11 +57,11 @@ func KBFSGitProtocol(i KBFSGitInterface) rpc.Protocol {
 		Name: "keybase.1.KBFSGit",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"createRepo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CreateRepoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CreateRepoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CreateRepoArg)(nil), args)
@@ -72,11 +72,11 @@ func KBFSGitProtocol(i KBFSGitInterface) rpc.Protocol {
 				},
 			},
 			"deleteRepo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteRepoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteRepoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteRepoArg)(nil), args)
@@ -87,11 +87,11 @@ func KBFSGitProtocol(i KBFSGitInterface) rpc.Protocol {
 				},
 			},
 			"gc": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GcArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GcArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GcArg)(nil), args)
@@ -112,19 +112,19 @@ type KBFSGitClient struct {
 // * createRepo creates a bare empty repo on KBFS under the given name in the given TLF.
 // * It returns the ID of the repo created.
 func (c KBFSGitClient) CreateRepo(ctx context.Context, __arg CreateRepoArg) (res RepoID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.KBFSGit.createRepo", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.KBFSGit.createRepo", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // * deleteRepo deletes repo on KBFS under the given name in the given TLF.
 func (c KBFSGitClient) DeleteRepo(ctx context.Context, __arg DeleteRepoArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.KBFSGit.deleteRepo", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.KBFSGit.deleteRepo", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // * gc runs garbage collection on the given repo, using the given options to
 // * see whether anything needs to be done.
 func (c KBFSGitClient) Gc(ctx context.Context, __arg GcArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.KBFSGit.gc", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.KBFSGit.gc", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/kbfsmount.go
+++ b/go/protocol/keybase1/kbfsmount.go
@@ -43,51 +43,51 @@ func KbfsMountProtocol(i KbfsMountInterface) rpc.Protocol {
 		Name: "keybase.1.kbfsMount",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"GetCurrentMountDir": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetCurrentMountDirArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetCurrentMountDir(ctx)
 					return
 				},
 			},
 			"WaitForMounts": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WaitForMountsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.WaitForMounts(ctx)
 					return
 				},
 			},
 			"GetPreferredMountDirs": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPreferredMountDirsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetPreferredMountDirs(ctx)
 					return
 				},
 			},
 			"GetAllAvailableMountDirs": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetAllAvailableMountDirsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetAllAvailableMountDirs(ctx)
 					return
 				},
 			},
 			"SetCurrentMountDir": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetCurrentMountDirArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetCurrentMountDirArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetCurrentMountDirArg)(nil), args)
@@ -98,11 +98,11 @@ func KbfsMountProtocol(i KbfsMountInterface) rpc.Protocol {
 				},
 			},
 			"GetKBFSPathInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetKBFSPathInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetKBFSPathInfoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetKBFSPathInfoArg)(nil), args)
@@ -121,33 +121,33 @@ type KbfsMountClient struct {
 }
 
 func (c KbfsMountClient) GetCurrentMountDir(ctx context.Context) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.GetCurrentMountDir", []interface{}{GetCurrentMountDirArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.GetCurrentMountDir", []any{GetCurrentMountDirArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c KbfsMountClient) WaitForMounts(ctx context.Context) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.WaitForMounts", []interface{}{WaitForMountsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.WaitForMounts", []any{WaitForMountsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c KbfsMountClient) GetPreferredMountDirs(ctx context.Context) (res []string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.GetPreferredMountDirs", []interface{}{GetPreferredMountDirsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.GetPreferredMountDirs", []any{GetPreferredMountDirsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c KbfsMountClient) GetAllAvailableMountDirs(ctx context.Context) (res []string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.GetAllAvailableMountDirs", []interface{}{GetAllAvailableMountDirsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.GetAllAvailableMountDirs", []any{GetAllAvailableMountDirsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c KbfsMountClient) SetCurrentMountDir(ctx context.Context, dir string) (err error) {
 	__arg := SetCurrentMountDirArg{Dir: dir}
-	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.SetCurrentMountDir", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.SetCurrentMountDir", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c KbfsMountClient) GetKBFSPathInfo(ctx context.Context, standardPath string) (res KBFSPathInfo, err error) {
 	__arg := GetKBFSPathInfoArg{StandardPath: standardPath}
-	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.GetKBFSPathInfo", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kbfsMount.GetKBFSPathInfo", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/kex2provisionee.go
+++ b/go/protocol/keybase1/kex2provisionee.go
@@ -66,11 +66,11 @@ func Kex2ProvisioneeProtocol(i Kex2ProvisioneeInterface) rpc.Protocol {
 		Name: "keybase.1.Kex2Provisionee",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"hello": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HelloArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]HelloArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]HelloArg)(nil), args)
@@ -81,11 +81,11 @@ func Kex2ProvisioneeProtocol(i Kex2ProvisioneeInterface) rpc.Protocol {
 				},
 			},
 			"didCounterSign": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DidCounterSignArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DidCounterSignArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DidCounterSignArg)(nil), args)
@@ -104,12 +104,12 @@ type Kex2ProvisioneeClient struct {
 }
 
 func (c Kex2ProvisioneeClient) Hello(ctx context.Context, __arg HelloArg) (res HelloRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.Kex2Provisionee.hello", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.Kex2Provisionee.hello", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c Kex2ProvisioneeClient) DidCounterSign(ctx context.Context, sig []byte) (err error) {
 	__arg := DidCounterSignArg{Sig: sig}
-	err = c.Cli.Call(ctx, "keybase.1.Kex2Provisionee.didCounterSign", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.Kex2Provisionee.didCounterSign", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/kex2provisionee2.go
+++ b/go/protocol/keybase1/kex2provisionee2.go
@@ -61,11 +61,11 @@ func Kex2Provisionee2Protocol(i Kex2Provisionee2Interface) rpc.Protocol {
 		Name: "keybase.1.Kex2Provisionee2",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"hello2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Hello2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]Hello2Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]Hello2Arg)(nil), args)
@@ -76,11 +76,11 @@ func Kex2Provisionee2Protocol(i Kex2Provisionee2Interface) rpc.Protocol {
 				},
 			},
 			"didCounterSign2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DidCounterSign2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DidCounterSign2Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DidCounterSign2Arg)(nil), args)
@@ -99,11 +99,11 @@ type Kex2Provisionee2Client struct {
 }
 
 func (c Kex2Provisionee2Client) Hello2(ctx context.Context, __arg Hello2Arg) (res Hello2Res, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.Kex2Provisionee2.hello2", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.Kex2Provisionee2.hello2", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c Kex2Provisionee2Client) DidCounterSign2(ctx context.Context, __arg DidCounterSign2Arg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.Kex2Provisionee2.didCounterSign2", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.Kex2Provisionee2.didCounterSign2", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/kex2provisioner.go
+++ b/go/protocol/keybase1/kex2provisioner.go
@@ -21,11 +21,11 @@ func Kex2ProvisionerProtocol(i Kex2ProvisionerInterface) rpc.Protocol {
 		Name: "keybase.1.Kex2Provisioner",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"kexStart": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]KexStartArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.KexStart(ctx)
 					return
 				},
@@ -39,6 +39,6 @@ type Kex2ProvisionerClient struct {
 }
 
 func (c Kex2ProvisionerClient) KexStart(ctx context.Context) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.Kex2Provisioner.kexStart", []interface{}{KexStartArg{}}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.Kex2Provisioner.kexStart", []any{KexStartArg{}}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/kvstore.go
+++ b/go/protocol/keybase1/kvstore.go
@@ -209,11 +209,11 @@ func KvstoreProtocol(i KvstoreInterface) rpc.Protocol {
 		Name: "keybase.1.kvstore",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getKVEntry": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetKVEntryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetKVEntryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetKVEntryArg)(nil), args)
@@ -224,11 +224,11 @@ func KvstoreProtocol(i KvstoreInterface) rpc.Protocol {
 				},
 			},
 			"putKVEntry": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PutKVEntryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PutKVEntryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PutKVEntryArg)(nil), args)
@@ -239,11 +239,11 @@ func KvstoreProtocol(i KvstoreInterface) rpc.Protocol {
 				},
 			},
 			"listKVNamespaces": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListKVNamespacesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ListKVNamespacesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ListKVNamespacesArg)(nil), args)
@@ -254,11 +254,11 @@ func KvstoreProtocol(i KvstoreInterface) rpc.Protocol {
 				},
 			},
 			"listKVEntries": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListKVEntriesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ListKVEntriesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ListKVEntriesArg)(nil), args)
@@ -269,11 +269,11 @@ func KvstoreProtocol(i KvstoreInterface) rpc.Protocol {
 				},
 			},
 			"delKVEntry": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DelKVEntryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DelKVEntryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DelKVEntryArg)(nil), args)
@@ -292,26 +292,26 @@ type KvstoreClient struct {
 }
 
 func (c KvstoreClient) GetKVEntry(ctx context.Context, __arg GetKVEntryArg) (res KVGetResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kvstore.getKVEntry", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kvstore.getKVEntry", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c KvstoreClient) PutKVEntry(ctx context.Context, __arg PutKVEntryArg) (res KVPutResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kvstore.putKVEntry", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kvstore.putKVEntry", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c KvstoreClient) ListKVNamespaces(ctx context.Context, __arg ListKVNamespacesArg) (res KVListNamespaceResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kvstore.listKVNamespaces", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kvstore.listKVNamespaces", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c KvstoreClient) ListKVEntries(ctx context.Context, __arg ListKVEntriesArg) (res KVListEntryResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kvstore.listKVEntries", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kvstore.listKVEntries", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c KvstoreClient) DelKVEntry(ctx context.Context, __arg DelKVEntryArg) (res KVDeleteEntryResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.kvstore.delKVEntry", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.kvstore.delKVEntry", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/log.go
+++ b/go/protocol/keybase1/log.go
@@ -30,11 +30,11 @@ func LogProtocol(i LogInterface) rpc.Protocol {
 		Name: "keybase.1.log",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"registerLogger": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterLoggerArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RegisterLoggerArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RegisterLoggerArg)(nil), args)
@@ -45,11 +45,11 @@ func LogProtocol(i LogInterface) rpc.Protocol {
 				},
 			},
 			"perfLogPoint": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PerfLogPointArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PerfLogPointArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PerfLogPointArg)(nil), args)
@@ -68,11 +68,11 @@ type LogClient struct {
 }
 
 func (c LogClient) RegisterLogger(ctx context.Context, __arg RegisterLoggerArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.log.registerLogger", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.log.registerLogger", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LogClient) PerfLogPoint(ctx context.Context, __arg PerfLogPointArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.log.perfLogPoint", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.log.perfLogPoint", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/log_ui.go
+++ b/go/protocol/keybase1/log_ui.go
@@ -24,11 +24,11 @@ func LogUiProtocol(i LogUiInterface) rpc.Protocol {
 		Name: "keybase.1.logUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"log": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LogArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LogArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LogArg)(nil), args)
@@ -47,6 +47,6 @@ type LogUiClient struct {
 }
 
 func (c LogUiClient) Log(ctx context.Context, __arg LogArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.logUi.log", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.logUi.log", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/login.go
+++ b/go/protocol/keybase1/login.go
@@ -151,11 +151,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 		Name: "keybase.1.login",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getConfiguredAccounts": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetConfiguredAccountsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetConfiguredAccountsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetConfiguredAccountsArg)(nil), args)
@@ -166,11 +166,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"login": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoginArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoginArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoginArg)(nil), args)
@@ -181,11 +181,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"loginProvisionedDevice": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoginProvisionedDeviceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoginProvisionedDeviceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoginProvisionedDeviceArg)(nil), args)
@@ -196,11 +196,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"loginWithPaperKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoginWithPaperKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoginWithPaperKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoginWithPaperKeyArg)(nil), args)
@@ -211,11 +211,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"logout": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LogoutArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LogoutArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LogoutArg)(nil), args)
@@ -226,11 +226,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"deprovision": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeprovisionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeprovisionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeprovisionArg)(nil), args)
@@ -241,11 +241,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"recoverAccountFromEmailAddress": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RecoverAccountFromEmailAddressArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RecoverAccountFromEmailAddressArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RecoverAccountFromEmailAddressArg)(nil), args)
@@ -256,11 +256,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"recoverPassphrase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RecoverPassphraseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RecoverPassphraseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RecoverPassphraseArg)(nil), args)
@@ -271,11 +271,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"paperKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PaperKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PaperKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PaperKeyArg)(nil), args)
@@ -286,11 +286,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"paperKeySubmit": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PaperKeySubmitArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PaperKeySubmitArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PaperKeySubmitArg)(nil), args)
@@ -301,11 +301,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"unlock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UnlockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UnlockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UnlockArg)(nil), args)
@@ -316,11 +316,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"unlockWithPassphrase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UnlockWithPassphraseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UnlockWithPassphraseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UnlockWithPassphraseArg)(nil), args)
@@ -331,11 +331,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"accountDelete": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AccountDeleteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AccountDeleteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AccountDeleteArg)(nil), args)
@@ -346,11 +346,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"loginOneshot": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoginOneshotArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoginOneshotArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoginOneshotArg)(nil), args)
@@ -361,11 +361,11 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 			},
 			"isOnline": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]IsOnlineArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.IsOnline(ctx)
 					return
 				},
@@ -383,7 +383,7 @@ type LoginClient struct {
 // secrets, but this definition may be expanded in the future.
 func (c LoginClient) GetConfiguredAccounts(ctx context.Context, sessionID int) (res []ConfiguredAccount, err error) {
 	__arg := GetConfiguredAccountsArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.login.getConfiguredAccounts", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.getConfiguredAccounts", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -391,7 +391,7 @@ func (c LoginClient) GetConfiguredAccounts(ctx context.Context, sessionID int) (
 // or keybase1.DeviceTypeV2_MOBILE. username is optional. If the current
 // device isn't provisioned, this function will provision it.
 func (c LoginClient) Login(ctx context.Context, __arg LoginArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.login", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.login", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -399,7 +399,7 @@ func (c LoginClient) Login(ctx context.Context, __arg LoginArg) (err error) {
 // If noPassphrasePrompt is set, then only a stored secret will be used to unlock
 // the device keys.
 func (c LoginClient) LoginProvisionedDevice(ctx context.Context, __arg LoginProvisionedDeviceArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.loginProvisionedDevice", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.loginProvisionedDevice", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -407,30 +407,30 @@ func (c LoginClient) LoginProvisionedDevice(ctx context.Context, __arg LoginProv
 // - trying unlocked device keys if available
 // - prompting for a paper key and using that
 func (c LoginClient) LoginWithPaperKey(ctx context.Context, __arg LoginWithPaperKeyArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.loginWithPaperKey", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.loginWithPaperKey", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LoginClient) Logout(ctx context.Context, __arg LogoutArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.logout", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.logout", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LoginClient) Deprovision(ctx context.Context, __arg DeprovisionArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.deprovision", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.deprovision", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LoginClient) RecoverAccountFromEmailAddress(ctx context.Context, email string) (err error) {
 	__arg := RecoverAccountFromEmailAddressArg{Email: email}
-	err = c.Cli.Call(ctx, "keybase.1.login.recoverAccountFromEmailAddress", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.recoverAccountFromEmailAddress", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Guide the user through possibilities of changing their passphrase.
 // Lets them change their passphrase using a paper key or enter the reset pipeline.
 func (c LoginClient) RecoverPassphrase(ctx context.Context, __arg RecoverPassphraseArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.recoverPassphrase", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.recoverPassphrase", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -438,32 +438,32 @@ func (c LoginClient) RecoverPassphrase(ctx context.Context, __arg RecoverPassphr
 // It calls login_ui.displayPaperKeyPhrase with the phrase.
 func (c LoginClient) PaperKey(ctx context.Context, sessionID int) (err error) {
 	__arg := PaperKeyArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.login.paperKey", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.paperKey", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // paperKeySubmit checks that paperPhrase is a valid paper key
 // for the logged in user, caches the keys, and sends a notification.
 func (c LoginClient) PaperKeySubmit(ctx context.Context, __arg PaperKeySubmitArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.paperKeySubmit", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.paperKeySubmit", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Unlock restores access to local key store by priming passphrase stream cache.
 func (c LoginClient) Unlock(ctx context.Context, sessionID int) (err error) {
 	__arg := UnlockArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.login.unlock", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.unlock", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LoginClient) UnlockWithPassphrase(ctx context.Context, __arg UnlockWithPassphraseArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.unlockWithPassphrase", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.unlockWithPassphrase", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // accountDelete deletes the current user's account.
 func (c LoginClient) AccountDelete(ctx context.Context, __arg AccountDeleteArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.accountDelete", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.accountDelete", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -471,13 +471,13 @@ func (c LoginClient) AccountDelete(ctx context.Context, __arg AccountDeleteArg) 
 // provisioning a device. It bootstraps credentials with the given
 // paperkey
 func (c LoginClient) LoginOneshot(ctx context.Context, __arg LoginOneshotArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.loginOneshot", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.loginOneshot", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // isOnline returns whether the device is able to open a connection to keybase.io.
 // Used for determining whether to offer proxy settings on the login screen.
 func (c LoginClient) IsOnline(ctx context.Context) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.login.isOnline", []interface{}{IsOnlineArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.login.isOnline", []any{IsOnlineArg{}}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/login_ui.go
+++ b/go/protocol/keybase1/login_ui.go
@@ -277,11 +277,11 @@ func LoginUiProtocol(i LoginUiInterface) rpc.Protocol {
 		Name: "keybase.1.loginUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getEmailOrUsername": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetEmailOrUsernameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetEmailOrUsernameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetEmailOrUsernameArg)(nil), args)
@@ -292,11 +292,11 @@ func LoginUiProtocol(i LoginUiInterface) rpc.Protocol {
 				},
 			},
 			"promptRevokePaperKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PromptRevokePaperKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PromptRevokePaperKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PromptRevokePaperKeysArg)(nil), args)
@@ -307,11 +307,11 @@ func LoginUiProtocol(i LoginUiInterface) rpc.Protocol {
 				},
 			},
 			"displayPaperKeyPhrase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayPaperKeyPhraseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayPaperKeyPhraseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayPaperKeyPhraseArg)(nil), args)
@@ -322,11 +322,11 @@ func LoginUiProtocol(i LoginUiInterface) rpc.Protocol {
 				},
 			},
 			"displayPrimaryPaperKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayPrimaryPaperKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayPrimaryPaperKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayPrimaryPaperKeyArg)(nil), args)
@@ -337,11 +337,11 @@ func LoginUiProtocol(i LoginUiInterface) rpc.Protocol {
 				},
 			},
 			"promptResetAccount": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PromptResetAccountArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PromptResetAccountArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PromptResetAccountArg)(nil), args)
@@ -352,11 +352,11 @@ func LoginUiProtocol(i LoginUiInterface) rpc.Protocol {
 				},
 			},
 			"displayResetProgress": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayResetProgressArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayResetProgressArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayResetProgressArg)(nil), args)
@@ -367,11 +367,11 @@ func LoginUiProtocol(i LoginUiInterface) rpc.Protocol {
 				},
 			},
 			"explainDeviceRecovery": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ExplainDeviceRecoveryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ExplainDeviceRecoveryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ExplainDeviceRecoveryArg)(nil), args)
@@ -382,11 +382,11 @@ func LoginUiProtocol(i LoginUiInterface) rpc.Protocol {
 				},
 			},
 			"promptPassphraseRecovery": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PromptPassphraseRecoveryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PromptPassphraseRecoveryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PromptPassphraseRecoveryArg)(nil), args)
@@ -397,11 +397,11 @@ func LoginUiProtocol(i LoginUiInterface) rpc.Protocol {
 				},
 			},
 			"chooseDeviceToRecoverWith": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChooseDeviceToRecoverWithArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChooseDeviceToRecoverWithArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChooseDeviceToRecoverWithArg)(nil), args)
@@ -412,11 +412,11 @@ func LoginUiProtocol(i LoginUiInterface) rpc.Protocol {
 				},
 			},
 			"displayResetMessage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayResetMessageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayResetMessageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayResetMessageArg)(nil), args)
@@ -436,22 +436,22 @@ type LoginUiClient struct {
 
 func (c LoginUiClient) GetEmailOrUsername(ctx context.Context, sessionID int) (res string, err error) {
 	__arg := GetEmailOrUsernameArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.loginUi.getEmailOrUsername", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.loginUi.getEmailOrUsername", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LoginUiClient) PromptRevokePaperKeys(ctx context.Context, __arg PromptRevokePaperKeysArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.loginUi.promptRevokePaperKeys", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.loginUi.promptRevokePaperKeys", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LoginUiClient) DisplayPaperKeyPhrase(ctx context.Context, __arg DisplayPaperKeyPhraseArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.loginUi.displayPaperKeyPhrase", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.loginUi.displayPaperKeyPhrase", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LoginUiClient) DisplayPrimaryPaperKey(ctx context.Context, __arg DisplayPrimaryPaperKeyArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.loginUi.displayPrimaryPaperKey", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.loginUi.displayPrimaryPaperKey", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -459,36 +459,36 @@ func (c LoginUiClient) DisplayPrimaryPaperKey(ctx context.Context, __arg Display
 // would like to either enter the autoreset pipeline and perform the reset
 // of the account.
 func (c LoginUiClient) PromptResetAccount(ctx context.Context, __arg PromptResetAccountArg) (res ResetPromptResponse, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.loginUi.promptResetAccount", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.loginUi.promptResetAccount", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // In some flows the user will get notified of the reset progress
 func (c LoginUiClient) DisplayResetProgress(ctx context.Context, __arg DisplayResetProgressArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.loginUi.displayResetProgress", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.loginUi.displayResetProgress", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // During recovery the service might want to explain to the user how they can change
 // their password by using the "change password" functionality on other devices.
 func (c LoginUiClient) ExplainDeviceRecovery(ctx context.Context, __arg ExplainDeviceRecoveryArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.loginUi.explainDeviceRecovery", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.loginUi.explainDeviceRecovery", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LoginUiClient) PromptPassphraseRecovery(ctx context.Context, __arg PromptPassphraseRecoveryArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.loginUi.promptPassphraseRecovery", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.loginUi.promptPassphraseRecovery", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Different from ProvisionUI's chooseDevice due to phrasing in the UI.
 func (c LoginUiClient) ChooseDeviceToRecoverWith(ctx context.Context, __arg ChooseDeviceToRecoverWithArg) (res DeviceID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.loginUi.chooseDeviceToRecoverWith", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.loginUi.chooseDeviceToRecoverWith", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Simply displays a message in the recovery flow.
 func (c LoginUiClient) DisplayResetMessage(ctx context.Context, __arg DisplayResetMessageArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.loginUi.displayResetMessage", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.loginUi.displayResetMessage", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/logsend.go
+++ b/go/protocol/keybase1/logsend.go
@@ -21,11 +21,11 @@ func LogsendProtocol(i LogsendInterface) rpc.Protocol {
 		Name: "keybase.1.logsend",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"prepareLogsend": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PrepareLogsendArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.PrepareLogsend(ctx)
 					return
 				},
@@ -39,6 +39,6 @@ type LogsendClient struct {
 }
 
 func (c LogsendClient) PrepareLogsend(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.logsend.prepareLogsend", []interface{}{PrepareLogsendArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.logsend.prepareLogsend", []any{PrepareLogsendArg{}}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/merkle.go
+++ b/go/protocol/keybase1/merkle.go
@@ -72,11 +72,11 @@ func MerkleProtocol(i MerkleInterface) rpc.Protocol {
 		Name: "keybase.1.merkle",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getCurrentMerkleRoot": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetCurrentMerkleRootArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetCurrentMerkleRootArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetCurrentMerkleRootArg)(nil), args)
@@ -87,11 +87,11 @@ func MerkleProtocol(i MerkleInterface) rpc.Protocol {
 				},
 			},
 			"verifyMerkleRootAndKBFS": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]VerifyMerkleRootAndKBFSArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]VerifyMerkleRootAndKBFSArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]VerifyMerkleRootAndKBFSArg)(nil), args)
@@ -115,7 +115,7 @@ type MerkleClient struct {
 // we force a GET and a round-trip.
 func (c MerkleClient) GetCurrentMerkleRoot(ctx context.Context, freshnessMsec int) (res MerkleRootAndTime, err error) {
 	__arg := GetCurrentMerkleRootArg{FreshnessMsec: freshnessMsec}
-	err = c.Cli.Call(ctx, "keybase.1.merkle.getCurrentMerkleRoot", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.merkle.getCurrentMerkleRoot", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -123,6 +123,6 @@ func (c MerkleClient) GetCurrentMerkleRoot(ctx context.Context, freshnessMsec in
 // root of the keybase server's Merkle tree, and that the given KBFS root
 // is included in that global root.
 func (c MerkleClient) VerifyMerkleRootAndKBFS(ctx context.Context, __arg VerifyMerkleRootAndKBFSArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.merkle.verifyMerkleRootAndKBFS", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.merkle.verifyMerkleRootAndKBFS", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/metadata.go
+++ b/go/protocol/keybase1/metadata.go
@@ -356,21 +356,21 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 		Name: "keybase.1.metadata",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getChallenge": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetChallengeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetChallenge(ctx)
 					return
 				},
 			},
 			"authenticate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AuthenticateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AuthenticateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AuthenticateArg)(nil), args)
@@ -381,11 +381,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"putMetadata": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PutMetadataArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PutMetadataArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PutMetadataArg)(nil), args)
@@ -396,11 +396,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"getMetadata": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetMetadataArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetMetadataArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetMetadataArg)(nil), args)
@@ -411,11 +411,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"getMetadataByTimestamp": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetMetadataByTimestampArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetMetadataByTimestampArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetMetadataByTimestampArg)(nil), args)
@@ -426,11 +426,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"registerForUpdates": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RegisterForUpdatesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RegisterForUpdatesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RegisterForUpdatesArg)(nil), args)
@@ -441,11 +441,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"pruneBranch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PruneBranchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PruneBranchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PruneBranchArg)(nil), args)
@@ -456,11 +456,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"putKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PutKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PutKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PutKeysArg)(nil), args)
@@ -471,11 +471,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"getKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetKeyArg)(nil), args)
@@ -486,11 +486,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"deleteKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteKeyArg)(nil), args)
@@ -501,11 +501,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"truncateLock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TruncateLockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TruncateLockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TruncateLockArg)(nil), args)
@@ -516,11 +516,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"truncateUnlock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TruncateUnlockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TruncateUnlockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TruncateUnlockArg)(nil), args)
@@ -531,11 +531,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"getFolderHandle": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetFolderHandleArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetFolderHandleArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetFolderHandleArg)(nil), args)
@@ -546,11 +546,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"getFoldersForRekey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetFoldersForRekeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetFoldersForRekeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetFoldersForRekeyArg)(nil), args)
@@ -561,31 +561,31 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"ping": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PingArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.Ping(ctx)
 					return
 				},
 			},
 			"ping2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]Ping2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.Ping2(ctx)
 					return
 				},
 			},
 			"getLatestFolderHandle": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetLatestFolderHandleArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetLatestFolderHandleArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetLatestFolderHandleArg)(nil), args)
@@ -596,11 +596,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"getKeyBundles": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetKeyBundlesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetKeyBundlesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetKeyBundlesArg)(nil), args)
@@ -611,11 +611,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"lock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LockArg)(nil), args)
@@ -626,11 +626,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"releaseLock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ReleaseLockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ReleaseLockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ReleaseLockArg)(nil), args)
@@ -641,11 +641,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"startImplicitTeamMigration": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StartImplicitTeamMigrationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]StartImplicitTeamMigrationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]StartImplicitTeamMigrationArg)(nil), args)
@@ -656,11 +656,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"getMerkleRoot": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetMerkleRootArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetMerkleRootArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetMerkleRootArg)(nil), args)
@@ -671,11 +671,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"getMerkleRootLatest": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetMerkleRootLatestArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetMerkleRootLatestArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetMerkleRootLatestArg)(nil), args)
@@ -686,11 +686,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"getMerkleRootSince": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetMerkleRootSinceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetMerkleRootSinceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetMerkleRootSinceArg)(nil), args)
@@ -701,11 +701,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"getMerkleNode": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetMerkleNodeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetMerkleNodeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetMerkleNodeArg)(nil), args)
@@ -716,11 +716,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"findNextMD": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FindNextMDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FindNextMDArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FindNextMDArg)(nil), args)
@@ -731,11 +731,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"setImplicitTeamModeForTest": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetImplicitTeamModeForTestArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetImplicitTeamModeForTestArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetImplicitTeamModeForTestArg)(nil), args)
@@ -746,11 +746,11 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 			},
 			"forceMerkleBuildForTest": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ForceMerkleBuildForTestArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.ForceMerkleBuildForTest(ctx)
 					return
 				},
@@ -764,150 +764,150 @@ type MetadataClient struct {
 }
 
 func (c MetadataClient) GetChallenge(ctx context.Context) (res ChallengeInfo, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getChallenge", []interface{}{GetChallengeArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getChallenge", []any{GetChallengeArg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) Authenticate(ctx context.Context, signature string) (res int, err error) {
 	__arg := AuthenticateArg{Signature: signature}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.authenticate", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.authenticate", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) PutMetadata(ctx context.Context, __arg PutMetadataArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.putMetadata", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.putMetadata", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetMetadata(ctx context.Context, __arg GetMetadataArg) (res MetadataResponse, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMetadata", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMetadata", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetMetadataByTimestamp(ctx context.Context, __arg GetMetadataByTimestampArg) (res MDBlock, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMetadataByTimestamp", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMetadataByTimestamp", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) RegisterForUpdates(ctx context.Context, __arg RegisterForUpdatesArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.registerForUpdates", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.registerForUpdates", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) PruneBranch(ctx context.Context, __arg PruneBranchArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.pruneBranch", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.pruneBranch", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) PutKeys(ctx context.Context, __arg PutKeysArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.putKeys", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.putKeys", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetKey(ctx context.Context, __arg GetKeyArg) (res []byte, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getKey", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getKey", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) DeleteKey(ctx context.Context, __arg DeleteKeyArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.deleteKey", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.deleteKey", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) TruncateLock(ctx context.Context, folderID string) (res bool, err error) {
 	__arg := TruncateLockArg{FolderID: folderID}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.truncateLock", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.truncateLock", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) TruncateUnlock(ctx context.Context, folderID string) (res bool, err error) {
 	__arg := TruncateUnlockArg{FolderID: folderID}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.truncateUnlock", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.truncateUnlock", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetFolderHandle(ctx context.Context, __arg GetFolderHandleArg) (res []byte, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getFolderHandle", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getFolderHandle", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetFoldersForRekey(ctx context.Context, deviceKID KID) (err error) {
 	__arg := GetFoldersForRekeyArg{DeviceKID: deviceKID}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getFoldersForRekey", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getFoldersForRekey", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) Ping(ctx context.Context) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.ping", []interface{}{PingArg{}}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.ping", []any{PingArg{}}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) Ping2(ctx context.Context) (res PingResponse, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.ping2", []interface{}{Ping2Arg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.ping2", []any{Ping2Arg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetLatestFolderHandle(ctx context.Context, folderID string) (res []byte, err error) {
 	__arg := GetLatestFolderHandleArg{FolderID: folderID}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getLatestFolderHandle", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getLatestFolderHandle", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetKeyBundles(ctx context.Context, __arg GetKeyBundlesArg) (res KeyBundleResponse, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getKeyBundles", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getKeyBundles", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) Lock(ctx context.Context, __arg LockArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.lock", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.lock", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) ReleaseLock(ctx context.Context, __arg ReleaseLockArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.releaseLock", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.releaseLock", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) StartImplicitTeamMigration(ctx context.Context, folderID string) (err error) {
 	__arg := StartImplicitTeamMigrationArg{FolderID: folderID}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.startImplicitTeamMigration", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.startImplicitTeamMigration", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetMerkleRoot(ctx context.Context, __arg GetMerkleRootArg) (res MerkleRoot, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMerkleRoot", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMerkleRoot", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetMerkleRootLatest(ctx context.Context, treeID MerkleTreeID) (res MerkleRoot, err error) {
 	__arg := GetMerkleRootLatestArg{TreeID: treeID}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMerkleRootLatest", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMerkleRootLatest", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetMerkleRootSince(ctx context.Context, __arg GetMerkleRootSinceArg) (res MerkleRoot, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMerkleRootSince", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMerkleRootSince", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) GetMerkleNode(ctx context.Context, hash string) (res []byte, err error) {
 	__arg := GetMerkleNodeArg{Hash: hash}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMerkleNode", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.getMerkleNode", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) FindNextMD(ctx context.Context, __arg FindNextMDArg) (res FindNextMDResponse, err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.findNextMD", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.findNextMD", []any{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) SetImplicitTeamModeForTest(ctx context.Context, implicitTeamMode string) (err error) {
 	__arg := SetImplicitTeamModeForTestArg{ImplicitTeamMode: implicitTeamMode}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.setImplicitTeamModeForTest", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.setImplicitTeamModeForTest", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataClient) ForceMerkleBuildForTest(ctx context.Context) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.forceMerkleBuildForTest", []interface{}{ForceMerkleBuildForTestArg{}}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadata.forceMerkleBuildForTest", []any{ForceMerkleBuildForTestArg{}}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/metadata_update.go
+++ b/go/protocol/keybase1/metadata_update.go
@@ -46,11 +46,11 @@ func MetadataUpdateProtocol(i MetadataUpdateInterface) rpc.Protocol {
 		Name: "keybase.1.metadataUpdate",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"metadataUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MetadataUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MetadataUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MetadataUpdateArg)(nil), args)
@@ -61,11 +61,11 @@ func MetadataUpdateProtocol(i MetadataUpdateInterface) rpc.Protocol {
 				},
 			},
 			"folderNeedsRekey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FolderNeedsRekeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FolderNeedsRekeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FolderNeedsRekeyArg)(nil), args)
@@ -76,11 +76,11 @@ func MetadataUpdateProtocol(i MetadataUpdateInterface) rpc.Protocol {
 				},
 			},
 			"foldersNeedRekey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FoldersNeedRekeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FoldersNeedRekeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FoldersNeedRekeyArg)(nil), args)
@@ -99,17 +99,17 @@ type MetadataUpdateClient struct {
 }
 
 func (c MetadataUpdateClient) MetadataUpdate(ctx context.Context, __arg MetadataUpdateArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadataUpdate.metadataUpdate", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadataUpdate.metadataUpdate", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataUpdateClient) FolderNeedsRekey(ctx context.Context, __arg FolderNeedsRekeyArg) (err error) {
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadataUpdate.folderNeedsRekey", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadataUpdate.folderNeedsRekey", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 
 func (c MetadataUpdateClient) FoldersNeedRekey(ctx context.Context, requests []RekeyRequest) (err error) {
 	__arg := FoldersNeedRekeyArg{Requests: requests}
-	err = c.Cli.CallCompressed(ctx, "keybase.1.metadataUpdate.foldersNeedRekey", []interface{}{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
+	err = c.Cli.CallCompressed(ctx, "keybase.1.metadataUpdate.foldersNeedRekey", []any{__arg}, nil, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_app.go
+++ b/go/protocol/keybase1/notify_app.go
@@ -21,11 +21,11 @@ func NotifyAppProtocol(i NotifyAppInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyApp",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"exit": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ExitArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.Exit(ctx)
 					return
 				},
@@ -39,6 +39,6 @@ type NotifyAppClient struct {
 }
 
 func (c NotifyAppClient) Exit(ctx context.Context) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyApp.exit", []interface{}{ExitArg{}}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyApp.exit", []any{ExitArg{}}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_audit.go
+++ b/go/protocol/keybase1/notify_audit.go
@@ -27,11 +27,11 @@ func NotifyAuditProtocol(i NotifyAuditInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyAudit",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"rootAuditError": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RootAuditErrorArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RootAuditErrorArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RootAuditErrorArg)(nil), args)
@@ -42,11 +42,11 @@ func NotifyAuditProtocol(i NotifyAuditInterface) rpc.Protocol {
 				},
 			},
 			"boxAuditError": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BoxAuditErrorArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BoxAuditErrorArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BoxAuditErrorArg)(nil), args)
@@ -66,12 +66,12 @@ type NotifyAuditClient struct {
 
 func (c NotifyAuditClient) RootAuditError(ctx context.Context, message string) (err error) {
 	__arg := RootAuditErrorArg{Message: message}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyAudit.rootAuditError", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyAudit.rootAuditError", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyAuditClient) BoxAuditError(ctx context.Context, message string) (err error) {
 	__arg := BoxAuditErrorArg{Message: message}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyAudit.boxAuditError", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyAudit.boxAuditError", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_badges.go
+++ b/go/protocol/keybase1/notify_badges.go
@@ -257,11 +257,11 @@ func NotifyBadgesProtocol(i NotifyBadgesInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyBadges",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"badgeState": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BadgeStateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BadgeStateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BadgeStateArg)(nil), args)
@@ -281,6 +281,6 @@ type NotifyBadgesClient struct {
 
 func (c NotifyBadgesClient) BadgeState(ctx context.Context, badgeState BadgeState) (err error) {
 	__arg := BadgeStateArg{BadgeState: badgeState}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyBadges.badgeState", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyBadges.badgeState", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_can_user_perform.go
+++ b/go/protocol/keybase1/notify_can_user_perform.go
@@ -22,11 +22,11 @@ func NotifyCanUserPerformProtocol(i NotifyCanUserPerformInterface) rpc.Protocol 
 		Name: "keybase.1.NotifyCanUserPerform",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"canUserPerformChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CanUserPerformChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CanUserPerformChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CanUserPerformChangedArg)(nil), args)
@@ -46,6 +46,6 @@ type NotifyCanUserPerformClient struct {
 
 func (c NotifyCanUserPerformClient) CanUserPerformChanged(ctx context.Context, teamName string) (err error) {
 	__arg := CanUserPerformChangedArg{TeamName: teamName}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyCanUserPerform.canUserPerformChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyCanUserPerform.canUserPerformChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_ctl.go
+++ b/go/protocol/keybase1/notify_ctl.go
@@ -94,11 +94,11 @@ func NotifyCtlProtocol(i NotifyCtlInterface) rpc.Protocol {
 		Name: "keybase.1.notifyCtl",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"setNotifications": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetNotificationsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetNotificationsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetNotificationsArg)(nil), args)
@@ -118,6 +118,6 @@ type NotifyCtlClient struct {
 
 func (c NotifyCtlClient) SetNotifications(ctx context.Context, channels NotificationChannels) (err error) {
 	__arg := SetNotificationsArg{Channels: channels}
-	err = c.Cli.Call(ctx, "keybase.1.notifyCtl.setNotifications", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.notifyCtl.setNotifications", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_device_clone.go
+++ b/go/protocol/keybase1/notify_device_clone.go
@@ -22,11 +22,11 @@ func NotifyDeviceCloneProtocol(i NotifyDeviceCloneInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyDeviceClone",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"deviceCloneCountChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeviceCloneCountChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeviceCloneCountChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeviceCloneCountChangedArg)(nil), args)
@@ -46,6 +46,6 @@ type NotifyDeviceCloneClient struct {
 
 func (c NotifyDeviceCloneClient) DeviceCloneCountChanged(ctx context.Context, newClones int) (err error) {
 	__arg := DeviceCloneCountChangedArg{NewClones: newClones}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyDeviceClone.deviceCloneCountChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyDeviceClone.deviceCloneCountChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_email.go
+++ b/go/protocol/keybase1/notify_email.go
@@ -29,11 +29,11 @@ func NotifyEmailAddressProtocol(i NotifyEmailAddressInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyEmailAddress",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"emailAddressVerified": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]EmailAddressVerifiedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]EmailAddressVerifiedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]EmailAddressVerifiedArg)(nil), args)
@@ -44,11 +44,11 @@ func NotifyEmailAddressProtocol(i NotifyEmailAddressInterface) rpc.Protocol {
 				},
 			},
 			"emailsChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]EmailsChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]EmailsChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]EmailsChangedArg)(nil), args)
@@ -68,11 +68,11 @@ type NotifyEmailAddressClient struct {
 
 func (c NotifyEmailAddressClient) EmailAddressVerified(ctx context.Context, emailAddress EmailAddress) (err error) {
 	__arg := EmailAddressVerifiedArg{EmailAddress: emailAddress}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyEmailAddress.emailAddressVerified", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyEmailAddress.emailAddressVerified", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyEmailAddressClient) EmailsChanged(ctx context.Context, __arg EmailsChangedArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyEmailAddress.emailsChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyEmailAddress.emailsChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_ephemeral.go
+++ b/go/protocol/keybase1/notify_ephemeral.go
@@ -37,11 +37,11 @@ func NotifyEphemeralProtocol(i NotifyEphemeralInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyEphemeral",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"newTeamEk": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NewTeamEkArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NewTeamEkArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NewTeamEkArg)(nil), args)
@@ -52,11 +52,11 @@ func NotifyEphemeralProtocol(i NotifyEphemeralInterface) rpc.Protocol {
 				},
 			},
 			"newTeambotEk": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NewTeambotEkArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NewTeambotEkArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NewTeambotEkArg)(nil), args)
@@ -67,11 +67,11 @@ func NotifyEphemeralProtocol(i NotifyEphemeralInterface) rpc.Protocol {
 				},
 			},
 			"teambotEkNeeded": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeambotEkNeededArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeambotEkNeededArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeambotEkNeededArg)(nil), args)
@@ -90,16 +90,16 @@ type NotifyEphemeralClient struct {
 }
 
 func (c NotifyEphemeralClient) NewTeamEk(ctx context.Context, __arg NewTeamEkArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyEphemeral.newTeamEk", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyEphemeral.newTeamEk", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyEphemeralClient) NewTeambotEk(ctx context.Context, __arg NewTeambotEkArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.NotifyEphemeral.newTeambotEk", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.NotifyEphemeral.newTeambotEk", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyEphemeralClient) TeambotEkNeeded(ctx context.Context, __arg TeambotEkNeededArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.NotifyEphemeral.teambotEkNeeded", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.NotifyEphemeral.teambotEkNeeded", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_favorites.go
+++ b/go/protocol/keybase1/notify_favorites.go
@@ -22,11 +22,11 @@ func NotifyFavoritesProtocol(i NotifyFavoritesInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyFavorites",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"favoritesChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FavoritesChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FavoritesChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FavoritesChangedArg)(nil), args)
@@ -46,6 +46,6 @@ type NotifyFavoritesClient struct {
 
 func (c NotifyFavoritesClient) FavoritesChanged(ctx context.Context, uid UID) (err error) {
 	__arg := FavoritesChangedArg{Uid: uid}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFavorites.favoritesChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFavorites.favoritesChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_featuredbots.go
+++ b/go/protocol/keybase1/notify_featuredbots.go
@@ -24,11 +24,11 @@ func NotifyFeaturedBotsProtocol(i NotifyFeaturedBotsInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyFeaturedBots",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"featuredBotsUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FeaturedBotsUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FeaturedBotsUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FeaturedBotsUpdateArg)(nil), args)
@@ -47,6 +47,6 @@ type NotifyFeaturedBotsClient struct {
 }
 
 func (c NotifyFeaturedBotsClient) FeaturedBotsUpdate(ctx context.Context, __arg FeaturedBotsUpdateArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFeaturedBots.featuredBotsUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFeaturedBots.featuredBotsUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_fs.go
+++ b/go/protocol/keybase1/notify_fs.go
@@ -73,11 +73,11 @@ func NotifyFSProtocol(i NotifyFSInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyFS",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"FSActivity": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSActivityArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSActivityArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSActivityArg)(nil), args)
@@ -88,11 +88,11 @@ func NotifyFSProtocol(i NotifyFSInterface) rpc.Protocol {
 				},
 			},
 			"FSPathUpdated": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSPathUpdatedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSPathUpdatedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSPathUpdatedArg)(nil), args)
@@ -103,11 +103,11 @@ func NotifyFSProtocol(i NotifyFSInterface) rpc.Protocol {
 				},
 			},
 			"FSSyncActivity": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSSyncActivityArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSSyncActivityArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSSyncActivityArg)(nil), args)
@@ -118,11 +118,11 @@ func NotifyFSProtocol(i NotifyFSInterface) rpc.Protocol {
 				},
 			},
 			"FSEditListResponse": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSEditListResponseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSEditListResponseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSEditListResponseArg)(nil), args)
@@ -133,11 +133,11 @@ func NotifyFSProtocol(i NotifyFSInterface) rpc.Protocol {
 				},
 			},
 			"FSSyncStatusResponse": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSSyncStatusResponseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSSyncStatusResponseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSSyncStatusResponseArg)(nil), args)
@@ -148,11 +148,11 @@ func NotifyFSProtocol(i NotifyFSInterface) rpc.Protocol {
 				},
 			},
 			"FSOverallSyncStatusChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSOverallSyncStatusChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSOverallSyncStatusChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSOverallSyncStatusChangedArg)(nil), args)
@@ -163,21 +163,21 @@ func NotifyFSProtocol(i NotifyFSInterface) rpc.Protocol {
 				},
 			},
 			"FSFavoritesChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSFavoritesChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.FSFavoritesChanged(ctx)
 					return
 				},
 			},
 			"FSOnlineStatusChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSOnlineStatusChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSOnlineStatusChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSOnlineStatusChangedArg)(nil), args)
@@ -188,11 +188,11 @@ func NotifyFSProtocol(i NotifyFSInterface) rpc.Protocol {
 				},
 			},
 			"FSSubscriptionNotifyPath": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSSubscriptionNotifyPathArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSSubscriptionNotifyPathArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSSubscriptionNotifyPathArg)(nil), args)
@@ -203,11 +203,11 @@ func NotifyFSProtocol(i NotifyFSInterface) rpc.Protocol {
 				},
 			},
 			"FSSubscriptionNotify": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSSubscriptionNotifyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSSubscriptionNotifyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSSubscriptionNotifyArg)(nil), args)
@@ -227,55 +227,55 @@ type NotifyFSClient struct {
 
 func (c NotifyFSClient) FSActivity(ctx context.Context, notification FSNotification) (err error) {
 	__arg := FSActivityArg{Notification: notification}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSActivity", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSActivity", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyFSClient) FSPathUpdated(ctx context.Context, path string) (err error) {
 	__arg := FSPathUpdatedArg{Path: path}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSPathUpdated", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSPathUpdated", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyFSClient) FSSyncActivity(ctx context.Context, status FSPathSyncStatus) (err error) {
 	__arg := FSSyncActivityArg{Status: status}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSSyncActivity", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSSyncActivity", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyFSClient) FSEditListResponse(ctx context.Context, __arg FSEditListResponseArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSEditListResponse", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSEditListResponse", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyFSClient) FSSyncStatusResponse(ctx context.Context, __arg FSSyncStatusResponseArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSSyncStatusResponse", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSSyncStatusResponse", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyFSClient) FSOverallSyncStatusChanged(ctx context.Context, status FolderSyncStatus) (err error) {
 	__arg := FSOverallSyncStatusChangedArg{Status: status}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSOverallSyncStatusChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSOverallSyncStatusChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyFSClient) FSFavoritesChanged(ctx context.Context) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSFavoritesChanged", []interface{}{FSFavoritesChangedArg{}}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSFavoritesChanged", []any{FSFavoritesChangedArg{}}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyFSClient) FSOnlineStatusChanged(ctx context.Context, online bool) (err error) {
 	__arg := FSOnlineStatusChangedArg{Online: online}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSOnlineStatusChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSOnlineStatusChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyFSClient) FSSubscriptionNotifyPath(ctx context.Context, __arg FSSubscriptionNotifyPathArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSSubscriptionNotifyPath", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSSubscriptionNotifyPath", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyFSClient) FSSubscriptionNotify(ctx context.Context, __arg FSSubscriptionNotifyArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSSubscriptionNotify", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSSubscriptionNotify", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_fs_request.go
+++ b/go/protocol/keybase1/notify_fs_request.go
@@ -27,11 +27,11 @@ func NotifyFSRequestProtocol(i NotifyFSRequestInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyFSRequest",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"FSEditListRequest": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSEditListRequestArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSEditListRequestArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSEditListRequestArg)(nil), args)
@@ -42,11 +42,11 @@ func NotifyFSRequestProtocol(i NotifyFSRequestInterface) rpc.Protocol {
 				},
 			},
 			"FSSyncStatusRequest": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FSSyncStatusRequestArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FSSyncStatusRequestArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FSSyncStatusRequestArg)(nil), args)
@@ -66,12 +66,12 @@ type NotifyFSRequestClient struct {
 
 func (c NotifyFSRequestClient) FSEditListRequest(ctx context.Context, req FSEditListRequest) (err error) {
 	__arg := FSEditListRequestArg{Req: req}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFSRequest.FSEditListRequest", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFSRequest.FSEditListRequest", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyFSRequestClient) FSSyncStatusRequest(ctx context.Context, req FSSyncStatusRequest) (err error) {
 	__arg := FSSyncStatusRequestArg{Req: req}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyFSRequest.FSSyncStatusRequest", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFSRequest.FSSyncStatusRequest", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_invite_friends.go
+++ b/go/protocol/keybase1/notify_invite_friends.go
@@ -22,11 +22,11 @@ func NotifyInviteFriendsProtocol(i NotifyInviteFriendsInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyInviteFriends",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"updateInviteCounts": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UpdateInviteCountsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UpdateInviteCountsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UpdateInviteCountsArg)(nil), args)
@@ -46,6 +46,6 @@ type NotifyInviteFriendsClient struct {
 
 func (c NotifyInviteFriendsClient) UpdateInviteCounts(ctx context.Context, counts InviteCounts) (err error) {
 	__arg := UpdateInviteCountsArg{Counts: counts}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyInviteFriends.updateInviteCounts", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyInviteFriends.updateInviteCounts", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_keyfamily.go
+++ b/go/protocol/keybase1/notify_keyfamily.go
@@ -22,11 +22,11 @@ func NotifyKeyfamilyProtocol(i NotifyKeyfamilyInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyKeyfamily",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"keyfamilyChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]KeyfamilyChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]KeyfamilyChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]KeyfamilyChangedArg)(nil), args)
@@ -46,6 +46,6 @@ type NotifyKeyfamilyClient struct {
 
 func (c NotifyKeyfamilyClient) KeyfamilyChanged(ctx context.Context, uid UID) (err error) {
 	__arg := KeyfamilyChangedArg{Uid: uid}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyKeyfamily.keyfamilyChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyKeyfamily.keyfamilyChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_paperkey.go
+++ b/go/protocol/keybase1/notify_paperkey.go
@@ -24,11 +24,11 @@ func NotifyPaperKeyProtocol(i NotifyPaperKeyInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyPaperKey",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"paperKeyCached": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PaperKeyCachedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PaperKeyCachedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PaperKeyCachedArg)(nil), args)
@@ -47,6 +47,6 @@ type NotifyPaperKeyClient struct {
 }
 
 func (c NotifyPaperKeyClient) PaperKeyCached(ctx context.Context, __arg PaperKeyCachedArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyPaperKey.paperKeyCached", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyPaperKey.paperKeyCached", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_pgp.go
+++ b/go/protocol/keybase1/notify_pgp.go
@@ -21,11 +21,11 @@ func NotifyPGPProtocol(i NotifyPGPInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyPGP",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"pgpKeyInSecretStoreFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPKeyInSecretStoreFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.PGPKeyInSecretStoreFile(ctx)
 					return
 				},
@@ -39,6 +39,6 @@ type NotifyPGPClient struct {
 }
 
 func (c NotifyPGPClient) PGPKeyInSecretStoreFile(ctx context.Context) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyPGP.pgpKeyInSecretStoreFile", []interface{}{PGPKeyInSecretStoreFileArg{}}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyPGP.pgpKeyInSecretStoreFile", []any{PGPKeyInSecretStoreFileArg{}}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_phone.go
+++ b/go/protocol/keybase1/notify_phone.go
@@ -24,11 +24,11 @@ func NotifyPhoneNumberProtocol(i NotifyPhoneNumberInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyPhoneNumber",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"phoneNumbersChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PhoneNumbersChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PhoneNumbersChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PhoneNumbersChangedArg)(nil), args)
@@ -47,6 +47,6 @@ type NotifyPhoneNumberClient struct {
 }
 
 func (c NotifyPhoneNumberClient) PhoneNumbersChanged(ctx context.Context, __arg PhoneNumbersChangedArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyPhoneNumber.phoneNumbersChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyPhoneNumber.phoneNumbersChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_runtimestats.go
+++ b/go/protocol/keybase1/notify_runtimestats.go
@@ -226,11 +226,11 @@ func NotifyRuntimeStatsProtocol(i NotifyRuntimeStatsInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyRuntimeStats",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"runtimeStatsUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RuntimeStatsUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RuntimeStatsUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RuntimeStatsUpdateArg)(nil), args)
@@ -250,6 +250,6 @@ type NotifyRuntimeStatsClient struct {
 
 func (c NotifyRuntimeStatsClient) RuntimeStatsUpdate(ctx context.Context, stats *RuntimeStats) (err error) {
 	__arg := RuntimeStatsUpdateArg{Stats: stats}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyRuntimeStats.runtimeStatsUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyRuntimeStats.runtimeStatsUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_saltpack.go
+++ b/go/protocol/keybase1/notify_saltpack.go
@@ -70,11 +70,11 @@ func NotifySaltpackProtocol(i NotifySaltpackInterface) rpc.Protocol {
 		Name: "keybase.1.NotifySaltpack",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"saltpackOperationStart": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackOperationStartArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackOperationStartArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackOperationStartArg)(nil), args)
@@ -85,11 +85,11 @@ func NotifySaltpackProtocol(i NotifySaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackOperationProgress": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackOperationProgressArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackOperationProgressArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackOperationProgressArg)(nil), args)
@@ -100,11 +100,11 @@ func NotifySaltpackProtocol(i NotifySaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackOperationDone": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackOperationDoneArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackOperationDoneArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackOperationDoneArg)(nil), args)
@@ -123,16 +123,16 @@ type NotifySaltpackClient struct {
 }
 
 func (c NotifySaltpackClient) SaltpackOperationStart(ctx context.Context, __arg SaltpackOperationStartArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifySaltpack.saltpackOperationStart", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifySaltpack.saltpackOperationStart", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifySaltpackClient) SaltpackOperationProgress(ctx context.Context, __arg SaltpackOperationProgressArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifySaltpack.saltpackOperationProgress", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifySaltpack.saltpackOperationProgress", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifySaltpackClient) SaltpackOperationDone(ctx context.Context, __arg SaltpackOperationDoneArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifySaltpack.saltpackOperationDone", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifySaltpack.saltpackOperationDone", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_service.go
+++ b/go/protocol/keybase1/notify_service.go
@@ -45,11 +45,11 @@ func NotifyServiceProtocol(i NotifyServiceInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyService",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"HTTPSrvInfoUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HTTPSrvInfoUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]HTTPSrvInfoUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]HTTPSrvInfoUpdateArg)(nil), args)
@@ -60,11 +60,11 @@ func NotifyServiceProtocol(i NotifyServiceInterface) rpc.Protocol {
 				},
 			},
 			"handleKeybaseLink": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HandleKeybaseLinkArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]HandleKeybaseLinkArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]HandleKeybaseLinkArg)(nil), args)
@@ -75,11 +75,11 @@ func NotifyServiceProtocol(i NotifyServiceInterface) rpc.Protocol {
 				},
 			},
 			"shutdown": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ShutdownArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ShutdownArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ShutdownArg)(nil), args)
@@ -99,17 +99,17 @@ type NotifyServiceClient struct {
 
 func (c NotifyServiceClient) HTTPSrvInfoUpdate(ctx context.Context, info HttpSrvInfo) (err error) {
 	__arg := HTTPSrvInfoUpdateArg{Info: info}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyService.HTTPSrvInfoUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyService.HTTPSrvInfoUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyServiceClient) HandleKeybaseLink(ctx context.Context, __arg HandleKeybaseLinkArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyService.handleKeybaseLink", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyService.handleKeybaseLink", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyServiceClient) Shutdown(ctx context.Context, code int) (err error) {
 	__arg := ShutdownArg{Code: code}
-	err = c.Cli.Call(ctx, "keybase.1.NotifyService.shutdown", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.NotifyService.shutdown", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_session.go
+++ b/go/protocol/keybase1/notify_session.go
@@ -34,21 +34,21 @@ func NotifySessionProtocol(i NotifySessionInterface) rpc.Protocol {
 		Name: "keybase.1.NotifySession",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"loggedOut": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoggedOutArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.LoggedOut(ctx)
 					return
 				},
 			},
 			"loggedIn": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoggedInArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoggedInArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoggedInArg)(nil), args)
@@ -59,11 +59,11 @@ func NotifySessionProtocol(i NotifySessionInterface) rpc.Protocol {
 				},
 			},
 			"clientOutOfDate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ClientOutOfDateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ClientOutOfDateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ClientOutOfDateArg)(nil), args)
@@ -82,16 +82,16 @@ type NotifySessionClient struct {
 }
 
 func (c NotifySessionClient) LoggedOut(ctx context.Context) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifySession.loggedOut", []interface{}{LoggedOutArg{}}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifySession.loggedOut", []any{LoggedOutArg{}}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifySessionClient) LoggedIn(ctx context.Context, __arg LoggedInArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.NotifySession.loggedIn", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.NotifySession.loggedIn", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c NotifySessionClient) ClientOutOfDate(ctx context.Context, __arg ClientOutOfDateArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.NotifySession.clientOutOfDate", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.NotifySession.clientOutOfDate", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_team.go
+++ b/go/protocol/keybase1/notify_team.go
@@ -160,11 +160,11 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyTeam",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"teamChangedByID": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamChangedByIDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamChangedByIDArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamChangedByIDArg)(nil), args)
@@ -175,11 +175,11 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 				},
 			},
 			"teamChangedByName": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamChangedByNameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamChangedByNameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamChangedByNameArg)(nil), args)
@@ -190,11 +190,11 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 				},
 			},
 			"teamDeleted": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamDeletedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamDeletedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamDeletedArg)(nil), args)
@@ -205,11 +205,11 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 				},
 			},
 			"teamAbandoned": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamAbandonedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamAbandonedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamAbandonedArg)(nil), args)
@@ -220,11 +220,11 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 				},
 			},
 			"teamExit": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamExitArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamExitArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamExitArg)(nil), args)
@@ -235,11 +235,11 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 				},
 			},
 			"newlyAddedToTeam": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NewlyAddedToTeamArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NewlyAddedToTeamArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NewlyAddedToTeamArg)(nil), args)
@@ -250,11 +250,11 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 				},
 			},
 			"teamRoleMapChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamRoleMapChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamRoleMapChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamRoleMapChangedArg)(nil), args)
@@ -265,11 +265,11 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 				},
 			},
 			"avatarUpdated": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AvatarUpdatedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AvatarUpdatedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AvatarUpdatedArg)(nil), args)
@@ -280,21 +280,21 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 				},
 			},
 			"teamMetadataUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamMetadataUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.TeamMetadataUpdate(ctx)
 					return
 				},
 			},
 			"teamTreeMembershipsPartial": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamTreeMembershipsPartialArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamTreeMembershipsPartialArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamTreeMembershipsPartialArg)(nil), args)
@@ -305,11 +305,11 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 				},
 			},
 			"teamTreeMembershipsDone": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamTreeMembershipsDoneArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamTreeMembershipsDoneArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamTreeMembershipsDoneArg)(nil), args)
@@ -328,63 +328,63 @@ type NotifyTeamClient struct {
 }
 
 func (c NotifyTeamClient) TeamChangedByID(ctx context.Context, __arg TeamChangedByIDArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamChangedByID", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamChangedByID", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeamClient) TeamChangedByName(ctx context.Context, __arg TeamChangedByNameArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamChangedByName", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamChangedByName", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeamClient) TeamDeleted(ctx context.Context, teamID TeamID) (err error) {
 	__arg := TeamDeletedArg{TeamID: teamID}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamDeleted", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamDeleted", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeamClient) TeamAbandoned(ctx context.Context, teamID TeamID) (err error) {
 	__arg := TeamAbandonedArg{TeamID: teamID}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamAbandoned", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamAbandoned", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeamClient) TeamExit(ctx context.Context, teamID TeamID) (err error) {
 	__arg := TeamExitArg{TeamID: teamID}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamExit", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamExit", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeamClient) NewlyAddedToTeam(ctx context.Context, teamID TeamID) (err error) {
 	__arg := NewlyAddedToTeamArg{TeamID: teamID}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.newlyAddedToTeam", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.newlyAddedToTeam", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeamClient) TeamRoleMapChanged(ctx context.Context, newVersion UserTeamVersion) (err error) {
 	__arg := TeamRoleMapChangedArg{NewVersion: newVersion}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamRoleMapChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamRoleMapChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeamClient) AvatarUpdated(ctx context.Context, __arg AvatarUpdatedArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.avatarUpdated", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.avatarUpdated", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeamClient) TeamMetadataUpdate(ctx context.Context) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamMetadataUpdate", []interface{}{TeamMetadataUpdateArg{}}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamMetadataUpdate", []any{TeamMetadataUpdateArg{}}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeamClient) TeamTreeMembershipsPartial(ctx context.Context, membership TeamTreeMembership) (err error) {
 	__arg := TeamTreeMembershipsPartialArg{Membership: membership}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamTreeMembershipsPartial", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamTreeMembershipsPartial", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeamClient) TeamTreeMembershipsDone(ctx context.Context, result TeamTreeMembershipsDoneResult) (err error) {
 	__arg := TeamTreeMembershipsDoneArg{Result: result}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamTreeMembershipsDone", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamTreeMembershipsDone", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_teambot.go
+++ b/go/protocol/keybase1/notify_teambot.go
@@ -32,11 +32,11 @@ func NotifyTeambotProtocol(i NotifyTeambotInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyTeambot",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"newTeambotKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NewTeambotKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NewTeambotKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NewTeambotKeyArg)(nil), args)
@@ -47,11 +47,11 @@ func NotifyTeambotProtocol(i NotifyTeambotInterface) rpc.Protocol {
 				},
 			},
 			"teambotKeyNeeded": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeambotKeyNeededArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeambotKeyNeededArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeambotKeyNeededArg)(nil), args)
@@ -70,11 +70,11 @@ type NotifyTeambotClient struct {
 }
 
 func (c NotifyTeambotClient) NewTeambotKey(ctx context.Context, __arg NewTeambotKeyArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeambot.newTeambotKey", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeambot.newTeambotKey", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTeambotClient) TeambotKeyNeeded(ctx context.Context, __arg TeambotKeyNeededArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.NotifyTeambot.teambotKeyNeeded", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.NotifyTeambot.teambotKeyNeeded", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_tracking.go
+++ b/go/protocol/keybase1/notify_tracking.go
@@ -36,11 +36,11 @@ func NotifyTrackingProtocol(i NotifyTrackingInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyTracking",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"trackingChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TrackingChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TrackingChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TrackingChangedArg)(nil), args)
@@ -51,11 +51,11 @@ func NotifyTrackingProtocol(i NotifyTrackingInterface) rpc.Protocol {
 				},
 			},
 			"trackingInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TrackingInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TrackingInfoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TrackingInfoArg)(nil), args)
@@ -66,11 +66,11 @@ func NotifyTrackingProtocol(i NotifyTrackingInterface) rpc.Protocol {
 				},
 			},
 			"notifyUserBlocked": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NotifyUserBlockedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NotifyUserBlockedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NotifyUserBlockedArg)(nil), args)
@@ -89,17 +89,17 @@ type NotifyTrackingClient struct {
 }
 
 func (c NotifyTrackingClient) TrackingChanged(ctx context.Context, __arg TrackingChangedArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTracking.trackingChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTracking.trackingChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTrackingClient) TrackingInfo(ctx context.Context, __arg TrackingInfoArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTracking.trackingInfo", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTracking.trackingInfo", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyTrackingClient) NotifyUserBlocked(ctx context.Context, b UserBlockedSummary) (err error) {
 	__arg := NotifyUserBlockedArg{B: b}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyTracking.notifyUserBlocked", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTracking.notifyUserBlocked", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/notify_users.go
+++ b/go/protocol/keybase1/notify_users.go
@@ -38,11 +38,11 @@ func NotifyUsersProtocol(i NotifyUsersInterface) rpc.Protocol {
 		Name: "keybase.1.NotifyUsers",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"userChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UserChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UserChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UserChangedArg)(nil), args)
@@ -53,11 +53,11 @@ func NotifyUsersProtocol(i NotifyUsersInterface) rpc.Protocol {
 				},
 			},
 			"webOfTrustChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WebOfTrustChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]WebOfTrustChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]WebOfTrustChangedArg)(nil), args)
@@ -68,11 +68,11 @@ func NotifyUsersProtocol(i NotifyUsersInterface) rpc.Protocol {
 				},
 			},
 			"passwordChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PasswordChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PasswordChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PasswordChangedArg)(nil), args)
@@ -83,11 +83,11 @@ func NotifyUsersProtocol(i NotifyUsersInterface) rpc.Protocol {
 				},
 			},
 			"identifyUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]IdentifyUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]IdentifyUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]IdentifyUpdateArg)(nil), args)
@@ -107,23 +107,23 @@ type NotifyUsersClient struct {
 
 func (c NotifyUsersClient) UserChanged(ctx context.Context, uid UID) (err error) {
 	__arg := UserChangedArg{Uid: uid}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyUsers.userChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyUsers.userChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyUsersClient) WebOfTrustChanged(ctx context.Context, username string) (err error) {
 	__arg := WebOfTrustChangedArg{Username: username}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyUsers.webOfTrustChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyUsers.webOfTrustChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyUsersClient) PasswordChanged(ctx context.Context, state PassphraseState) (err error) {
 	__arg := PasswordChangedArg{State: state}
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyUsers.passwordChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyUsers.passwordChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyUsersClient) IdentifyUpdate(ctx context.Context, __arg IdentifyUpdateArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.NotifyUsers.identifyUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyUsers.identifyUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/paperprovision.go
+++ b/go/protocol/keybase1/paperprovision.go
@@ -28,11 +28,11 @@ func PaperprovisionProtocol(i PaperprovisionInterface) rpc.Protocol {
 		Name: "keybase.1.paperprovision",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"paperProvision": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PaperProvisionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PaperProvisionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PaperProvisionArg)(nil), args)
@@ -54,6 +54,6 @@ type PaperprovisionClient struct {
 // If the current device isn't provisioned, this function will
 // provision it.
 func (c PaperprovisionClient) PaperProvision(ctx context.Context, __arg PaperProvisionArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.paperprovision.paperProvision", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.paperprovision.paperProvision", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/pgp.go
+++ b/go/protocol/keybase1/pgp.go
@@ -359,11 +359,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 		Name: "keybase.1.pgp",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"pgpSign": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPSignArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPSignArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPSignArg)(nil), args)
@@ -374,11 +374,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpPull": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPPullArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPPullArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPPullArg)(nil), args)
@@ -389,11 +389,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpEncrypt": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPEncryptArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPEncryptArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPEncryptArg)(nil), args)
@@ -404,11 +404,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpDecrypt": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPDecryptArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPDecryptArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPDecryptArg)(nil), args)
@@ -419,11 +419,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpVerify": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPVerifyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPVerifyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPVerifyArg)(nil), args)
@@ -434,11 +434,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpImport": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPImportArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPImportArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPImportArg)(nil), args)
@@ -449,11 +449,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpExport": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPExportArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPExportArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPExportArg)(nil), args)
@@ -464,11 +464,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpExportByFingerprint": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPExportByFingerprintArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPExportByFingerprintArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPExportByFingerprintArg)(nil), args)
@@ -479,11 +479,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpExportByKID": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPExportByKIDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPExportByKIDArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPExportByKIDArg)(nil), args)
@@ -494,11 +494,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpKeyGen": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPKeyGenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPKeyGenArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPKeyGenArg)(nil), args)
@@ -509,11 +509,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpKeyGenDefault": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPKeyGenDefaultArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPKeyGenDefaultArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPKeyGenDefaultArg)(nil), args)
@@ -524,11 +524,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpDeletePrimary": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPDeletePrimaryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPDeletePrimaryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPDeletePrimaryArg)(nil), args)
@@ -539,11 +539,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpSelect": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPSelectArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPSelectArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPSelectArg)(nil), args)
@@ -554,11 +554,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPUpdateArg)(nil), args)
@@ -569,11 +569,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpPurge": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPPurgeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPPurgeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPPurgeArg)(nil), args)
@@ -584,11 +584,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpStorageDismiss": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPStorageDismissArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPStorageDismissArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPStorageDismissArg)(nil), args)
@@ -599,11 +599,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpPushPrivate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPPushPrivateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPPushPrivateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPPushPrivateArg)(nil), args)
@@ -614,11 +614,11 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 				},
 			},
 			"pgpPullPrivate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PGPPullPrivateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PGPPullPrivateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PGPPullPrivateArg)(nil), args)
@@ -637,103 +637,103 @@ type PGPClient struct {
 }
 
 func (c PGPClient) PGPSign(ctx context.Context, __arg PGPSignArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpSign", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpSign", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Download PGP keys for tracked users and update the local GPG keyring.
 // If usernames is nonempty, update only those users.
 func (c PGPClient) PGPPull(ctx context.Context, __arg PGPPullArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpPull", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpPull", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PGPClient) PGPEncrypt(ctx context.Context, __arg PGPEncryptArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpEncrypt", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpEncrypt", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PGPClient) PGPDecrypt(ctx context.Context, __arg PGPDecryptArg) (res PGPSigVerification, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpDecrypt", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpDecrypt", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c PGPClient) PGPVerify(ctx context.Context, __arg PGPVerifyArg) (res PGPSigVerification, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpVerify", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpVerify", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c PGPClient) PGPImport(ctx context.Context, __arg PGPImportArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpImport", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpImport", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Exports active PGP keys. Only allows armored export.
 func (c PGPClient) PGPExport(ctx context.Context, __arg PGPExportArg) (res []KeyInfo, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpExport", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpExport", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c PGPClient) PGPExportByFingerprint(ctx context.Context, __arg PGPExportByFingerprintArg) (res []KeyInfo, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpExportByFingerprint", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpExportByFingerprint", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c PGPClient) PGPExportByKID(ctx context.Context, __arg PGPExportByKIDArg) (res []KeyInfo, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpExportByKID", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpExportByKID", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c PGPClient) PGPKeyGen(ctx context.Context, __arg PGPKeyGenArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpKeyGen", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpKeyGen", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PGPClient) PGPKeyGenDefault(ctx context.Context, __arg PGPKeyGenDefaultArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpKeyGenDefault", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpKeyGenDefault", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PGPClient) PGPDeletePrimary(ctx context.Context, sessionID int) (err error) {
 	__arg := PGPDeletePrimaryArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpDeletePrimary", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpDeletePrimary", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Select an existing key and add to Keybase.
 func (c PGPClient) PGPSelect(ctx context.Context, __arg PGPSelectArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpSelect", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpSelect", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Push updated key(s) to the server.
 func (c PGPClient) PGPUpdate(ctx context.Context, __arg PGPUpdateArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpUpdate", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpUpdate", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PGPClient) PGPPurge(ctx context.Context, __arg PGPPurgeArg) (res PGPPurgeRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpPurge", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpPurge", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Dismiss the PGP unlock via secret_store_file notification.
 func (c PGPClient) PGPStorageDismiss(ctx context.Context, sessionID int) (err error) {
 	__arg := PGPStorageDismissArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpStorageDismiss", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpStorageDismiss", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // push the PGP key that matches the given fingerprints from GnuPG to KBFS. If it is empty, then
 // push all matching PGP keys in the user's sigchain.
 func (c PGPClient) PGPPushPrivate(ctx context.Context, __arg PGPPushPrivateArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpPushPrivate", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpPushPrivate", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // pull the given PGP keys from KBFS to the local GnuPG keychain. If it is empty, then
 // attempt to pull all matching PGP keys in the user's sigchain.
 func (c PGPClient) PGPPullPrivate(ctx context.Context, __arg PGPPullPrivateArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpPullPrivate", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpPullPrivate", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/pgp_ui.go
+++ b/go/protocol/keybase1/pgp_ui.go
@@ -58,11 +58,11 @@ func PGPUiProtocol(i PGPUiInterface) rpc.Protocol {
 		Name: "keybase.1.pgpUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"outputPGPWarning": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]OutputPGPWarningArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]OutputPGPWarningArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]OutputPGPWarningArg)(nil), args)
@@ -73,11 +73,11 @@ func PGPUiProtocol(i PGPUiInterface) rpc.Protocol {
 				},
 			},
 			"outputSignatureSuccess": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]OutputSignatureSuccessArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]OutputSignatureSuccessArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]OutputSignatureSuccessArg)(nil), args)
@@ -88,11 +88,11 @@ func PGPUiProtocol(i PGPUiInterface) rpc.Protocol {
 				},
 			},
 			"outputSignatureNonKeybase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]OutputSignatureNonKeybaseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]OutputSignatureNonKeybaseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]OutputSignatureNonKeybaseArg)(nil), args)
@@ -103,11 +103,11 @@ func PGPUiProtocol(i PGPUiInterface) rpc.Protocol {
 				},
 			},
 			"keyGenerated": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]KeyGeneratedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]KeyGeneratedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]KeyGeneratedArg)(nil), args)
@@ -118,11 +118,11 @@ func PGPUiProtocol(i PGPUiInterface) rpc.Protocol {
 				},
 			},
 			"shouldPushPrivate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ShouldPushPrivateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ShouldPushPrivateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ShouldPushPrivateArg)(nil), args)
@@ -133,11 +133,11 @@ func PGPUiProtocol(i PGPUiInterface) rpc.Protocol {
 				},
 			},
 			"finished": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FinishedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FinishedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FinishedArg)(nil), args)
@@ -156,32 +156,32 @@ type PGPUiClient struct {
 }
 
 func (c PGPUiClient) OutputPGPWarning(ctx context.Context, __arg OutputPGPWarningArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgpUi.outputPGPWarning", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgpUi.outputPGPWarning", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PGPUiClient) OutputSignatureSuccess(ctx context.Context, __arg OutputSignatureSuccessArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgpUi.outputSignatureSuccess", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgpUi.outputSignatureSuccess", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PGPUiClient) OutputSignatureNonKeybase(ctx context.Context, __arg OutputSignatureNonKeybaseArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgpUi.outputSignatureNonKeybase", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgpUi.outputSignatureNonKeybase", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PGPUiClient) KeyGenerated(ctx context.Context, __arg KeyGeneratedArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgpUi.keyGenerated", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgpUi.keyGenerated", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PGPUiClient) ShouldPushPrivate(ctx context.Context, __arg ShouldPushPrivateArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgpUi.shouldPushPrivate", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgpUi.shouldPushPrivate", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c PGPUiClient) Finished(ctx context.Context, sessionID int) (err error) {
 	__arg := FinishedArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.pgpUi.finished", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pgpUi.finished", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/phone_numbers.go
+++ b/go/protocol/keybase1/phone_numbers.go
@@ -126,11 +126,11 @@ func PhoneNumbersProtocol(i PhoneNumbersInterface) rpc.Protocol {
 		Name: "keybase.1.phoneNumbers",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"addPhoneNumber": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AddPhoneNumberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AddPhoneNumberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AddPhoneNumberArg)(nil), args)
@@ -141,11 +141,11 @@ func PhoneNumbersProtocol(i PhoneNumbersInterface) rpc.Protocol {
 				},
 			},
 			"editPhoneNumber": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]EditPhoneNumberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]EditPhoneNumberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]EditPhoneNumberArg)(nil), args)
@@ -156,11 +156,11 @@ func PhoneNumbersProtocol(i PhoneNumbersInterface) rpc.Protocol {
 				},
 			},
 			"verifyPhoneNumber": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]VerifyPhoneNumberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]VerifyPhoneNumberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]VerifyPhoneNumberArg)(nil), args)
@@ -171,11 +171,11 @@ func PhoneNumbersProtocol(i PhoneNumbersInterface) rpc.Protocol {
 				},
 			},
 			"resendVerificationForPhoneNumber": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ResendVerificationForPhoneNumberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ResendVerificationForPhoneNumberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ResendVerificationForPhoneNumberArg)(nil), args)
@@ -186,11 +186,11 @@ func PhoneNumbersProtocol(i PhoneNumbersInterface) rpc.Protocol {
 				},
 			},
 			"getPhoneNumbers": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPhoneNumbersArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPhoneNumbersArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPhoneNumbersArg)(nil), args)
@@ -201,11 +201,11 @@ func PhoneNumbersProtocol(i PhoneNumbersInterface) rpc.Protocol {
 				},
 			},
 			"deletePhoneNumber": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeletePhoneNumberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeletePhoneNumberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeletePhoneNumberArg)(nil), args)
@@ -216,11 +216,11 @@ func PhoneNumbersProtocol(i PhoneNumbersInterface) rpc.Protocol {
 				},
 			},
 			"setVisibilityPhoneNumber": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetVisibilityPhoneNumberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetVisibilityPhoneNumberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetVisibilityPhoneNumberArg)(nil), args)
@@ -231,11 +231,11 @@ func PhoneNumbersProtocol(i PhoneNumbersInterface) rpc.Protocol {
 				},
 			},
 			"setVisibilityAllPhoneNumber": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetVisibilityAllPhoneNumberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetVisibilityAllPhoneNumberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetVisibilityAllPhoneNumberArg)(nil), args)
@@ -254,42 +254,42 @@ type PhoneNumbersClient struct {
 }
 
 func (c PhoneNumbersClient) AddPhoneNumber(ctx context.Context, __arg AddPhoneNumberArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.addPhoneNumber", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.addPhoneNumber", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PhoneNumbersClient) EditPhoneNumber(ctx context.Context, __arg EditPhoneNumberArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.editPhoneNumber", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.editPhoneNumber", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PhoneNumbersClient) VerifyPhoneNumber(ctx context.Context, __arg VerifyPhoneNumberArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.verifyPhoneNumber", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.verifyPhoneNumber", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PhoneNumbersClient) ResendVerificationForPhoneNumber(ctx context.Context, __arg ResendVerificationForPhoneNumberArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.resendVerificationForPhoneNumber", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.resendVerificationForPhoneNumber", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PhoneNumbersClient) GetPhoneNumbers(ctx context.Context, sessionID int) (res []UserPhoneNumber, err error) {
 	__arg := GetPhoneNumbersArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.getPhoneNumbers", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.getPhoneNumbers", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c PhoneNumbersClient) DeletePhoneNumber(ctx context.Context, __arg DeletePhoneNumberArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.deletePhoneNumber", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.deletePhoneNumber", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PhoneNumbersClient) SetVisibilityPhoneNumber(ctx context.Context, __arg SetVisibilityPhoneNumberArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.setVisibilityPhoneNumber", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.setVisibilityPhoneNumber", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PhoneNumbersClient) SetVisibilityAllPhoneNumber(ctx context.Context, __arg SetVisibilityAllPhoneNumberArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.setVisibilityAllPhoneNumber", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.phoneNumbers.setVisibilityAllPhoneNumber", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/pprof.go
+++ b/go/protocol/keybase1/pprof.go
@@ -51,11 +51,11 @@ func PprofProtocol(i PprofInterface) rpc.Protocol {
 		Name: "keybase.1.pprof",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"processorProfile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ProcessorProfileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ProcessorProfileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ProcessorProfileArg)(nil), args)
@@ -66,11 +66,11 @@ func PprofProtocol(i PprofInterface) rpc.Protocol {
 				},
 			},
 			"heapProfile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HeapProfileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]HeapProfileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]HeapProfileArg)(nil), args)
@@ -81,11 +81,11 @@ func PprofProtocol(i PprofInterface) rpc.Protocol {
 				},
 			},
 			"logProcessorProfile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LogProcessorProfileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LogProcessorProfileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LogProcessorProfileArg)(nil), args)
@@ -96,11 +96,11 @@ func PprofProtocol(i PprofInterface) rpc.Protocol {
 				},
 			},
 			"trace": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TraceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TraceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TraceArg)(nil), args)
@@ -111,11 +111,11 @@ func PprofProtocol(i PprofInterface) rpc.Protocol {
 				},
 			},
 			"logTrace": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LogTraceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LogTraceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LogTraceArg)(nil), args)
@@ -134,26 +134,26 @@ type PprofClient struct {
 }
 
 func (c PprofClient) ProcessorProfile(ctx context.Context, __arg ProcessorProfileArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pprof.processorProfile", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pprof.processorProfile", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PprofClient) HeapProfile(ctx context.Context, __arg HeapProfileArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pprof.heapProfile", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pprof.heapProfile", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PprofClient) LogProcessorProfile(ctx context.Context, __arg LogProcessorProfileArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pprof.logProcessorProfile", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pprof.logProcessorProfile", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PprofClient) Trace(ctx context.Context, __arg TraceArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pprof.trace", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pprof.trace", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c PprofClient) LogTrace(ctx context.Context, __arg LogTraceArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pprof.logTrace", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.pprof.logTrace", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/prove.go
+++ b/go/protocol/keybase1/prove.go
@@ -75,11 +75,11 @@ func ProveProtocol(i ProveInterface) rpc.Protocol {
 		Name: "keybase.1.prove",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"startProof": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StartProofArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]StartProofArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]StartProofArg)(nil), args)
@@ -90,11 +90,11 @@ func ProveProtocol(i ProveInterface) rpc.Protocol {
 				},
 			},
 			"checkProof": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CheckProofArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CheckProofArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CheckProofArg)(nil), args)
@@ -105,31 +105,31 @@ func ProveProtocol(i ProveInterface) rpc.Protocol {
 				},
 			},
 			"listSomeProofServices": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListSomeProofServicesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.ListSomeProofServices(ctx)
 					return
 				},
 			},
 			"listProofServices": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListProofServicesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.ListProofServices(ctx)
 					return
 				},
 			},
 			"validateUsername": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ValidateUsernameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ValidateUsernameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ValidateUsernameArg)(nil), args)
@@ -148,26 +148,26 @@ type ProveClient struct {
 }
 
 func (c ProveClient) StartProof(ctx context.Context, __arg StartProofArg) (res StartProofResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.prove.startProof", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.prove.startProof", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ProveClient) CheckProof(ctx context.Context, __arg CheckProofArg) (res CheckProofStatus, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.prove.checkProof", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.prove.checkProof", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ProveClient) ListSomeProofServices(ctx context.Context) (res []string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.prove.listSomeProofServices", []interface{}{ListSomeProofServicesArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.prove.listSomeProofServices", []any{ListSomeProofServicesArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ProveClient) ListProofServices(ctx context.Context) (res []string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.prove.listProofServices", []interface{}{ListProofServicesArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.prove.listProofServices", []any{ListProofServicesArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ProveClient) ValidateUsername(ctx context.Context, __arg ValidateUsernameArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.prove.validateUsername", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.prove.validateUsername", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/prove_ui.go
+++ b/go/protocol/keybase1/prove_ui.go
@@ -155,11 +155,11 @@ func ProveUiProtocol(i ProveUiInterface) rpc.Protocol {
 		Name: "keybase.1.proveUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"promptOverwrite": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PromptOverwriteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PromptOverwriteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PromptOverwriteArg)(nil), args)
@@ -170,11 +170,11 @@ func ProveUiProtocol(i ProveUiInterface) rpc.Protocol {
 				},
 			},
 			"promptUsername": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PromptUsernameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PromptUsernameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PromptUsernameArg)(nil), args)
@@ -185,11 +185,11 @@ func ProveUiProtocol(i ProveUiInterface) rpc.Protocol {
 				},
 			},
 			"outputPrechecks": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]OutputPrechecksArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]OutputPrechecksArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]OutputPrechecksArg)(nil), args)
@@ -200,11 +200,11 @@ func ProveUiProtocol(i ProveUiInterface) rpc.Protocol {
 				},
 			},
 			"preProofWarning": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PreProofWarningArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PreProofWarningArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PreProofWarningArg)(nil), args)
@@ -215,11 +215,11 @@ func ProveUiProtocol(i ProveUiInterface) rpc.Protocol {
 				},
 			},
 			"outputInstructions": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]OutputInstructionsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]OutputInstructionsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]OutputInstructionsArg)(nil), args)
@@ -230,11 +230,11 @@ func ProveUiProtocol(i ProveUiInterface) rpc.Protocol {
 				},
 			},
 			"okToCheck": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]OkToCheckArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]OkToCheckArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]OkToCheckArg)(nil), args)
@@ -245,11 +245,11 @@ func ProveUiProtocol(i ProveUiInterface) rpc.Protocol {
 				},
 			},
 			"checking": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CheckingArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CheckingArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CheckingArg)(nil), args)
@@ -260,11 +260,11 @@ func ProveUiProtocol(i ProveUiInterface) rpc.Protocol {
 				},
 			},
 			"continueChecking": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ContinueCheckingArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ContinueCheckingArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ContinueCheckingArg)(nil), args)
@@ -275,11 +275,11 @@ func ProveUiProtocol(i ProveUiInterface) rpc.Protocol {
 				},
 			},
 			"displayRecheckWarning": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayRecheckWarningArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayRecheckWarningArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayRecheckWarningArg)(nil), args)
@@ -298,47 +298,47 @@ type ProveUiClient struct {
 }
 
 func (c ProveUiClient) PromptOverwrite(ctx context.Context, __arg PromptOverwriteArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.proveUi.promptOverwrite", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.proveUi.promptOverwrite", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ProveUiClient) PromptUsername(ctx context.Context, __arg PromptUsernameArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.proveUi.promptUsername", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.proveUi.promptUsername", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ProveUiClient) OutputPrechecks(ctx context.Context, __arg OutputPrechecksArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.proveUi.outputPrechecks", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.proveUi.outputPrechecks", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ProveUiClient) PreProofWarning(ctx context.Context, __arg PreProofWarningArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.proveUi.preProofWarning", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.proveUi.preProofWarning", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ProveUiClient) OutputInstructions(ctx context.Context, __arg OutputInstructionsArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.proveUi.outputInstructions", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.proveUi.outputInstructions", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ProveUiClient) OkToCheck(ctx context.Context, __arg OkToCheckArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.proveUi.okToCheck", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.proveUi.okToCheck", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ProveUiClient) Checking(ctx context.Context, __arg CheckingArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.proveUi.checking", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.proveUi.checking", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c ProveUiClient) ContinueChecking(ctx context.Context, sessionID int) (res bool, err error) {
 	__arg := ContinueCheckingArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.proveUi.continueChecking", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.proveUi.continueChecking", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ProveUiClient) DisplayRecheckWarning(ctx context.Context, __arg DisplayRecheckWarningArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.proveUi.displayRecheckWarning", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.proveUi.displayRecheckWarning", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/provision_ui.go
+++ b/go/protocol/keybase1/provision_ui.go
@@ -227,11 +227,11 @@ func ProvisionUiProtocol(i ProvisionUiInterface) rpc.Protocol {
 		Name: "keybase.1.provisionUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"chooseProvisioningMethod": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChooseProvisioningMethodArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChooseProvisioningMethodArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChooseProvisioningMethodArg)(nil), args)
@@ -242,11 +242,11 @@ func ProvisionUiProtocol(i ProvisionUiInterface) rpc.Protocol {
 				},
 			},
 			"chooseGPGMethod": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChooseGPGMethodArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChooseGPGMethodArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChooseGPGMethodArg)(nil), args)
@@ -257,11 +257,11 @@ func ProvisionUiProtocol(i ProvisionUiInterface) rpc.Protocol {
 				},
 			},
 			"switchToGPGSignOK": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SwitchToGPGSignOKArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SwitchToGPGSignOKArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SwitchToGPGSignOKArg)(nil), args)
@@ -272,11 +272,11 @@ func ProvisionUiProtocol(i ProvisionUiInterface) rpc.Protocol {
 				},
 			},
 			"chooseDevice": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChooseDeviceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChooseDeviceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChooseDeviceArg)(nil), args)
@@ -287,11 +287,11 @@ func ProvisionUiProtocol(i ProvisionUiInterface) rpc.Protocol {
 				},
 			},
 			"chooseDeviceType": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChooseDeviceTypeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChooseDeviceTypeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChooseDeviceTypeArg)(nil), args)
@@ -302,11 +302,11 @@ func ProvisionUiProtocol(i ProvisionUiInterface) rpc.Protocol {
 				},
 			},
 			"DisplayAndPromptSecret": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplayAndPromptSecretArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplayAndPromptSecretArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplayAndPromptSecretArg)(nil), args)
@@ -317,11 +317,11 @@ func ProvisionUiProtocol(i ProvisionUiInterface) rpc.Protocol {
 				},
 			},
 			"DisplaySecretExchanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DisplaySecretExchangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DisplaySecretExchangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DisplaySecretExchangedArg)(nil), args)
@@ -332,11 +332,11 @@ func ProvisionUiProtocol(i ProvisionUiInterface) rpc.Protocol {
 				},
 			},
 			"PromptNewDeviceName": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PromptNewDeviceNameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PromptNewDeviceNameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PromptNewDeviceNameArg)(nil), args)
@@ -347,11 +347,11 @@ func ProvisionUiProtocol(i ProvisionUiInterface) rpc.Protocol {
 				},
 			},
 			"ProvisioneeSuccess": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ProvisioneeSuccessArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ProvisioneeSuccessArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ProvisioneeSuccessArg)(nil), args)
@@ -362,11 +362,11 @@ func ProvisionUiProtocol(i ProvisionUiInterface) rpc.Protocol {
 				},
 			},
 			"ProvisionerSuccess": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ProvisionerSuccessArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ProvisionerSuccessArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ProvisionerSuccessArg)(nil), args)
@@ -389,7 +389,7 @@ type ProvisionUiClient struct {
 // method for provisioning.  gpgOption will be true if GPG
 // should be offered as an option.
 func (c ProvisionUiClient) ChooseProvisioningMethod(ctx context.Context, __arg ChooseProvisioningMethodArg) (res ProvisionMethod, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.provisionUi.chooseProvisioningMethod", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.provisionUi.chooseProvisioningMethod", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -405,7 +405,7 @@ func (c ProvisionUiClient) ChooseProvisioningMethod(ctx context.Context, __arg C
 // After this, gpg_ui.selectKey will be called (if there are
 // multiple keys available).
 func (c ProvisionUiClient) ChooseGPGMethod(ctx context.Context, __arg ChooseGPGMethodArg) (res GPGMethod, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.provisionUi.chooseGPGMethod", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.provisionUi.chooseGPGMethod", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -414,12 +414,12 @@ func (c ProvisionUiClient) ChooseGPGMethod(ctx context.Context, __arg ChooseGPGM
 // with this key.  Return true to switch to GPG signing,
 // false to abort provisioning.
 func (c ProvisionUiClient) SwitchToGPGSignOK(ctx context.Context, __arg SwitchToGPGSignOKArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.provisionUi.switchToGPGSignOK", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.provisionUi.switchToGPGSignOK", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c ProvisionUiClient) ChooseDevice(ctx context.Context, __arg ChooseDeviceArg) (res DeviceID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.provisionUi.chooseDevice", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.provisionUi.chooseDevice", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -427,7 +427,7 @@ func (c ProvisionUiClient) ChooseDevice(ctx context.Context, __arg ChooseDeviceA
 // If selecting the existing device type, set kind to EXISTING_DEVICE_0.
 // If selecting the new device type, set kind to NEW_DEVICE_1.
 func (c ProvisionUiClient) ChooseDeviceType(ctx context.Context, __arg ChooseDeviceTypeArg) (res DeviceType, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.provisionUi.chooseDeviceType", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.provisionUi.chooseDeviceType", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -436,7 +436,7 @@ func (c ProvisionUiClient) ChooseDeviceType(ctx context.Context, __arg ChooseDev
 // If it does not return a secret, it will be canceled when this device receives the secret via kex2.
 // If there is an error in the phrase, then previousErr will be set when this is called again.
 func (c ProvisionUiClient) DisplayAndPromptSecret(ctx context.Context, __arg DisplayAndPromptSecretArg) (res SecretResponse, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.provisionUi.DisplayAndPromptSecret", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.provisionUi.DisplayAndPromptSecret", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -444,7 +444,7 @@ func (c ProvisionUiClient) DisplayAndPromptSecret(ctx context.Context, __arg Dis
 // devices.
 func (c ProvisionUiClient) DisplaySecretExchanged(ctx context.Context, sessionID int) (err error) {
 	__arg := DisplaySecretExchangedArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.provisionUi.DisplaySecretExchanged", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.provisionUi.DisplaySecretExchanged", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -453,18 +453,18 @@ func (c ProvisionUiClient) DisplaySecretExchanged(ctx context.Context, sessionID
 // names for the user.  If the device name returned to the service is invalid or already
 // taken, it will call this again with an error message in errorMessage.
 func (c ProvisionUiClient) PromptNewDeviceName(ctx context.Context, __arg PromptNewDeviceNameArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.provisionUi.PromptNewDeviceName", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.provisionUi.PromptNewDeviceName", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // ProvisioneeSuccess is called on provisionee when it is successfully provisioned.
 func (c ProvisionUiClient) ProvisioneeSuccess(ctx context.Context, __arg ProvisioneeSuccessArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.provisionUi.ProvisioneeSuccess", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.provisionUi.ProvisioneeSuccess", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // ProvisionerSuccess is called on provisioner when it successfully provisions another device.
 func (c ProvisionUiClient) ProvisionerSuccess(ctx context.Context, __arg ProvisionerSuccessArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.provisionUi.ProvisionerSuccess", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.provisionUi.ProvisionerSuccess", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/quota.go
+++ b/go/protocol/keybase1/quota.go
@@ -38,11 +38,11 @@ func QuotaProtocol(i QuotaInterface) rpc.Protocol {
 		Name: "keybase.1.quota",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"verifySession": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]VerifySessionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]VerifySessionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]VerifySessionArg)(nil), args)
@@ -62,6 +62,6 @@ type QuotaClient struct {
 
 func (c QuotaClient) VerifySession(ctx context.Context, session string) (res VerifySessionRes, err error) {
 	__arg := VerifySessionArg{Session: session}
-	err = c.Cli.Call(ctx, "keybase.1.quota.verifySession", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.quota.verifySession", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/reachability.go
+++ b/go/protocol/keybase1/reachability.go
@@ -73,11 +73,11 @@ func ReachabilityProtocol(i ReachabilityInterface) rpc.Protocol {
 		Name: "keybase.1.reachability",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"reachabilityChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ReachabilityChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ReachabilityChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ReachabilityChangedArg)(nil), args)
@@ -88,21 +88,21 @@ func ReachabilityProtocol(i ReachabilityInterface) rpc.Protocol {
 				},
 			},
 			"startReachability": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StartReachabilityArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.StartReachability(ctx)
 					return
 				},
 			},
 			"checkReachability": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CheckReachabilityArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.CheckReachability(ctx)
 					return
 				},
@@ -117,19 +117,19 @@ type ReachabilityClient struct {
 
 func (c ReachabilityClient) ReachabilityChanged(ctx context.Context, reachability Reachability) (err error) {
 	__arg := ReachabilityChangedArg{Reachability: reachability}
-	err = c.Cli.Notify(ctx, "keybase.1.reachability.reachabilityChanged", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.reachability.reachabilityChanged", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 // Start reachability checks and return current status, which
 // may be cached.
 func (c ReachabilityClient) StartReachability(ctx context.Context) (res Reachability, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.reachability.startReachability", []interface{}{StartReachabilityArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.reachability.startReachability", []any{StartReachabilityArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 // Performs a reachability check. This is not a cached response.
 func (c ReachabilityClient) CheckReachability(ctx context.Context) (res Reachability, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.reachability.checkReachability", []interface{}{CheckReachabilityArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.reachability.checkReachability", []any{CheckReachabilityArg{}}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/rekey.go
+++ b/go/protocol/keybase1/rekey.go
@@ -224,11 +224,11 @@ func RekeyProtocol(i RekeyInterface) rpc.Protocol {
 		Name: "keybase.1.rekey",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"showPendingRekeyStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ShowPendingRekeyStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ShowPendingRekeyStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ShowPendingRekeyStatusArg)(nil), args)
@@ -239,11 +239,11 @@ func RekeyProtocol(i RekeyInterface) rpc.Protocol {
 				},
 			},
 			"getPendingRekeyStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPendingRekeyStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPendingRekeyStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPendingRekeyStatusArg)(nil), args)
@@ -254,11 +254,11 @@ func RekeyProtocol(i RekeyInterface) rpc.Protocol {
 				},
 			},
 			"debugShowRekeyStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DebugShowRekeyStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DebugShowRekeyStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DebugShowRekeyStatusArg)(nil), args)
@@ -269,11 +269,11 @@ func RekeyProtocol(i RekeyInterface) rpc.Protocol {
 				},
 			},
 			"rekeyStatusFinish": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RekeyStatusFinishArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RekeyStatusFinishArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RekeyStatusFinishArg)(nil), args)
@@ -284,11 +284,11 @@ func RekeyProtocol(i RekeyInterface) rpc.Protocol {
 				},
 			},
 			"rekeySync": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RekeySyncArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RekeySyncArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RekeySyncArg)(nil), args)
@@ -299,11 +299,11 @@ func RekeyProtocol(i RekeyInterface) rpc.Protocol {
 				},
 			},
 			"getRevokeWarning": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetRevokeWarningArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetRevokeWarningArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetRevokeWarningArg)(nil), args)
@@ -325,14 +325,14 @@ type RekeyClient struct {
 // or nothing if none were pending.
 func (c RekeyClient) ShowPendingRekeyStatus(ctx context.Context, sessionID int) (err error) {
 	__arg := ShowPendingRekeyStatusArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.rekey.showPendingRekeyStatus", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.rekey.showPendingRekeyStatus", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // GetPendingRekeyStatus returns the pending ProblemSetDevices.
 func (c RekeyClient) GetPendingRekeyStatus(ctx context.Context, sessionID int) (res ProblemSetDevices, err error) {
 	__arg := GetPendingRekeyStatusArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.rekey.getPendingRekeyStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.rekey.getPendingRekeyStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -340,7 +340,7 @@ func (c RekeyClient) GetPendingRekeyStatus(ctx context.Context, sessionID int) (
 // the current user.
 func (c RekeyClient) DebugShowRekeyStatus(ctx context.Context, sessionID int) (err error) {
 	__arg := DebugShowRekeyStatusArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.rekey.debugShowRekeyStatus", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.rekey.debugShowRekeyStatus", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -348,7 +348,7 @@ func (c RekeyClient) DebugShowRekeyStatus(ctx context.Context, sessionID int) (e
 // can be Fixed or Ignored.
 func (c RekeyClient) RekeyStatusFinish(ctx context.Context, sessionID int) (res Outcome, err error) {
 	__arg := RekeyStatusFinishArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.rekey.rekeyStatusFinish", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.rekey.rekeyStatusFinish", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -356,13 +356,13 @@ func (c RekeyClient) RekeyStatusFinish(ctx context.Context, sessionID int) (res 
 // to assert state. Good for race-free testing, not very useful in production.
 // Force overrides a long-snooze.
 func (c RekeyClient) RekeySync(ctx context.Context, __arg RekeySyncArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.rekey.rekeySync", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.rekey.rekeySync", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // GetRevokeWarning computes the TLFs that will be endangered if actingDevice
 // revokes targetDevice.
 func (c RekeyClient) GetRevokeWarning(ctx context.Context, __arg GetRevokeWarningArg) (res RevokeWarning, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.rekey.getRevokeWarning", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.rekey.getRevokeWarning", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/rekey_ui.go
+++ b/go/protocol/keybase1/rekey_ui.go
@@ -97,21 +97,21 @@ func RekeyUIProtocol(i RekeyUIInterface) rpc.Protocol {
 		Name: "keybase.1.rekeyUI",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"delegateRekeyUI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DelegateRekeyUIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.DelegateRekeyUI(ctx)
 					return
 				},
 			},
 			"refresh": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RefreshArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RefreshArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RefreshArg)(nil), args)
@@ -122,11 +122,11 @@ func RekeyUIProtocol(i RekeyUIInterface) rpc.Protocol {
 				},
 			},
 			"rekeySendEvent": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RekeySendEventArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RekeySendEventArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RekeySendEventArg)(nil), args)
@@ -145,20 +145,20 @@ type RekeyUIClient struct {
 }
 
 func (c RekeyUIClient) DelegateRekeyUI(ctx context.Context) (res int, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.rekeyUI.delegateRekeyUI", []interface{}{DelegateRekeyUIArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.rekeyUI.delegateRekeyUI", []any{DelegateRekeyUIArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 // Refresh is called whenever Electron should refresh the UI, either
 // because a change came in, or because there was a timeout poll.
 func (c RekeyUIClient) Refresh(ctx context.Context, __arg RefreshArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.rekeyUI.refresh", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.rekeyUI.refresh", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // RekeySendEvent sends updates as to what's going on in the rekey
 // thread. This is mainly useful in testing.
 func (c RekeyUIClient) RekeySendEvent(ctx context.Context, __arg RekeySendEventArg) (err error) {
-	err = c.Cli.Notify(ctx, "keybase.1.rekeyUI.rekeySendEvent", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "keybase.1.rekeyUI.rekeySendEvent", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/revoke.go
+++ b/go/protocol/keybase1/revoke.go
@@ -37,11 +37,11 @@ func RevokeProtocol(i RevokeInterface) rpc.Protocol {
 		Name: "keybase.1.revoke",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"revokeKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RevokeKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RevokeKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RevokeKeyArg)(nil), args)
@@ -52,11 +52,11 @@ func RevokeProtocol(i RevokeInterface) rpc.Protocol {
 				},
 			},
 			"revokeDevice": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RevokeDeviceArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RevokeDeviceArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RevokeDeviceArg)(nil), args)
@@ -67,11 +67,11 @@ func RevokeProtocol(i RevokeInterface) rpc.Protocol {
 				},
 			},
 			"revokeSigs": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RevokeSigsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RevokeSigsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RevokeSigsArg)(nil), args)
@@ -90,16 +90,16 @@ type RevokeClient struct {
 }
 
 func (c RevokeClient) RevokeKey(ctx context.Context, __arg RevokeKeyArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.revoke.revokeKey", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.revoke.revokeKey", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c RevokeClient) RevokeDevice(ctx context.Context, __arg RevokeDeviceArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.revoke.revokeDevice", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.revoke.revokeDevice", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c RevokeClient) RevokeSigs(ctx context.Context, __arg RevokeSigsArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.revoke.revokeSigs", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.revoke.revokeSigs", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/saltpack.go
+++ b/go/protocol/keybase1/saltpack.go
@@ -403,11 +403,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 		Name: "keybase.1.saltpack",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"saltpackEncrypt": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackEncryptArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackEncryptArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackEncryptArg)(nil), args)
@@ -418,11 +418,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackDecrypt": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackDecryptArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackDecryptArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackDecryptArg)(nil), args)
@@ -433,11 +433,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackSign": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackSignArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackSignArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackSignArg)(nil), args)
@@ -448,11 +448,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackVerify": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackVerifyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackVerifyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackVerifyArg)(nil), args)
@@ -463,11 +463,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackEncryptString": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackEncryptStringArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackEncryptStringArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackEncryptStringArg)(nil), args)
@@ -478,11 +478,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackEncryptStringToTextFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackEncryptStringToTextFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackEncryptStringToTextFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackEncryptStringToTextFileArg)(nil), args)
@@ -493,11 +493,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackEncryptFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackEncryptFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackEncryptFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackEncryptFileArg)(nil), args)
@@ -508,11 +508,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackDecryptString": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackDecryptStringArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackDecryptStringArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackDecryptStringArg)(nil), args)
@@ -523,11 +523,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackDecryptFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackDecryptFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackDecryptFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackDecryptFileArg)(nil), args)
@@ -538,11 +538,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackSignString": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackSignStringArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackSignStringArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackSignStringArg)(nil), args)
@@ -553,11 +553,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackSignStringToTextFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackSignStringToTextFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackSignStringToTextFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackSignStringToTextFileArg)(nil), args)
@@ -568,11 +568,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackSignFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackSignFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackSignFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackSignFileArg)(nil), args)
@@ -583,11 +583,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackSaveCiphertextToFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackSaveCiphertextToFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackSaveCiphertextToFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackSaveCiphertextToFileArg)(nil), args)
@@ -598,11 +598,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackSaveSignedMsgToFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackSaveSignedMsgToFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackSaveSignedMsgToFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackSaveSignedMsgToFileArg)(nil), args)
@@ -613,11 +613,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackVerifyString": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackVerifyStringArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackVerifyStringArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackVerifyStringArg)(nil), args)
@@ -628,11 +628,11 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 				},
 			},
 			"saltpackVerifyFile": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackVerifyFileArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackVerifyFileArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackVerifyFileArg)(nil), args)
@@ -651,81 +651,81 @@ type SaltpackClient struct {
 }
 
 func (c SaltpackClient) SaltpackEncrypt(ctx context.Context, __arg SaltpackEncryptArg) (res SaltpackEncryptResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncrypt", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncrypt", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackDecrypt(ctx context.Context, __arg SaltpackDecryptArg) (res SaltpackEncryptedMessageInfo, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackDecrypt", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackDecrypt", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackSign(ctx context.Context, __arg SaltpackSignArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSign", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSign", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackVerify(ctx context.Context, __arg SaltpackVerifyArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackVerify", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackVerify", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackEncryptString(ctx context.Context, __arg SaltpackEncryptStringArg) (res SaltpackEncryptStringResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncryptString", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncryptString", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackEncryptStringToTextFile(ctx context.Context, __arg SaltpackEncryptStringToTextFileArg) (res SaltpackEncryptFileResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncryptStringToTextFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncryptStringToTextFile", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackEncryptFile(ctx context.Context, __arg SaltpackEncryptFileArg) (res SaltpackEncryptFileResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncryptFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncryptFile", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackDecryptString(ctx context.Context, __arg SaltpackDecryptStringArg) (res SaltpackPlaintextResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackDecryptString", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackDecryptString", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackDecryptFile(ctx context.Context, __arg SaltpackDecryptFileArg) (res SaltpackFileResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackDecryptFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackDecryptFile", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackSignString(ctx context.Context, __arg SaltpackSignStringArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSignString", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSignString", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackSignStringToTextFile(ctx context.Context, __arg SaltpackSignStringToTextFileArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSignStringToTextFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSignStringToTextFile", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackSignFile(ctx context.Context, __arg SaltpackSignFileArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSignFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSignFile", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackSaveCiphertextToFile(ctx context.Context, __arg SaltpackSaveCiphertextToFileArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSaveCiphertextToFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSaveCiphertextToFile", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackSaveSignedMsgToFile(ctx context.Context, __arg SaltpackSaveSignedMsgToFileArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSaveSignedMsgToFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSaveSignedMsgToFile", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackVerifyString(ctx context.Context, __arg SaltpackVerifyStringArg) (res SaltpackVerifyResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackVerifyString", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackVerifyString", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackClient) SaltpackVerifyFile(ctx context.Context, __arg SaltpackVerifyFileArg) (res SaltpackVerifyFileResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackVerifyFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackVerifyFile", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/saltpack_ui.go
+++ b/go/protocol/keybase1/saltpack_ui.go
@@ -101,11 +101,11 @@ func SaltpackUiProtocol(i SaltpackUiInterface) rpc.Protocol {
 		Name: "keybase.1.saltpackUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"saltpackPromptForDecrypt": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackPromptForDecryptArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackPromptForDecryptArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackPromptForDecryptArg)(nil), args)
@@ -116,11 +116,11 @@ func SaltpackUiProtocol(i SaltpackUiInterface) rpc.Protocol {
 				},
 			},
 			"saltpackVerifySuccess": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackVerifySuccessArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackVerifySuccessArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackVerifySuccessArg)(nil), args)
@@ -131,11 +131,11 @@ func SaltpackUiProtocol(i SaltpackUiInterface) rpc.Protocol {
 				},
 			},
 			"saltpackVerifyBadSender": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SaltpackVerifyBadSenderArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SaltpackVerifyBadSenderArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SaltpackVerifyBadSenderArg)(nil), args)
@@ -154,16 +154,16 @@ type SaltpackUiClient struct {
 }
 
 func (c SaltpackUiClient) SaltpackPromptForDecrypt(ctx context.Context, __arg SaltpackPromptForDecryptArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpackUi.saltpackPromptForDecrypt", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpackUi.saltpackPromptForDecrypt", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackUiClient) SaltpackVerifySuccess(ctx context.Context, __arg SaltpackVerifySuccessArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpackUi.saltpackVerifySuccess", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpackUi.saltpackVerifySuccess", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SaltpackUiClient) SaltpackVerifyBadSender(ctx context.Context, __arg SaltpackVerifyBadSenderArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpackUi.saltpackVerifyBadSender", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.saltpackUi.saltpackVerifyBadSender", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/scanproofs.go
+++ b/go/protocol/keybase1/scanproofs.go
@@ -28,11 +28,11 @@ func ScanProofsProtocol(i ScanProofsInterface) rpc.Protocol {
 		Name: "keybase.1.ScanProofs",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"scanProofs": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ScanProofsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ScanProofsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ScanProofsArg)(nil), args)
@@ -51,6 +51,6 @@ type ScanProofsClient struct {
 }
 
 func (c ScanProofsClient) ScanProofs(ctx context.Context, __arg ScanProofsArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.ScanProofs.scanProofs", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ScanProofs.scanProofs", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/secret_ui.go
+++ b/go/protocol/keybase1/secret_ui.go
@@ -60,11 +60,11 @@ func SecretUiProtocol(i SecretUiInterface) rpc.Protocol {
 		Name: "keybase.1.secretUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getPassphrase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPassphraseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPassphraseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPassphraseArg)(nil), args)
@@ -83,6 +83,6 @@ type SecretUiClient struct {
 }
 
 func (c SecretUiClient) GetPassphrase(ctx context.Context, __arg GetPassphraseArg) (res GetPassphraseRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.secretUi.getPassphrase", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.secretUi.getPassphrase", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/secretkeys.go
+++ b/go/protocol/keybase1/secretkeys.go
@@ -66,11 +66,11 @@ func SecretKeysProtocol(i SecretKeysInterface) rpc.Protocol {
 		Name: "keybase.1.SecretKeys",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getSecretKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetSecretKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetSecretKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetSecretKeysArg)(nil), args)
@@ -90,6 +90,6 @@ type SecretKeysClient struct {
 
 func (c SecretKeysClient) GetSecretKeys(ctx context.Context, sessionID int) (res SecretKeys, err error) {
 	__arg := GetSecretKeysArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.SecretKeys.getSecretKeys", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SecretKeys.getSecretKeys", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/selfprovision.go
+++ b/go/protocol/keybase1/selfprovision.go
@@ -25,11 +25,11 @@ func SelfprovisionProtocol(i SelfprovisionInterface) rpc.Protocol {
 		Name: "keybase.1.selfprovision",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"selfProvision": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SelfProvisionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SelfProvisionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SelfProvisionArg)(nil), args)
@@ -50,6 +50,6 @@ type SelfprovisionClient struct {
 // Performs self provision. If the current device is clone, this function
 // will provision it as a new device.
 func (c SelfprovisionClient) SelfProvision(ctx context.Context, __arg SelfProvisionArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.selfprovision.selfProvision", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.selfprovision.selfProvision", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/session.go
+++ b/go/protocol/keybase1/session.go
@@ -44,11 +44,11 @@ func SessionProtocol(i SessionInterface) rpc.Protocol {
 		Name: "keybase.1.session",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"currentSession": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CurrentSessionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CurrentSessionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CurrentSessionArg)(nil), args)
@@ -59,11 +59,11 @@ func SessionProtocol(i SessionInterface) rpc.Protocol {
 				},
 			},
 			"sessionPing": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SessionPingArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.SessionPing(ctx)
 					return
 				},
@@ -78,11 +78,11 @@ type SessionClient struct {
 
 func (c SessionClient) CurrentSession(ctx context.Context, sessionID int) (res Session, err error) {
 	__arg := CurrentSessionArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.session.currentSession", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.session.currentSession", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SessionClient) SessionPing(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.session.sessionPing", []interface{}{SessionPingArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.session.sessionPing", []any{SessionPingArg{}}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/signup.go
+++ b/go/protocol/keybase1/signup.go
@@ -77,11 +77,11 @@ func SignupProtocol(i SignupInterface) rpc.Protocol {
 		Name: "keybase.1.signup",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"checkUsernameAvailable": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CheckUsernameAvailableArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CheckUsernameAvailableArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CheckUsernameAvailableArg)(nil), args)
@@ -92,11 +92,11 @@ func SignupProtocol(i SignupInterface) rpc.Protocol {
 				},
 			},
 			"signup": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SignupArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SignupArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SignupArg)(nil), args)
@@ -107,11 +107,11 @@ func SignupProtocol(i SignupInterface) rpc.Protocol {
 				},
 			},
 			"inviteRequest": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]InviteRequestArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]InviteRequestArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]InviteRequestArg)(nil), args)
@@ -122,11 +122,11 @@ func SignupProtocol(i SignupInterface) rpc.Protocol {
 				},
 			},
 			"checkInvitationCode": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CheckInvitationCodeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CheckInvitationCodeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CheckInvitationCodeArg)(nil), args)
@@ -137,11 +137,11 @@ func SignupProtocol(i SignupInterface) rpc.Protocol {
 				},
 			},
 			"getInvitationCode": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetInvitationCodeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetInvitationCodeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetInvitationCodeArg)(nil), args)
@@ -160,27 +160,27 @@ type SignupClient struct {
 }
 
 func (c SignupClient) CheckUsernameAvailable(ctx context.Context, __arg CheckUsernameAvailableArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.signup.checkUsernameAvailable", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.signup.checkUsernameAvailable", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SignupClient) Signup(ctx context.Context, __arg SignupArg) (res SignupRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.signup.signup", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.signup.signup", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SignupClient) InviteRequest(ctx context.Context, __arg InviteRequestArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.signup.inviteRequest", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.signup.inviteRequest", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SignupClient) CheckInvitationCode(ctx context.Context, __arg CheckInvitationCodeArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.signup.checkInvitationCode", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.signup.checkInvitationCode", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SignupClient) GetInvitationCode(ctx context.Context, sessionID int) (res string, err error) {
 	__arg := GetInvitationCodeArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.signup.getInvitationCode", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.signup.getInvitationCode", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/sigs.go
+++ b/go/protocol/keybase1/sigs.go
@@ -99,11 +99,11 @@ func SigsProtocol(i SigsInterface) rpc.Protocol {
 		Name: "keybase.1.sigs",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"sigList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SigListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SigListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SigListArg)(nil), args)
@@ -114,11 +114,11 @@ func SigsProtocol(i SigsInterface) rpc.Protocol {
 				},
 			},
 			"sigListJSON": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SigListJSONArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SigListJSONArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SigListJSONArg)(nil), args)
@@ -137,11 +137,11 @@ type SigsClient struct {
 }
 
 func (c SigsClient) SigList(ctx context.Context, __arg SigListArg) (res []Sig, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.sigs.sigList", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.sigs.sigList", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SigsClient) SigListJSON(ctx context.Context, __arg SigListJSONArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.sigs.sigListJSON", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.sigs.sigListJSON", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -2131,11 +2131,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 		Name: "keybase.1.SimpleFS",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"simpleFSList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSListArg)(nil), args)
@@ -2146,11 +2146,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSListRecursive": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSListRecursiveArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSListRecursiveArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSListRecursiveArg)(nil), args)
@@ -2161,11 +2161,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSListRecursiveToDepth": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSListRecursiveToDepthArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSListRecursiveToDepthArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSListRecursiveToDepthArg)(nil), args)
@@ -2176,11 +2176,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSReadList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSReadListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSReadListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSReadListArg)(nil), args)
@@ -2191,11 +2191,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSCopy": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSCopyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSCopyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSCopyArg)(nil), args)
@@ -2206,11 +2206,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSSymlink": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSymlinkArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSymlinkArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSymlinkArg)(nil), args)
@@ -2221,11 +2221,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSCopyRecursive": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSCopyRecursiveArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSCopyRecursiveArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSCopyRecursiveArg)(nil), args)
@@ -2236,11 +2236,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSMove": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSMoveArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSMoveArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSMoveArg)(nil), args)
@@ -2251,11 +2251,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSRename": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSRenameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSRenameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSRenameArg)(nil), args)
@@ -2266,11 +2266,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSOpen": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSOpenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSOpenArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSOpenArg)(nil), args)
@@ -2281,11 +2281,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSSetStat": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSetStatArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSetStatArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSetStatArg)(nil), args)
@@ -2296,11 +2296,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSRead": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSReadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSReadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSReadArg)(nil), args)
@@ -2311,11 +2311,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSWrite": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSWriteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSWriteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSWriteArg)(nil), args)
@@ -2326,11 +2326,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSRemove": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSRemoveArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSRemoveArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSRemoveArg)(nil), args)
@@ -2341,11 +2341,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSStat": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSStatArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSStatArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSStatArg)(nil), args)
@@ -2356,11 +2356,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSGetRevisions": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetRevisionsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSGetRevisionsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSGetRevisionsArg)(nil), args)
@@ -2371,11 +2371,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSReadRevisions": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSReadRevisionsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSReadRevisionsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSReadRevisionsArg)(nil), args)
@@ -2386,21 +2386,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSMakeOpid": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSMakeOpidArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSMakeOpid(ctx)
 					return
 				},
 			},
 			"simpleFSClose": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSCloseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSCloseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSCloseArg)(nil), args)
@@ -2411,11 +2411,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSCancel": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSCancelArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSCancelArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSCancelArg)(nil), args)
@@ -2426,11 +2426,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSCheck": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSCheckArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSCheckArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSCheckArg)(nil), args)
@@ -2441,21 +2441,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSGetOps": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetOpsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSGetOps(ctx)
 					return
 				},
 			},
 			"simpleFSWait": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSWaitArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSWaitArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSWaitArg)(nil), args)
@@ -2466,21 +2466,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSDumpDebuggingInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSDumpDebuggingInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.SimpleFSDumpDebuggingInfo(ctx)
 					return
 				},
 			},
 			"simpleFSClearConflictState": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSClearConflictStateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSClearConflictStateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSClearConflictStateArg)(nil), args)
@@ -2491,11 +2491,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSFinishResolvingConflict": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSFinishResolvingConflictArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSFinishResolvingConflictArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSFinishResolvingConflictArg)(nil), args)
@@ -2506,11 +2506,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSForceStuckConflict": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSForceStuckConflictArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSForceStuckConflictArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSForceStuckConflictArg)(nil), args)
@@ -2521,11 +2521,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSSyncStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSyncStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSyncStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSyncStatusArg)(nil), args)
@@ -2536,21 +2536,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSUserEditHistory": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSUserEditHistoryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSUserEditHistory(ctx)
 					return
 				},
 			},
 			"simpleFSFolderEditHistory": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSFolderEditHistoryArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSFolderEditHistoryArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSFolderEditHistoryArg)(nil), args)
@@ -2561,31 +2561,31 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSListFavorites": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSListFavoritesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSListFavorites(ctx)
 					return
 				},
 			},
 			"simpleFSGetUserQuotaUsage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetUserQuotaUsageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSGetUserQuotaUsage(ctx)
 					return
 				},
 			},
 			"simpleFSGetTeamQuotaUsage": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetTeamQuotaUsageArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSGetTeamQuotaUsageArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSGetTeamQuotaUsageArg)(nil), args)
@@ -2596,11 +2596,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSReset": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSResetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSResetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSResetArg)(nil), args)
@@ -2611,11 +2611,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSFolderSyncConfigAndStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSFolderSyncConfigAndStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSFolderSyncConfigAndStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSFolderSyncConfigAndStatusArg)(nil), args)
@@ -2626,11 +2626,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSSetFolderSyncConfig": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSetFolderSyncConfigArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSetFolderSyncConfigArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSetFolderSyncConfigArg)(nil), args)
@@ -2641,11 +2641,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSSyncConfigAndStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSyncConfigAndStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSyncConfigAndStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSyncConfigAndStatusArg)(nil), args)
@@ -2656,11 +2656,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSGetFolder": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetFolderArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSGetFolderArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSGetFolderArg)(nil), args)
@@ -2671,11 +2671,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSGetOnlineStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetOnlineStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSGetOnlineStatusArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSGetOnlineStatusArg)(nil), args)
@@ -2686,21 +2686,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSCheckReachability": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSCheckReachabilityArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.SimpleFSCheckReachability(ctx)
 					return
 				},
 			},
 			"simpleFSSetDebugLevel": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSetDebugLevelArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSetDebugLevelArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSetDebugLevelArg)(nil), args)
@@ -2711,21 +2711,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSSettings(ctx)
 					return
 				},
 			},
 			"simpleFSSetNotificationThreshold": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSetNotificationThresholdArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSetNotificationThresholdArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSetNotificationThresholdArg)(nil), args)
@@ -2736,11 +2736,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSSetSfmiBannerDismissed": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSetSfmiBannerDismissedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSetSfmiBannerDismissedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSetSfmiBannerDismissedArg)(nil), args)
@@ -2751,11 +2751,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSSetSyncOnCellular": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSetSyncOnCellularArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSetSyncOnCellularArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSetSyncOnCellularArg)(nil), args)
@@ -2766,11 +2766,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSObfuscatePath": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSObfuscatePathArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSObfuscatePathArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSObfuscatePathArg)(nil), args)
@@ -2781,11 +2781,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSDeobfuscatePath": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSDeobfuscatePathArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSDeobfuscatePathArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSDeobfuscatePathArg)(nil), args)
@@ -2796,21 +2796,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSGetStats": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetStatsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSGetStats(ctx)
 					return
 				},
 			},
 			"simpleFSSubscribePath": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSubscribePathArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSubscribePathArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSubscribePathArg)(nil), args)
@@ -2821,11 +2821,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSSubscribeNonPath": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSubscribeNonPathArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSubscribeNonPathArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSubscribeNonPathArg)(nil), args)
@@ -2836,11 +2836,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSUnsubscribe": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSUnsubscribeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSUnsubscribeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSUnsubscribeArg)(nil), args)
@@ -2851,11 +2851,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSStartDownload": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSStartDownloadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSStartDownloadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSStartDownloadArg)(nil), args)
@@ -2866,11 +2866,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSGetDownloadInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetDownloadInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSGetDownloadInfoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSGetDownloadInfoArg)(nil), args)
@@ -2881,21 +2881,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSGetDownloadStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetDownloadStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSGetDownloadStatus(ctx)
 					return
 				},
 			},
 			"simpleFSCancelDownload": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSCancelDownloadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSCancelDownloadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSCancelDownloadArg)(nil), args)
@@ -2906,11 +2906,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSDismissDownload": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSDismissDownloadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSDismissDownloadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSDismissDownloadArg)(nil), args)
@@ -2921,11 +2921,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSConfigureDownload": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSConfigureDownloadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSConfigureDownloadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSConfigureDownloadArg)(nil), args)
@@ -2936,21 +2936,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSMakeTempDirForUpload": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSMakeTempDirForUploadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSMakeTempDirForUpload(ctx)
 					return
 				},
 			},
 			"simpleFSStartUpload": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSStartUploadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSStartUploadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSStartUploadArg)(nil), args)
@@ -2961,21 +2961,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSGetUploadStatus": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetUploadStatusArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSGetUploadStatus(ctx)
 					return
 				},
 			},
 			"simpleFSCancelUpload": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSCancelUploadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSCancelUploadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSCancelUploadArg)(nil), args)
@@ -2986,11 +2986,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSDismissUpload": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSDismissUploadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSDismissUploadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSDismissUploadArg)(nil), args)
@@ -3001,21 +3001,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSGetFilesTabBadge": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetFilesTabBadgeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSGetFilesTabBadge(ctx)
 					return
 				},
 			},
 			"simpleFSGetGUIFileContext": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetGUIFileContextArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSGetGUIFileContextArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSGetGUIFileContextArg)(nil), args)
@@ -3026,11 +3026,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSUserIn": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSUserInArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSUserInArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSUserInArg)(nil), args)
@@ -3041,11 +3041,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSUserOut": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSUserOutArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSUserOutArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSUserOutArg)(nil), args)
@@ -3056,11 +3056,11 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSSearchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSSearchArg)(nil), args)
@@ -3071,31 +3071,31 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 			},
 			"simpleFSResetIndex": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSResetIndexArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.SimpleFSResetIndex(ctx)
 					return
 				},
 			},
 			"simpleFSGetIndexProgress": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSGetIndexProgressArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.SimpleFSGetIndexProgress(ctx)
 					return
 				},
 			},
 			"simpleFSCancelJournalUploads": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SimpleFSCancelJournalUploadsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SimpleFSCancelJournalUploadsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SimpleFSCancelJournalUploadsArg)(nil), args)
@@ -3121,7 +3121,7 @@ type SimpleFSClient struct {
 // corresponding TLF, until another call refreshes the subscription on a
 // different TLF.
 func (c SimpleFSClient) SimpleFSList(ctx context.Context, __arg SimpleFSListArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSList", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSList", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -3131,13 +3131,13 @@ func (c SimpleFSClient) SimpleFSList(ctx context.Context, __arg SimpleFSListArg)
 // corresponding TLF, until another call refreshes the subscription on a
 // different TLF.
 func (c SimpleFSClient) SimpleFSListRecursive(ctx context.Context, __arg SimpleFSListRecursiveArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSListRecursive", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSListRecursive", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Begin recursive list of items in directory at path up to a given depth
 func (c SimpleFSClient) SimpleFSListRecursiveToDepth(ctx context.Context, __arg SimpleFSListRecursiveToDepthArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSListRecursiveToDepth", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSListRecursiveToDepth", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -3145,19 +3145,19 @@ func (c SimpleFSClient) SimpleFSListRecursiveToDepth(ctx context.Context, __arg 
 // to get more entries.
 func (c SimpleFSClient) SimpleFSReadList(ctx context.Context, opID OpID) (res SimpleFSListResult, err error) {
 	__arg := SimpleFSReadListArg{OpID: opID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSReadList", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSReadList", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Begin copy of file or directory.
 func (c SimpleFSClient) SimpleFSCopy(ctx context.Context, __arg SimpleFSCopyArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCopy", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCopy", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Make a symlink of file or directory
 func (c SimpleFSClient) SimpleFSSymlink(ctx context.Context, __arg SimpleFSSymlinkArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSymlink", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSymlink", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -3168,19 +3168,19 @@ func (c SimpleFSClient) SimpleFSSymlink(ctx context.Context, __arg SimpleFSSymli
 // returned in that case.  For directories that share a name, the copy will
 // continue recursively into the directory without causing an error.
 func (c SimpleFSClient) SimpleFSCopyRecursive(ctx context.Context, __arg SimpleFSCopyRecursiveArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCopyRecursive", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCopyRecursive", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Begin move of file or directory, from/to KBFS only
 func (c SimpleFSClient) SimpleFSMove(ctx context.Context, __arg SimpleFSMoveArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSMove", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSMove", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Rename file or directory, KBFS side only
 func (c SimpleFSClient) SimpleFSRename(ctx context.Context, __arg SimpleFSRenameArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSRename", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSRename", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -3188,13 +3188,13 @@ func (c SimpleFSClient) SimpleFSRename(ctx context.Context, __arg SimpleFSRename
 // or create a directory
 // Files must be closed afterwards.
 func (c SimpleFSClient) SimpleFSOpen(ctx context.Context, __arg SimpleFSOpenArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSOpen", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSOpen", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Set/clear file bits - only executable for now
 func (c SimpleFSClient) SimpleFSSetStat(ctx context.Context, __arg SimpleFSSetStatArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetStat", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetStat", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -3203,32 +3203,32 @@ func (c SimpleFSClient) SimpleFSSetStat(ctx context.Context, __arg SimpleFSSetSt
 // Repeat until zero bytes are returned or error.
 // If size is zero, read an arbitrary amount.
 func (c SimpleFSClient) SimpleFSRead(ctx context.Context, __arg SimpleFSReadArg) (res FileContent, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSRead", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSRead", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Append content to opened file.
 // May be repeated until OpID is closed.
 func (c SimpleFSClient) SimpleFSWrite(ctx context.Context, __arg SimpleFSWriteArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSWrite", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSWrite", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Remove file or directory from filesystem
 func (c SimpleFSClient) SimpleFSRemove(ctx context.Context, __arg SimpleFSRemoveArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSRemove", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSRemove", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Get info about file
 func (c SimpleFSClient) SimpleFSStat(ctx context.Context, __arg SimpleFSStatArg) (res Dirent, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSStat", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSStat", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Get revision info for a directory entry
 func (c SimpleFSClient) SimpleFSGetRevisions(ctx context.Context, __arg SimpleFSGetRevisionsArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetRevisions", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetRevisions", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -3236,13 +3236,13 @@ func (c SimpleFSClient) SimpleFSGetRevisions(ctx context.Context, __arg SimpleFS
 // to get more revisions.
 func (c SimpleFSClient) SimpleFSReadRevisions(ctx context.Context, opID OpID) (res GetRevisionsResult, err error) {
 	__arg := SimpleFSReadRevisionsArg{OpID: opID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSReadRevisions", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSReadRevisions", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Convenience helper for generating new random value
 func (c SimpleFSClient) SimpleFSMakeOpid(ctx context.Context) (res OpID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSMakeOpid", []interface{}{SimpleFSMakeOpidArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSMakeOpid", []any{SimpleFSMakeOpidArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -3250,66 +3250,66 @@ func (c SimpleFSClient) SimpleFSMakeOpid(ctx context.Context) (res OpID, err err
 // Must be called after list/copy/remove
 func (c SimpleFSClient) SimpleFSClose(ctx context.Context, opID OpID) (err error) {
 	__arg := SimpleFSCloseArg{OpID: opID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSClose", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSClose", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Cancels a running operation, like copy.
 func (c SimpleFSClient) SimpleFSCancel(ctx context.Context, opID OpID) (err error) {
 	__arg := SimpleFSCancelArg{OpID: opID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancel", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancel", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Check progress of pending operation
 func (c SimpleFSClient) SimpleFSCheck(ctx context.Context, opID OpID) (res OpProgress, err error) {
 	__arg := SimpleFSCheckArg{OpID: opID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCheck", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCheck", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Get all the outstanding operations
 func (c SimpleFSClient) SimpleFSGetOps(ctx context.Context) (res []OpDescription, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetOps", []interface{}{SimpleFSGetOpsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetOps", []any{SimpleFSGetOpsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 // Blocking wait for the pending operation to finish
 func (c SimpleFSClient) SimpleFSWait(ctx context.Context, opID OpID) (err error) {
 	__arg := SimpleFSWaitArg{OpID: opID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSWait", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSWait", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Instructs KBFS to dump debugging info into its logs.
 func (c SimpleFSClient) SimpleFSDumpDebuggingInfo(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDumpDebuggingInfo", []interface{}{SimpleFSDumpDebuggingInfoArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDumpDebuggingInfo", []any{SimpleFSDumpDebuggingInfoArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSClearConflictState(ctx context.Context, path Path) (err error) {
 	__arg := SimpleFSClearConflictStateArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSClearConflictState", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSClearConflictState", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSFinishResolvingConflict(ctx context.Context, path Path) (err error) {
 	__arg := SimpleFSFinishResolvingConflictArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSFinishResolvingConflict", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSFinishResolvingConflict", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Force a TLF into a stuck conflict state (for testing).
 func (c SimpleFSClient) SimpleFSForceStuckConflict(ctx context.Context, path Path) (err error) {
 	__arg := SimpleFSForceStuckConflictArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSForceStuckConflict", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSForceStuckConflict", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Get sync status.
 func (c SimpleFSClient) SimpleFSSyncStatus(ctx context.Context, filter ListFilter) (res FSSyncStatus, err error) {
 	__arg := SimpleFSSyncStatusArg{Filter: filter}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSyncStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSyncStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -3318,7 +3318,7 @@ func (c SimpleFSClient) SimpleFSSyncStatus(ctx context.Context, filter ListFilte
 // writer-TLF pair.  They are in descending order by the modification time
 // (as recorded by the server) of the most recent edit in each history.
 func (c SimpleFSClient) SimpleFSUserEditHistory(ctx context.Context) (res []FSFolderEditHistory, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSUserEditHistory", []interface{}{SimpleFSUserEditHistoryArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSUserEditHistory", []any{SimpleFSUserEditHistoryArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -3328,21 +3328,21 @@ func (c SimpleFSClient) SimpleFSUserEditHistory(ctx context.Context) (res []FSFo
 // recorded by the server) of their most recent edit.
 func (c SimpleFSClient) SimpleFSFolderEditHistory(ctx context.Context, path Path) (res FSFolderEditHistory, err error) {
 	__arg := SimpleFSFolderEditHistoryArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSFolderEditHistory", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSFolderEditHistory", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // simpleFSListFavorites gets the current favorites, ignored folders, and new
 // folders from the KBFS cache.
 func (c SimpleFSClient) SimpleFSListFavorites(ctx context.Context) (res FavoritesResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSListFavorites", []interface{}{SimpleFSListFavoritesArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSListFavorites", []any{SimpleFSListFavoritesArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 // simpleFSGetUserQuotaUsage returns the quota usage for the logged-in
 // user.  Any usage includes local journal usage as well.
 func (c SimpleFSClient) SimpleFSGetUserQuotaUsage(ctx context.Context) (res SimpleFSQuotaUsage, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetUserQuotaUsage", []interface{}{SimpleFSGetUserQuotaUsageArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetUserQuotaUsage", []any{SimpleFSGetUserQuotaUsageArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -3351,212 +3351,212 @@ func (c SimpleFSClient) SimpleFSGetUserQuotaUsage(ctx context.Context) (res Simp
 // local journal usage as well.
 func (c SimpleFSClient) SimpleFSGetTeamQuotaUsage(ctx context.Context, teamName TeamName) (res SimpleFSQuotaUsage, err error) {
 	__arg := SimpleFSGetTeamQuotaUsageArg{TeamName: teamName}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetTeamQuotaUsage", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetTeamQuotaUsage", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // simpleFSReset completely resets the KBFS folder referenced in `path`.
 // It should only be called after explicit user confirmation.
 func (c SimpleFSClient) SimpleFSReset(ctx context.Context, __arg SimpleFSResetArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSReset", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSReset", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSFolderSyncConfigAndStatus(ctx context.Context, path Path) (res FolderSyncConfigAndStatus, err error) {
 	__arg := SimpleFSFolderSyncConfigAndStatusArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSFolderSyncConfigAndStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSFolderSyncConfigAndStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSSetFolderSyncConfig(ctx context.Context, __arg SimpleFSSetFolderSyncConfigArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetFolderSyncConfig", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetFolderSyncConfig", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSSyncConfigAndStatus(ctx context.Context, identifyBehavior *TLFIdentifyBehavior) (res SyncConfigAndStatusRes, err error) {
 	__arg := SimpleFSSyncConfigAndStatusArg{IdentifyBehavior: identifyBehavior}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSyncConfigAndStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSyncConfigAndStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSGetFolder(ctx context.Context, path KBFSPath) (res FolderWithFavFlags, err error) {
 	__arg := SimpleFSGetFolderArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetFolder", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetFolder", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSGetOnlineStatus(ctx context.Context, clientID string) (res KbfsOnlineStatus, err error) {
 	__arg := SimpleFSGetOnlineStatusArg{ClientID: clientID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetOnlineStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetOnlineStatus", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSCheckReachability(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCheckReachability", []interface{}{SimpleFSCheckReachabilityArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCheckReachability", []any{SimpleFSCheckReachabilityArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSSetDebugLevel(ctx context.Context, level string) (err error) {
 	__arg := SimpleFSSetDebugLevelArg{Level: level}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetDebugLevel", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetDebugLevel", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSSettings(ctx context.Context) (res FSSettings, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSettings", []interface{}{SimpleFSSettingsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSettings", []any{SimpleFSSettingsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSSetNotificationThreshold(ctx context.Context, threshold int64) (err error) {
 	__arg := SimpleFSSetNotificationThresholdArg{Threshold: threshold}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetNotificationThreshold", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetNotificationThreshold", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSSetSfmiBannerDismissed(ctx context.Context, dismissed bool) (err error) {
 	__arg := SimpleFSSetSfmiBannerDismissedArg{Dismissed: dismissed}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetSfmiBannerDismissed", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetSfmiBannerDismissed", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSSetSyncOnCellular(ctx context.Context, syncOnCellular bool) (err error) {
 	__arg := SimpleFSSetSyncOnCellularArg{SyncOnCellular: syncOnCellular}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetSyncOnCellular", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetSyncOnCellular", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSObfuscatePath(ctx context.Context, path Path) (res string, err error) {
 	__arg := SimpleFSObfuscatePathArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSObfuscatePath", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSObfuscatePath", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSDeobfuscatePath(ctx context.Context, path Path) (res []string, err error) {
 	__arg := SimpleFSDeobfuscatePathArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDeobfuscatePath", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDeobfuscatePath", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSGetStats(ctx context.Context) (res SimpleFSStats, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetStats", []interface{}{SimpleFSGetStatsArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetStats", []any{SimpleFSGetStatsArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSSubscribePath(ctx context.Context, __arg SimpleFSSubscribePathArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSubscribePath", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSubscribePath", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSSubscribeNonPath(ctx context.Context, __arg SimpleFSSubscribeNonPathArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSubscribeNonPath", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSubscribeNonPath", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSUnsubscribe(ctx context.Context, __arg SimpleFSUnsubscribeArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSUnsubscribe", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSUnsubscribe", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSStartDownload(ctx context.Context, __arg SimpleFSStartDownloadArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSStartDownload", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSStartDownload", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSGetDownloadInfo(ctx context.Context, downloadID string) (res DownloadInfo, err error) {
 	__arg := SimpleFSGetDownloadInfoArg{DownloadID: downloadID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetDownloadInfo", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetDownloadInfo", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSGetDownloadStatus(ctx context.Context) (res DownloadStatus, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetDownloadStatus", []interface{}{SimpleFSGetDownloadStatusArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetDownloadStatus", []any{SimpleFSGetDownloadStatusArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSCancelDownload(ctx context.Context, downloadID string) (err error) {
 	__arg := SimpleFSCancelDownloadArg{DownloadID: downloadID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancelDownload", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancelDownload", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSDismissDownload(ctx context.Context, downloadID string) (err error) {
 	__arg := SimpleFSDismissDownloadArg{DownloadID: downloadID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDismissDownload", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDismissDownload", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSConfigureDownload(ctx context.Context, __arg SimpleFSConfigureDownloadArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSConfigureDownload", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSConfigureDownload", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSMakeTempDirForUpload(ctx context.Context) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSMakeTempDirForUpload", []interface{}{SimpleFSMakeTempDirForUploadArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSMakeTempDirForUpload", []any{SimpleFSMakeTempDirForUploadArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSStartUpload(ctx context.Context, __arg SimpleFSStartUploadArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSStartUpload", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSStartUpload", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSGetUploadStatus(ctx context.Context) (res []UploadState, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetUploadStatus", []interface{}{SimpleFSGetUploadStatusArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetUploadStatus", []any{SimpleFSGetUploadStatusArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSCancelUpload(ctx context.Context, uploadID string) (err error) {
 	__arg := SimpleFSCancelUploadArg{UploadID: uploadID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancelUpload", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancelUpload", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSDismissUpload(ctx context.Context, uploadID string) (err error) {
 	__arg := SimpleFSDismissUploadArg{UploadID: uploadID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDismissUpload", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDismissUpload", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSGetFilesTabBadge(ctx context.Context) (res FilesTabBadge, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetFilesTabBadge", []interface{}{SimpleFSGetFilesTabBadgeArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetFilesTabBadge", []any{SimpleFSGetFilesTabBadgeArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSGetGUIFileContext(ctx context.Context, path KBFSPath) (res GUIFileContext, err error) {
 	__arg := SimpleFSGetGUIFileContextArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetGUIFileContext", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetGUIFileContext", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSUserIn(ctx context.Context, clientID string) (err error) {
 	__arg := SimpleFSUserInArg{ClientID: clientID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSUserIn", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSUserIn", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSUserOut(ctx context.Context, clientID string) (err error) {
 	__arg := SimpleFSUserOutArg{ClientID: clientID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSUserOut", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSUserOut", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSSearch(ctx context.Context, __arg SimpleFSSearchArg) (res SimpleFSSearchResults, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSearch", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSearch", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSResetIndex(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSResetIndex", []interface{}{SimpleFSResetIndexArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSResetIndex", []any{SimpleFSResetIndexArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSGetIndexProgress(ctx context.Context) (res SimpleFSIndexProgress, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetIndexProgress", []interface{}{SimpleFSGetIndexProgressArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetIndexProgress", []any{SimpleFSGetIndexProgressArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c SimpleFSClient) SimpleFSCancelJournalUploads(ctx context.Context, path KBFSPath) (err error) {
 	__arg := SimpleFSCancelJournalUploadsArg{Path: path}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancelJournalUploads", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancelJournalUploads", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/stream_ui.go
+++ b/go/protocol/keybase1/stream_ui.go
@@ -43,11 +43,11 @@ func StreamUiProtocol(i StreamUiInterface) rpc.Protocol {
 		Name: "keybase.1.streamUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"close": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CloseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CloseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CloseArg)(nil), args)
@@ -58,11 +58,11 @@ func StreamUiProtocol(i StreamUiInterface) rpc.Protocol {
 				},
 			},
 			"read": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ReadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ReadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ReadArg)(nil), args)
@@ -73,11 +73,11 @@ func StreamUiProtocol(i StreamUiInterface) rpc.Protocol {
 				},
 			},
 			"reset": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ResetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ResetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ResetArg)(nil), args)
@@ -88,11 +88,11 @@ func StreamUiProtocol(i StreamUiInterface) rpc.Protocol {
 				},
 			},
 			"write": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WriteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]WriteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]WriteArg)(nil), args)
@@ -111,21 +111,21 @@ type StreamUiClient struct {
 }
 
 func (c StreamUiClient) Close(ctx context.Context, __arg CloseArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.streamUi.close", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.streamUi.close", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c StreamUiClient) Read(ctx context.Context, __arg ReadArg) (res []byte, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.streamUi.read", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.streamUi.read", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c StreamUiClient) Reset(ctx context.Context, __arg ResetArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.streamUi.reset", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.streamUi.reset", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c StreamUiClient) Write(ctx context.Context, __arg WriteArg) (res int, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.streamUi.write", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.streamUi.write", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -5030,11 +5030,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 		Name: "keybase.1.teams",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getUntrustedTeamInfo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUntrustedTeamInfoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetUntrustedTeamInfoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetUntrustedTeamInfoArg)(nil), args)
@@ -5045,11 +5045,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamCreate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamCreateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamCreateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamCreateArg)(nil), args)
@@ -5060,11 +5060,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamCreateWithSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamCreateWithSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamCreateWithSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamCreateWithSettingsArg)(nil), args)
@@ -5075,11 +5075,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamCreateFancy": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamCreateFancyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamCreateFancyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamCreateFancyArg)(nil), args)
@@ -5090,11 +5090,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamGetByID": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamGetByIDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamGetByIDArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamGetByIDArg)(nil), args)
@@ -5105,11 +5105,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamGet": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamGetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamGetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamGetArg)(nil), args)
@@ -5120,11 +5120,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamGetMembersByID": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamGetMembersByIDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamGetMembersByIDArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamGetMembersByIDArg)(nil), args)
@@ -5135,11 +5135,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamListUnverified": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamListUnverifiedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamListUnverifiedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamListUnverifiedArg)(nil), args)
@@ -5150,11 +5150,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamListTeammates": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamListTeammatesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamListTeammatesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamListTeammatesArg)(nil), args)
@@ -5165,11 +5165,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamListVerified": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamListVerifiedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamListVerifiedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamListVerifiedArg)(nil), args)
@@ -5180,11 +5180,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamListSubteamsRecursive": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamListSubteamsRecursiveArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamListSubteamsRecursiveArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamListSubteamsRecursiveArg)(nil), args)
@@ -5195,11 +5195,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamAddMember": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamAddMemberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamAddMemberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamAddMemberArg)(nil), args)
@@ -5210,11 +5210,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamAddMembers": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamAddMembersArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamAddMembersArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamAddMembersArg)(nil), args)
@@ -5225,11 +5225,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamAddMembersMultiRole": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamAddMembersMultiRoleArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamAddMembersMultiRoleArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamAddMembersMultiRoleArg)(nil), args)
@@ -5240,11 +5240,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamRemoveMember": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamRemoveMemberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamRemoveMemberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamRemoveMemberArg)(nil), args)
@@ -5255,11 +5255,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamRemoveMembers": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamRemoveMembersArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamRemoveMembersArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamRemoveMembersArg)(nil), args)
@@ -5270,11 +5270,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamLeave": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamLeaveArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamLeaveArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamLeaveArg)(nil), args)
@@ -5285,11 +5285,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamEditMember": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamEditMemberArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamEditMemberArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamEditMemberArg)(nil), args)
@@ -5300,11 +5300,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamEditMembers": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamEditMembersArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamEditMembersArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamEditMembersArg)(nil), args)
@@ -5315,11 +5315,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamGetBotSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamGetBotSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamGetBotSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamGetBotSettingsArg)(nil), args)
@@ -5330,11 +5330,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamSetBotSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamSetBotSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamSetBotSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamSetBotSettingsArg)(nil), args)
@@ -5345,11 +5345,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"untrustedTeamExists": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UntrustedTeamExistsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UntrustedTeamExistsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UntrustedTeamExistsArg)(nil), args)
@@ -5360,11 +5360,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamRename": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamRenameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamRenameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamRenameArg)(nil), args)
@@ -5375,11 +5375,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamAcceptInvite": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamAcceptInviteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamAcceptInviteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamAcceptInviteArg)(nil), args)
@@ -5390,11 +5390,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamRequestAccess": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamRequestAccessArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamRequestAccessArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamRequestAccessArg)(nil), args)
@@ -5405,11 +5405,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamAcceptInviteOrRequestAccess": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamAcceptInviteOrRequestAccessArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamAcceptInviteOrRequestAccessArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamAcceptInviteOrRequestAccessArg)(nil), args)
@@ -5420,11 +5420,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamListRequests": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamListRequestsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamListRequestsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamListRequestsArg)(nil), args)
@@ -5435,11 +5435,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamListMyAccessRequests": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamListMyAccessRequestsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamListMyAccessRequestsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamListMyAccessRequestsArg)(nil), args)
@@ -5450,11 +5450,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamIgnoreRequest": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamIgnoreRequestArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamIgnoreRequestArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamIgnoreRequestArg)(nil), args)
@@ -5465,11 +5465,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamTreeUnverified": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamTreeUnverifiedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamTreeUnverifiedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamTreeUnverifiedArg)(nil), args)
@@ -5480,11 +5480,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamGetSubteamsUnverified": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamGetSubteamsUnverifiedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamGetSubteamsUnverifiedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamGetSubteamsUnverifiedArg)(nil), args)
@@ -5495,11 +5495,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamDelete": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamDeleteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamDeleteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamDeleteArg)(nil), args)
@@ -5510,11 +5510,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamSetSettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamSetSettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamSetSettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamSetSettingsArg)(nil), args)
@@ -5525,11 +5525,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamCreateSeitanToken": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamCreateSeitanTokenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamCreateSeitanTokenArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamCreateSeitanTokenArg)(nil), args)
@@ -5540,11 +5540,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamCreateSeitanTokenV2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamCreateSeitanTokenV2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamCreateSeitanTokenV2Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamCreateSeitanTokenV2Arg)(nil), args)
@@ -5555,11 +5555,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamCreateSeitanInvitelink": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamCreateSeitanInvitelinkArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamCreateSeitanInvitelinkArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamCreateSeitanInvitelinkArg)(nil), args)
@@ -5570,11 +5570,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamCreateSeitanInvitelinkWithDuration": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamCreateSeitanInvitelinkWithDurationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamCreateSeitanInvitelinkWithDurationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamCreateSeitanInvitelinkWithDurationArg)(nil), args)
@@ -5585,11 +5585,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"getInviteLinkDetails": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetInviteLinkDetailsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetInviteLinkDetailsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetInviteLinkDetailsArg)(nil), args)
@@ -5600,11 +5600,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamAddEmailsBulk": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamAddEmailsBulkArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamAddEmailsBulkArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamAddEmailsBulkArg)(nil), args)
@@ -5615,11 +5615,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"lookupImplicitTeam": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LookupImplicitTeamArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LookupImplicitTeamArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LookupImplicitTeamArg)(nil), args)
@@ -5630,11 +5630,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"lookupOrCreateImplicitTeam": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LookupOrCreateImplicitTeamArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LookupOrCreateImplicitTeamArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LookupOrCreateImplicitTeamArg)(nil), args)
@@ -5645,11 +5645,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamReAddMemberAfterReset": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamReAddMemberAfterResetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamReAddMemberAfterResetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamReAddMemberAfterResetArg)(nil), args)
@@ -5660,11 +5660,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"loadTeamPlusApplicationKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadTeamPlusApplicationKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadTeamPlusApplicationKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadTeamPlusApplicationKeysArg)(nil), args)
@@ -5675,11 +5675,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"getTeamRootID": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamRootIDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamRootIDArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamRootIDArg)(nil), args)
@@ -5690,11 +5690,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"getTeamShowcase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamShowcaseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamShowcaseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamShowcaseArg)(nil), args)
@@ -5705,11 +5705,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"getTeamAndMemberShowcase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamAndMemberShowcaseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamAndMemberShowcaseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamAndMemberShowcaseArg)(nil), args)
@@ -5720,11 +5720,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"setTeamShowcase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetTeamShowcaseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetTeamShowcaseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetTeamShowcaseArg)(nil), args)
@@ -5735,11 +5735,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"setTeamMemberShowcase": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetTeamMemberShowcaseArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetTeamMemberShowcaseArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetTeamMemberShowcaseArg)(nil), args)
@@ -5750,11 +5750,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"canUserPerform": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CanUserPerformArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CanUserPerformArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CanUserPerformArg)(nil), args)
@@ -5765,11 +5765,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamRotateKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamRotateKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamRotateKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamRotateKeyArg)(nil), args)
@@ -5780,11 +5780,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamDebug": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamDebugArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamDebugArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamDebugArg)(nil), args)
@@ -5795,11 +5795,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"getTarsDisabled": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTarsDisabledArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTarsDisabledArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTarsDisabledArg)(nil), args)
@@ -5810,11 +5810,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"setTarsDisabled": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetTarsDisabledArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetTarsDisabledArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetTarsDisabledArg)(nil), args)
@@ -5825,11 +5825,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"teamProfileAddList": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamProfileAddListArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamProfileAddListArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamProfileAddListArg)(nil), args)
@@ -5840,11 +5840,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"uploadTeamAvatar": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UploadTeamAvatarArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UploadTeamAvatarArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UploadTeamAvatarArg)(nil), args)
@@ -5855,11 +5855,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"tryDecryptWithTeamKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TryDecryptWithTeamKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TryDecryptWithTeamKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TryDecryptWithTeamKeyArg)(nil), args)
@@ -5870,11 +5870,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"findNextMerkleRootAfterTeamRemoval": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FindNextMerkleRootAfterTeamRemovalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FindNextMerkleRootAfterTeamRemovalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FindNextMerkleRootAfterTeamRemovalArg)(nil), args)
@@ -5885,11 +5885,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"findNextMerkleRootAfterTeamRemovalBySigningKey": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FindNextMerkleRootAfterTeamRemovalBySigningKeyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FindNextMerkleRootAfterTeamRemovalBySigningKeyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FindNextMerkleRootAfterTeamRemovalBySigningKeyArg)(nil), args)
@@ -5900,11 +5900,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"profileTeamLoad": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ProfileTeamLoadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ProfileTeamLoadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ProfileTeamLoadArg)(nil), args)
@@ -5915,11 +5915,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"getTeamID": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamIDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamIDArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamIDArg)(nil), args)
@@ -5930,11 +5930,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"getTeamName": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamNameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamNameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamNameArg)(nil), args)
@@ -5945,11 +5945,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"ftl": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FtlArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FtlArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FtlArg)(nil), args)
@@ -5960,21 +5960,21 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"getTeamRoleMap": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamRoleMapArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetTeamRoleMap(ctx)
 					return
 				},
 			},
 			"getAnnotatedTeam": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetAnnotatedTeamArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetAnnotatedTeamArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetAnnotatedTeamArg)(nil), args)
@@ -5985,11 +5985,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"getAnnotatedTeamByName": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetAnnotatedTeamByNameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetAnnotatedTeamByNameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetAnnotatedTeamByNameArg)(nil), args)
@@ -6000,11 +6000,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"loadTeamTreeMembershipsAsync": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadTeamTreeMembershipsAsyncArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadTeamTreeMembershipsAsyncArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadTeamTreeMembershipsAsyncArg)(nil), args)
@@ -6015,11 +6015,11 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 			},
 			"findAssertionsInTeamNoResolve": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FindAssertionsInTeamNoResolveArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FindAssertionsInTeamNoResolveArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FindAssertionsInTeamNoResolveArg)(nil), args)
@@ -6039,214 +6039,214 @@ type TeamsClient struct {
 
 func (c TeamsClient) GetUntrustedTeamInfo(ctx context.Context, teamName TeamName) (res UntrustedTeamInfo, err error) {
 	__arg := GetUntrustedTeamInfoArg{TeamName: teamName}
-	err = c.Cli.Call(ctx, "keybase.1.teams.getUntrustedTeamInfo", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getUntrustedTeamInfo", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamCreate(ctx context.Context, __arg TeamCreateArg) (res TeamCreateResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreate", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreate", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamCreateWithSettings(ctx context.Context, __arg TeamCreateWithSettingsArg) (res TeamCreateResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateWithSettings", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateWithSettings", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamCreateFancy(ctx context.Context, __arg TeamCreateFancyArg) (res TeamID, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateFancy", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateFancy", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamGetByID(ctx context.Context, __arg TeamGetByIDArg) (res TeamDetails, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetByID", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetByID", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamGet(ctx context.Context, __arg TeamGetArg) (res TeamDetails, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamGet", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamGet", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamGetMembersByID(ctx context.Context, __arg TeamGetMembersByIDArg) (res []TeamMemberDetails, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetMembersByID", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetMembersByID", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamListUnverified(ctx context.Context, __arg TeamListUnverifiedArg) (res AnnotatedTeamList, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamListUnverified", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamListUnverified", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamListTeammates(ctx context.Context, __arg TeamListTeammatesArg) (res AnnotatedTeamList, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamListTeammates", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamListTeammates", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamListVerified(ctx context.Context, __arg TeamListVerifiedArg) (res AnnotatedTeamList, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamListVerified", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamListVerified", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamListSubteamsRecursive(ctx context.Context, __arg TeamListSubteamsRecursiveArg) (res []TeamIDAndName, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamListSubteamsRecursive", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamListSubteamsRecursive", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamAddMember(ctx context.Context, __arg TeamAddMemberArg) (res TeamAddMemberResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddMember", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddMember", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamAddMembers(ctx context.Context, __arg TeamAddMembersArg) (res TeamAddMembersResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddMembers", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddMembers", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamAddMembersMultiRole(ctx context.Context, __arg TeamAddMembersMultiRoleArg) (res TeamAddMembersResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddMembersMultiRole", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddMembersMultiRole", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamRemoveMember(ctx context.Context, __arg TeamRemoveMemberArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamRemoveMember", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamRemoveMember", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamRemoveMembers(ctx context.Context, __arg TeamRemoveMembersArg) (res TeamRemoveMembersResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamRemoveMembers", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamRemoveMembers", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamLeave(ctx context.Context, __arg TeamLeaveArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamLeave", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamLeave", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamEditMember(ctx context.Context, __arg TeamEditMemberArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamEditMember", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamEditMember", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamEditMembers(ctx context.Context, __arg TeamEditMembersArg) (res TeamEditMembersResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamEditMembers", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamEditMembers", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamGetBotSettings(ctx context.Context, __arg TeamGetBotSettingsArg) (res TeamBotSettings, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetBotSettings", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetBotSettings", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamSetBotSettings(ctx context.Context, __arg TeamSetBotSettingsArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamSetBotSettings", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamSetBotSettings", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) UntrustedTeamExists(ctx context.Context, teamName TeamName) (res UntrustedTeamExistsResult, err error) {
 	__arg := UntrustedTeamExistsArg{TeamName: teamName}
-	err = c.Cli.Call(ctx, "keybase.1.teams.untrustedTeamExists", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.untrustedTeamExists", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamRename(ctx context.Context, __arg TeamRenameArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamRename", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamRename", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamAcceptInvite(ctx context.Context, __arg TeamAcceptInviteArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamAcceptInvite", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamAcceptInvite", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamRequestAccess(ctx context.Context, __arg TeamRequestAccessArg) (res TeamRequestAccessResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamRequestAccess", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamRequestAccess", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamAcceptInviteOrRequestAccess(ctx context.Context, __arg TeamAcceptInviteOrRequestAccessArg) (res TeamAcceptOrRequestResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamAcceptInviteOrRequestAccess", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamAcceptInviteOrRequestAccess", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamListRequests(ctx context.Context, __arg TeamListRequestsArg) (res []TeamJoinRequest, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamListRequests", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamListRequests", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamListMyAccessRequests(ctx context.Context, __arg TeamListMyAccessRequestsArg) (res []TeamName, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamListMyAccessRequests", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamListMyAccessRequests", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamIgnoreRequest(ctx context.Context, __arg TeamIgnoreRequestArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamIgnoreRequest", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamIgnoreRequest", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamTreeUnverified(ctx context.Context, __arg TeamTreeUnverifiedArg) (res TeamTreeResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamTreeUnverified", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamTreeUnverified", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamGetSubteamsUnverified(ctx context.Context, __arg TeamGetSubteamsUnverifiedArg) (res SubteamListResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetSubteamsUnverified", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetSubteamsUnverified", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamDelete(ctx context.Context, __arg TeamDeleteArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamDelete", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamDelete", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamSetSettings(ctx context.Context, __arg TeamSetSettingsArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamSetSettings", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamSetSettings", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamCreateSeitanToken(ctx context.Context, __arg TeamCreateSeitanTokenArg) (res SeitanIKey, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateSeitanToken", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateSeitanToken", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamCreateSeitanTokenV2(ctx context.Context, __arg TeamCreateSeitanTokenV2Arg) (res SeitanIKeyV2, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateSeitanTokenV2", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateSeitanTokenV2", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamCreateSeitanInvitelink(ctx context.Context, __arg TeamCreateSeitanInvitelinkArg) (res Invitelink, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateSeitanInvitelink", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateSeitanInvitelink", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamCreateSeitanInvitelinkWithDuration(ctx context.Context, __arg TeamCreateSeitanInvitelinkWithDurationArg) (res Invitelink, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateSeitanInvitelinkWithDuration", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateSeitanInvitelinkWithDuration", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) GetInviteLinkDetails(ctx context.Context, inviteID TeamInviteID) (res InviteLinkDetails, err error) {
 	__arg := GetInviteLinkDetailsArg{InviteID: inviteID}
-	err = c.Cli.Call(ctx, "keybase.1.teams.getInviteLinkDetails", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getInviteLinkDetails", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamAddEmailsBulk(ctx context.Context, __arg TeamAddEmailsBulkArg) (res BulkRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddEmailsBulk", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddEmailsBulk", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) LookupImplicitTeam(ctx context.Context, __arg LookupImplicitTeamArg) (res LookupImplicitTeamRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.lookupImplicitTeam", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.lookupImplicitTeam", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) LookupOrCreateImplicitTeam(ctx context.Context, __arg LookupOrCreateImplicitTeamArg) (res LookupImplicitTeamRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.lookupOrCreateImplicitTeam", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.lookupOrCreateImplicitTeam", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamReAddMemberAfterReset(ctx context.Context, __arg TeamReAddMemberAfterResetArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamReAddMemberAfterReset", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamReAddMemberAfterReset", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
@@ -6256,78 +6256,78 @@ func (c TeamsClient) TeamReAddMemberAfterReset(ctx context.Context, __arg TeamRe
 // * client is currently offline (or thinks it's offline), then the refreshers are overridden
 // * and ignored, and stale data might still be returned.
 func (c TeamsClient) LoadTeamPlusApplicationKeys(ctx context.Context, __arg LoadTeamPlusApplicationKeysArg) (res TeamPlusApplicationKeys, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.loadTeamPlusApplicationKeys", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.loadTeamPlusApplicationKeys", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) GetTeamRootID(ctx context.Context, id TeamID) (res TeamID, err error) {
 	__arg := GetTeamRootIDArg{Id: id}
-	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamRootID", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamRootID", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) GetTeamShowcase(ctx context.Context, teamID TeamID) (res TeamShowcase, err error) {
 	__arg := GetTeamShowcaseArg{TeamID: teamID}
-	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamShowcase", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamShowcase", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) GetTeamAndMemberShowcase(ctx context.Context, teamID TeamID) (res TeamAndMemberShowcase, err error) {
 	__arg := GetTeamAndMemberShowcaseArg{TeamID: teamID}
-	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamAndMemberShowcase", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamAndMemberShowcase", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) SetTeamShowcase(ctx context.Context, __arg SetTeamShowcaseArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.setTeamShowcase", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.setTeamShowcase", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) SetTeamMemberShowcase(ctx context.Context, __arg SetTeamMemberShowcaseArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.setTeamMemberShowcase", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.setTeamMemberShowcase", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) CanUserPerform(ctx context.Context, name string) (res TeamOperation, err error) {
 	__arg := CanUserPerformArg{Name: name}
-	err = c.Cli.Call(ctx, "keybase.1.teams.canUserPerform", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.canUserPerform", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamRotateKey(ctx context.Context, __arg TeamRotateKeyArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamRotateKey", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamRotateKey", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamDebug(ctx context.Context, teamID TeamID) (res TeamDebugRes, err error) {
 	__arg := TeamDebugArg{TeamID: teamID}
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamDebug", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamDebug", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) GetTarsDisabled(ctx context.Context, teamID TeamID) (res bool, err error) {
 	__arg := GetTarsDisabledArg{TeamID: teamID}
-	err = c.Cli.Call(ctx, "keybase.1.teams.getTarsDisabled", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getTarsDisabled", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) SetTarsDisabled(ctx context.Context, __arg SetTarsDisabledArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.setTarsDisabled", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.setTarsDisabled", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TeamProfileAddList(ctx context.Context, __arg TeamProfileAddListArg) (res []TeamProfileAddEntry, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamProfileAddList", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamProfileAddList", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) UploadTeamAvatar(ctx context.Context, __arg UploadTeamAvatarArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.uploadTeamAvatar", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.uploadTeamAvatar", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) TryDecryptWithTeamKey(ctx context.Context, __arg TryDecryptWithTeamKeyArg) (res []byte, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.tryDecryptWithTeamKey", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.tryDecryptWithTeamKey", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -6335,7 +6335,7 @@ func (c TeamsClient) TryDecryptWithTeamKey(ctx context.Context, __arg TryDecrypt
 // removed from the team at that given seqno in the team's chain. You should pass in a previous
 // Merkle root as a starting point for the binary search.
 func (c TeamsClient) FindNextMerkleRootAfterTeamRemoval(ctx context.Context, __arg FindNextMerkleRootAfterTeamRemovalArg) (res NextMerkleRootRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.findNextMerkleRootAfterTeamRemoval", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.findNextMerkleRootAfterTeamRemoval", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -6344,7 +6344,7 @@ func (c TeamsClient) FindNextMerkleRootAfterTeamRemoval(ctx context.Context, __a
 // we will return just the last one. When anyRoleAllowed is false, the team removal is any drop in
 // permissions from Writer (or above) to Reader (or below).
 func (c TeamsClient) FindNextMerkleRootAfterTeamRemovalBySigningKey(ctx context.Context, __arg FindNextMerkleRootAfterTeamRemovalBySigningKeyArg) (res NextMerkleRootRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.findNextMerkleRootAfterTeamRemovalBySigningKey", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.findNextMerkleRootAfterTeamRemovalBySigningKey", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -6352,7 +6352,7 @@ func (c TeamsClient) FindNextMerkleRootAfterTeamRemovalBySigningKey(ctx context.
 // the team load machinery.
 func (c TeamsClient) ProfileTeamLoad(ctx context.Context, arg LoadTeamArg) (res ProfileTeamLoadRes, err error) {
 	__arg := ProfileTeamLoadArg{Arg: arg}
-	err = c.Cli.Call(ctx, "keybase.1.teams.profileTeamLoad", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.profileTeamLoad", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -6360,7 +6360,7 @@ func (c TeamsClient) ProfileTeamLoad(ctx context.Context, arg LoadTeamArg) (res 
 // current user can't read the team.
 func (c TeamsClient) GetTeamID(ctx context.Context, teamName string) (res TeamID, err error) {
 	__arg := GetTeamIDArg{TeamName: teamName}
-	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamID", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamID", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -6368,39 +6368,39 @@ func (c TeamsClient) GetTeamID(ctx context.Context, teamName string) (res TeamID
 // current user can't read the team.
 func (c TeamsClient) GetTeamName(ctx context.Context, teamID TeamID) (res TeamName, err error) {
 	__arg := GetTeamNameArg{TeamID: teamID}
-	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamName", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamName", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) Ftl(ctx context.Context, arg FastTeamLoadArg) (res FastTeamLoadRes, err error) {
 	__arg := FtlArg{Arg: arg}
-	err = c.Cli.Call(ctx, "keybase.1.teams.ftl", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.ftl", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) GetTeamRoleMap(ctx context.Context) (res TeamRoleMapAndVersion, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamRoleMap", []interface{}{GetTeamRoleMapArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getTeamRoleMap", []any{GetTeamRoleMapArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) GetAnnotatedTeam(ctx context.Context, teamID TeamID) (res AnnotatedTeam, err error) {
 	__arg := GetAnnotatedTeamArg{TeamID: teamID}
-	err = c.Cli.Call(ctx, "keybase.1.teams.getAnnotatedTeam", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getAnnotatedTeam", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) GetAnnotatedTeamByName(ctx context.Context, teamName string) (res AnnotatedTeam, err error) {
 	__arg := GetAnnotatedTeamByNameArg{TeamName: teamName}
-	err = c.Cli.Call(ctx, "keybase.1.teams.getAnnotatedTeamByName", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.getAnnotatedTeamByName", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) LoadTeamTreeMembershipsAsync(ctx context.Context, __arg LoadTeamTreeMembershipsAsyncArg) (res TeamTreeInitial, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.loadTeamTreeMembershipsAsync", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.loadTeamTreeMembershipsAsync", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsClient) FindAssertionsInTeamNoResolve(ctx context.Context, __arg FindAssertionsInTeamNoResolveArg) (res []string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.findAssertionsInTeamNoResolve", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teams.findAssertionsInTeamNoResolve", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/teams_ui.go
+++ b/go/protocol/keybase1/teams_ui.go
@@ -35,11 +35,11 @@ func TeamsUiProtocol(i TeamsUiInterface) rpc.Protocol {
 		Name: "keybase.1.teamsUi",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"confirmRootTeamDelete": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ConfirmRootTeamDeleteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ConfirmRootTeamDeleteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ConfirmRootTeamDeleteArg)(nil), args)
@@ -50,11 +50,11 @@ func TeamsUiProtocol(i TeamsUiInterface) rpc.Protocol {
 				},
 			},
 			"confirmSubteamDelete": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ConfirmSubteamDeleteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ConfirmSubteamDeleteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ConfirmSubteamDeleteArg)(nil), args)
@@ -65,11 +65,11 @@ func TeamsUiProtocol(i TeamsUiInterface) rpc.Protocol {
 				},
 			},
 			"confirmInviteLinkAccept": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ConfirmInviteLinkAcceptArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ConfirmInviteLinkAcceptArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ConfirmInviteLinkAcceptArg)(nil), args)
@@ -88,16 +88,16 @@ type TeamsUiClient struct {
 }
 
 func (c TeamsUiClient) ConfirmRootTeamDelete(ctx context.Context, __arg ConfirmRootTeamDeleteArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teamsUi.confirmRootTeamDelete", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teamsUi.confirmRootTeamDelete", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsUiClient) ConfirmSubteamDelete(ctx context.Context, __arg ConfirmSubteamDeleteArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teamsUi.confirmSubteamDelete", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teamsUi.confirmSubteamDelete", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TeamsUiClient) ConfirmInviteLinkAccept(ctx context.Context, __arg ConfirmInviteLinkAcceptArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teamsUi.confirmInviteLinkAccept", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teamsUi.confirmInviteLinkAccept", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/teamsearch.go
+++ b/go/protocol/keybase1/teamsearch.go
@@ -106,11 +106,11 @@ func TeamSearchProtocol(i TeamSearchInterface) rpc.Protocol {
 		Name: "keybase.1.teamSearch",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"teamSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TeamSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TeamSearchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TeamSearchArg)(nil), args)
@@ -129,6 +129,6 @@ type TeamSearchClient struct {
 }
 
 func (c TeamSearchClient) TeamSearch(ctx context.Context, __arg TeamSearchArg) (res TeamSearchRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teamSearch.teamSearch", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.teamSearch.teamSearch", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/test.go
+++ b/go/protocol/keybase1/test.go
@@ -110,11 +110,11 @@ func TestProtocol(i TestInterface) rpc.Protocol {
 		Name: "keybase.1.test",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"test": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TestArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TestArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TestArg)(nil), args)
@@ -125,11 +125,11 @@ func TestProtocol(i TestInterface) rpc.Protocol {
 				},
 			},
 			"testCallback": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TestCallbackArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TestCallbackArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TestCallbackArg)(nil), args)
@@ -140,11 +140,11 @@ func TestProtocol(i TestInterface) rpc.Protocol {
 				},
 			},
 			"panic": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PanicArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PanicArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PanicArg)(nil), args)
@@ -155,21 +155,21 @@ func TestProtocol(i TestInterface) rpc.Protocol {
 				},
 			},
 			"testAirdropReg": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TestAirdropRegArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.TestAirdropReg(ctx)
 					return
 				},
 			},
 			"echo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]EchoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]EchoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]EchoArg)(nil), args)
@@ -191,32 +191,32 @@ type TestClient struct {
 // Will trigger the testCallback method, whose result will be set in the
 // returned Test object, reply property.
 func (c TestClient) Test(ctx context.Context, __arg TestArg) (res Test, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.test.test", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.test.test", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // This is a service callback triggered from test(..).
 // The name param is what was passed into test.
 func (c TestClient) TestCallback(ctx context.Context, __arg TestCallbackArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.test.testCallback", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.test.testCallback", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // For testing crashes.
 func (c TestClient) Panic(ctx context.Context, message string) (err error) {
 	__arg := PanicArg{Message: message}
-	err = c.Cli.Call(ctx, "keybase.1.test.panic", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.test.panic", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // For testing airdrop reg.
 func (c TestClient) TestAirdropReg(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.test.testAirdropReg", []interface{}{TestAirdropRegArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.test.testAirdropReg", []any{TestAirdropRegArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TestClient) Echo(ctx context.Context, arg Generic) (res Generic, err error) {
 	__arg := EchoArg{Arg: arg}
-	err = c.Cli.Call(ctx, "keybase.1.test.echo", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.test.echo", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/tlf.go
+++ b/go/protocol/keybase1/tlf.go
@@ -35,11 +35,11 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 		Name: "keybase.1.tlf",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"CryptKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CryptKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CryptKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CryptKeysArg)(nil), args)
@@ -50,11 +50,11 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 				},
 			},
 			"publicCanonicalTLFNameAndID": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PublicCanonicalTLFNameAndIDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PublicCanonicalTLFNameAndIDArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PublicCanonicalTLFNameAndIDArg)(nil), args)
@@ -65,11 +65,11 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 				},
 			},
 			"completeAndCanonicalizePrivateTlfName": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CompleteAndCanonicalizePrivateTlfNameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CompleteAndCanonicalizePrivateTlfNameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CompleteAndCanonicalizePrivateTlfNameArg)(nil), args)
@@ -90,7 +90,7 @@ type TlfClient struct {
 // CryptKeys returns TLF crypt keys from all generations.
 func (c TlfClient) CryptKeys(ctx context.Context, query TLFQuery) (res GetTLFCryptKeysRes, err error) {
 	__arg := CryptKeysArg{Query: query}
-	err = c.Cli.Call(ctx, "keybase.1.tlf.CryptKeys", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.tlf.CryptKeys", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -98,12 +98,12 @@ func (c TlfClient) CryptKeys(ctx context.Context, query TLFQuery) (res GetTLFCry
 // * TLFID should not be cached or stored persistently.
 func (c TlfClient) PublicCanonicalTLFNameAndID(ctx context.Context, query TLFQuery) (res CanonicalTLFNameAndIDWithBreaks, err error) {
 	__arg := PublicCanonicalTLFNameAndIDArg{Query: query}
-	err = c.Cli.Call(ctx, "keybase.1.tlf.publicCanonicalTLFNameAndID", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.tlf.publicCanonicalTLFNameAndID", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c TlfClient) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, query TLFQuery) (res CanonicalTLFNameAndIDWithBreaks, err error) {
 	__arg := CompleteAndCanonicalizePrivateTlfNameArg{Query: query}
-	err = c.Cli.Call(ctx, "keybase.1.tlf.completeAndCanonicalizePrivateTlfName", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.tlf.completeAndCanonicalizePrivateTlfName", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/tlf_keys.go
+++ b/go/protocol/keybase1/tlf_keys.go
@@ -204,11 +204,11 @@ func TlfKeysProtocol(i TlfKeysInterface) rpc.Protocol {
 		Name: "keybase.1.tlfKeys",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getTLFCryptKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTLFCryptKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTLFCryptKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTLFCryptKeysArg)(nil), args)
@@ -219,11 +219,11 @@ func TlfKeysProtocol(i TlfKeysInterface) rpc.Protocol {
 				},
 			},
 			"getPublicCanonicalTLFNameAndID": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPublicCanonicalTLFNameAndIDArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPublicCanonicalTLFNameAndIDArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPublicCanonicalTLFNameAndIDArg)(nil), args)
@@ -245,7 +245,7 @@ type TlfKeysClient struct {
 // TLF ID should not be cached or stored persistently.
 func (c TlfKeysClient) GetTLFCryptKeys(ctx context.Context, query TLFQuery) (res GetTLFCryptKeysRes, err error) {
 	__arg := GetTLFCryptKeysArg{Query: query}
-	err = c.Cli.Call(ctx, "keybase.1.tlfKeys.getTLFCryptKeys", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.tlfKeys.getTLFCryptKeys", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -253,6 +253,6 @@ func (c TlfKeysClient) GetTLFCryptKeys(ctx context.Context, query TLFQuery) (res
 // TLF ID should not be cached or stored persistently.
 func (c TlfKeysClient) GetPublicCanonicalTLFNameAndID(ctx context.Context, query TLFQuery) (res CanonicalTLFNameAndIDWithBreaks, err error) {
 	__arg := GetPublicCanonicalTLFNameAndIDArg{Query: query}
-	err = c.Cli.Call(ctx, "keybase.1.tlfKeys.getPublicCanonicalTLFNameAndID", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.tlfKeys.getPublicCanonicalTLFNameAndID", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/track.go
+++ b/go/protocol/keybase1/track.go
@@ -61,11 +61,11 @@ func TrackProtocol(i TrackInterface) rpc.Protocol {
 		Name: "keybase.1.track",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"track": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TrackArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TrackArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TrackArg)(nil), args)
@@ -76,11 +76,11 @@ func TrackProtocol(i TrackInterface) rpc.Protocol {
 				},
 			},
 			"trackWithToken": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]TrackWithTokenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]TrackWithTokenArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]TrackWithTokenArg)(nil), args)
@@ -91,11 +91,11 @@ func TrackProtocol(i TrackInterface) rpc.Protocol {
 				},
 			},
 			"dismissWithToken": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DismissWithTokenArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DismissWithTokenArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DismissWithTokenArg)(nil), args)
@@ -106,11 +106,11 @@ func TrackProtocol(i TrackInterface) rpc.Protocol {
 				},
 			},
 			"untrack": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UntrackArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UntrackArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UntrackArg)(nil), args)
@@ -121,11 +121,11 @@ func TrackProtocol(i TrackInterface) rpc.Protocol {
 				},
 			},
 			"checkTracking": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CheckTrackingArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CheckTrackingArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CheckTrackingArg)(nil), args)
@@ -136,11 +136,11 @@ func TrackProtocol(i TrackInterface) rpc.Protocol {
 				},
 			},
 			"fakeTrackingChanged": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FakeTrackingChangedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FakeTrackingChangedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FakeTrackingChangedArg)(nil), args)
@@ -162,34 +162,34 @@ type TrackClient struct {
 // If forceRemoteCheck is true, we force all remote proofs to be checked
 // (otherwise a cache is used).
 func (c TrackClient) Track(ctx context.Context, __arg TrackArg) (res ConfirmResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.track.track", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.track.track", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Track with token returned from identify.
 func (c TrackClient) TrackWithToken(ctx context.Context, __arg TrackWithTokenArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.track.trackWithToken", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.track.trackWithToken", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 // Called by the UI when the user decides *not* to track, to e.g. dismiss gregor items.
 func (c TrackClient) DismissWithToken(ctx context.Context, __arg DismissWithTokenArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.track.dismissWithToken", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.track.dismissWithToken", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TrackClient) Untrack(ctx context.Context, __arg UntrackArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.track.untrack", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.track.untrack", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TrackClient) CheckTracking(ctx context.Context, sessionID int) (err error) {
 	__arg := CheckTrackingArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.track.checkTracking", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.track.checkTracking", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c TrackClient) FakeTrackingChanged(ctx context.Context, __arg FakeTrackingChangedArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.track.fakeTrackingChanged", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.track.fakeTrackingChanged", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/ui.go
+++ b/go/protocol/keybase1/ui.go
@@ -54,11 +54,11 @@ func UiProtocol(i UiInterface) rpc.Protocol {
 		Name: "keybase.1.ui",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"promptYesNo": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PromptYesNoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PromptYesNoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PromptYesNoArg)(nil), args)
@@ -77,6 +77,6 @@ type UiClient struct {
 }
 
 func (c UiClient) PromptYesNo(ctx context.Context, __arg PromptYesNoArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.ui.promptYesNo", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.ui.promptYesNo", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/user.go
+++ b/go/protocol/keybase1/user.go
@@ -793,11 +793,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 		Name: "keybase.1.user",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"listTracking": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListTrackingArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ListTrackingArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ListTrackingArg)(nil), args)
@@ -808,11 +808,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"listTrackingJSON": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListTrackingJSONArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ListTrackingJSONArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ListTrackingJSONArg)(nil), args)
@@ -823,11 +823,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"listTrackersUnverified": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListTrackersUnverifiedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ListTrackersUnverifiedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ListTrackersUnverifiedArg)(nil), args)
@@ -838,11 +838,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"loadUser": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadUserArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadUserArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadUserArg)(nil), args)
@@ -853,11 +853,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"loadUserByName": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadUserByNameArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadUserByNameArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadUserByNameArg)(nil), args)
@@ -868,11 +868,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"loadUserPlusKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadUserPlusKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadUserPlusKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadUserPlusKeysArg)(nil), args)
@@ -883,11 +883,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"loadUserPlusKeysV2": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadUserPlusKeysV2Arg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadUserPlusKeysV2Arg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadUserPlusKeysV2Arg)(nil), args)
@@ -898,11 +898,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"loadPublicKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadPublicKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadPublicKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadPublicKeysArg)(nil), args)
@@ -913,11 +913,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"loadMyPublicKeys": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadMyPublicKeysArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadMyPublicKeysArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadMyPublicKeysArg)(nil), args)
@@ -928,11 +928,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"loadMySettings": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadMySettingsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadMySettingsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadMySettingsArg)(nil), args)
@@ -943,11 +943,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"loadAllPublicKeysUnverified": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadAllPublicKeysUnverifiedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadAllPublicKeysUnverifiedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadAllPublicKeysUnverifiedArg)(nil), args)
@@ -958,11 +958,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"profileEdit": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ProfileEditArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ProfileEditArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ProfileEditArg)(nil), args)
@@ -973,11 +973,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"interestingPeople": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]InterestingPeopleArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]InterestingPeopleArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]InterestingPeopleArg)(nil), args)
@@ -988,11 +988,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"meUserVersion": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MeUserVersionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MeUserVersionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MeUserVersionArg)(nil), args)
@@ -1003,11 +1003,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"getUPAK": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUPAKArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetUPAKArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetUPAKArg)(nil), args)
@@ -1018,11 +1018,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"getUPAKLite": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUPAKLiteArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetUPAKLiteArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetUPAKLiteArg)(nil), args)
@@ -1033,11 +1033,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"uploadUserAvatar": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UploadUserAvatarArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UploadUserAvatarArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UploadUserAvatarArg)(nil), args)
@@ -1048,11 +1048,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"proofSuggestions": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ProofSuggestionsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ProofSuggestionsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ProofSuggestionsArg)(nil), args)
@@ -1063,11 +1063,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"findNextMerkleRootAfterRevoke": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FindNextMerkleRootAfterRevokeArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FindNextMerkleRootAfterRevokeArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FindNextMerkleRootAfterRevokeArg)(nil), args)
@@ -1078,11 +1078,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"findNextMerkleRootAfterReset": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FindNextMerkleRootAfterResetArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FindNextMerkleRootAfterResetArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FindNextMerkleRootAfterResetArg)(nil), args)
@@ -1093,11 +1093,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"canLogout": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CanLogoutArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CanLogoutArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CanLogoutArg)(nil), args)
@@ -1108,11 +1108,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"loadPassphraseState": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LoadPassphraseStateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LoadPassphraseStateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LoadPassphraseStateArg)(nil), args)
@@ -1123,11 +1123,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"userCard": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UserCardArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UserCardArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UserCardArg)(nil), args)
@@ -1138,11 +1138,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"setUserBlocks": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetUserBlocksArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetUserBlocksArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetUserBlocksArg)(nil), args)
@@ -1153,11 +1153,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"getUserBlocks": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetUserBlocksArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetUserBlocksArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetUserBlocksArg)(nil), args)
@@ -1168,11 +1168,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"reportUser": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ReportUserArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ReportUserArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ReportUserArg)(nil), args)
@@ -1183,11 +1183,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"dismissBlockButtons": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DismissBlockButtonsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DismissBlockButtonsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DismissBlockButtonsArg)(nil), args)
@@ -1198,11 +1198,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"blockUser": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BlockUserArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BlockUserArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BlockUserArg)(nil), args)
@@ -1213,11 +1213,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"unblockUser": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UnblockUserArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UnblockUserArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UnblockUserArg)(nil), args)
@@ -1228,11 +1228,11 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 			},
 			"getTeamBlocks": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTeamBlocksArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTeamBlocksArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTeamBlocksArg)(nil), args)
@@ -1256,107 +1256,107 @@ type UserClient struct {
 //
 // If assertion is empty, it will use the current logged in user.
 func (c UserClient) ListTracking(ctx context.Context, __arg ListTrackingArg) (res UserSummarySet, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.listTracking", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.listTracking", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) ListTrackingJSON(ctx context.Context, __arg ListTrackingJSONArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.listTrackingJSON", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.listTrackingJSON", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // listTrackersUnverified returns the users following the given user, and is unverified
 // and server-trust.
 func (c UserClient) ListTrackersUnverified(ctx context.Context, __arg ListTrackersUnverifiedArg) (res UserSummarySet, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.listTrackersUnverified", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.listTrackersUnverified", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Load a user from the server.
 func (c UserClient) LoadUser(ctx context.Context, __arg LoadUserArg) (res User, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.loadUser", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.loadUser", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) LoadUserByName(ctx context.Context, __arg LoadUserByNameArg) (res User, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.loadUserByName", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.loadUserByName", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Load a user + device keys from the server.
 func (c UserClient) LoadUserPlusKeys(ctx context.Context, __arg LoadUserPlusKeysArg) (res UserPlusKeys, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.loadUserPlusKeys", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.loadUserPlusKeys", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) LoadUserPlusKeysV2(ctx context.Context, __arg LoadUserPlusKeysV2Arg) (res UserPlusKeysV2AllIncarnations, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.loadUserPlusKeysV2", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.loadUserPlusKeysV2", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Load public keys for a user.
 func (c UserClient) LoadPublicKeys(ctx context.Context, __arg LoadPublicKeysArg) (res []PublicKey, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.loadPublicKeys", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.loadPublicKeys", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Load my public keys (for logged in user).
 func (c UserClient) LoadMyPublicKeys(ctx context.Context, sessionID int) (res []PublicKey, err error) {
 	__arg := LoadMyPublicKeysArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.user.loadMyPublicKeys", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.loadMyPublicKeys", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Load user settings (for logged in user).
 func (c UserClient) LoadMySettings(ctx context.Context, sessionID int) (res UserSettings, err error) {
 	__arg := LoadMySettingsArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.user.loadMySettings", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.loadMySettings", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // Load all the user's public keys (even those in reset key families)
 // from the server with no verification
 func (c UserClient) LoadAllPublicKeysUnverified(ctx context.Context, __arg LoadAllPublicKeysUnverifiedArg) (res []PublicKey, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.loadAllPublicKeysUnverified", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.loadAllPublicKeysUnverified", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) ProfileEdit(ctx context.Context, __arg ProfileEditArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.profileEdit", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.profileEdit", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) InterestingPeople(ctx context.Context, __arg InterestingPeopleArg) (res []InterestingPerson, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.interestingPeople", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.interestingPeople", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) MeUserVersion(ctx context.Context, __arg MeUserVersionArg) (res UserVersion, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.meUserVersion", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.meUserVersion", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // getUPAK returns a UPAK. Used mainly for debugging.
 func (c UserClient) GetUPAK(ctx context.Context, __arg GetUPAKArg) (res UPAKVersioned, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.getUPAK", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.getUPAK", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 // getUPAKLite returns a UPKLiteV1AllIncarnations. Used mainly for debugging.
 func (c UserClient) GetUPAKLite(ctx context.Context, uid UID) (res UPKLiteV1AllIncarnations, err error) {
 	__arg := GetUPAKLiteArg{Uid: uid}
-	err = c.Cli.Call(ctx, "keybase.1.user.getUPAKLite", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.getUPAKLite", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) UploadUserAvatar(ctx context.Context, __arg UploadUserAvatarArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.uploadUserAvatar", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.uploadUserAvatar", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) ProofSuggestions(ctx context.Context, sessionID int) (res ProofSuggestionsRes, err error) {
 	__arg := ProofSuggestionsArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.user.proofSuggestions", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.proofSuggestions", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -1364,7 +1364,7 @@ func (c UserClient) ProofSuggestions(ctx context.Context, sessionID int) (res Pr
 // revocation at the given SigChainLocataion. The MerkleRootV2 prev is a hint as to where
 // we'll start our search. Usually it's the next one, but not always
 func (c UserClient) FindNextMerkleRootAfterRevoke(ctx context.Context, __arg FindNextMerkleRootAfterRevokeArg) (res NextMerkleRootRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.findNextMerkleRootAfterRevoke", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.findNextMerkleRootAfterRevoke", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -1372,62 +1372,62 @@ func (c UserClient) FindNextMerkleRootAfterRevoke(ctx context.Context, __arg Fin
 // at resetSeqno. You should pass it prev, which was the last known Merkle root at the time of
 // the reset. Usually, we'll just turn up the next Merkle root, but not always.
 func (c UserClient) FindNextMerkleRootAfterReset(ctx context.Context, __arg FindNextMerkleRootAfterResetArg) (res NextMerkleRootRes, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.findNextMerkleRootAfterReset", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.findNextMerkleRootAfterReset", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) CanLogout(ctx context.Context, sessionID int) (res CanLogoutRes, err error) {
 	__arg := CanLogoutArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.user.canLogout", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.canLogout", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) LoadPassphraseState(ctx context.Context, sessionID int) (res PassphraseState, err error) {
 	__arg := LoadPassphraseStateArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.user.loadPassphraseState", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.loadPassphraseState", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) UserCard(ctx context.Context, __arg UserCardArg) (res *UserCard, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.userCard", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.userCard", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) SetUserBlocks(ctx context.Context, __arg SetUserBlocksArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.setUserBlocks", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.setUserBlocks", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) GetUserBlocks(ctx context.Context, __arg GetUserBlocksArg) (res []UserBlock, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.getUserBlocks", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.getUserBlocks", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) ReportUser(ctx context.Context, __arg ReportUserArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.reportUser", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.reportUser", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) DismissBlockButtons(ctx context.Context, tlfID TLFID) (err error) {
 	__arg := DismissBlockButtonsArg{TlfID: tlfID}
-	err = c.Cli.Call(ctx, "keybase.1.user.dismissBlockButtons", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.dismissBlockButtons", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) BlockUser(ctx context.Context, username string) (err error) {
 	__arg := BlockUserArg{Username: username}
-	err = c.Cli.Call(ctx, "keybase.1.user.blockUser", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.blockUser", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) UnblockUser(ctx context.Context, username string) (err error) {
 	__arg := UnblockUserArg{Username: username}
-	err = c.Cli.Call(ctx, "keybase.1.user.unblockUser", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.unblockUser", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c UserClient) GetTeamBlocks(ctx context.Context, sessionID int) (res []TeamBlock, err error) {
 	__arg := GetTeamBlocksArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.user.getTeamBlocks", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.user.getTeamBlocks", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/usersearch.go
+++ b/go/protocol/keybase1/usersearch.go
@@ -304,11 +304,11 @@ func UserSearchProtocol(i UserSearchInterface) rpc.Protocol {
 		Name: "keybase.1.userSearch",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getNonUserDetails": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetNonUserDetailsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetNonUserDetailsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetNonUserDetailsArg)(nil), args)
@@ -319,11 +319,11 @@ func UserSearchProtocol(i UserSearchInterface) rpc.Protocol {
 				},
 			},
 			"userSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]UserSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]UserSearchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]UserSearchArg)(nil), args)
@@ -334,11 +334,11 @@ func UserSearchProtocol(i UserSearchInterface) rpc.Protocol {
 				},
 			},
 			"bulkEmailOrPhoneSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BulkEmailOrPhoneSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BulkEmailOrPhoneSearchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BulkEmailOrPhoneSearchArg)(nil), args)
@@ -357,16 +357,16 @@ type UserSearchClient struct {
 }
 
 func (c UserSearchClient) GetNonUserDetails(ctx context.Context, __arg GetNonUserDetailsArg) (res NonUserDetails, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.userSearch.getNonUserDetails", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.userSearch.getNonUserDetails", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserSearchClient) UserSearch(ctx context.Context, __arg UserSearchArg) (res []APIUserSearchResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.userSearch.userSearch", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.userSearch.userSearch", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c UserSearchClient) BulkEmailOrPhoneSearch(ctx context.Context, __arg BulkEmailOrPhoneSearchArg) (res []EmailOrPhoneNumberSearchResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.userSearch.bulkEmailOrPhoneSearch", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.userSearch.bulkEmailOrPhoneSearch", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/wot.go
+++ b/go/protocol/keybase1/wot.go
@@ -208,11 +208,11 @@ func WotProtocol(i WotInterface) rpc.Protocol {
 		Name: "keybase.1.wot",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"wotVouch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WotVouchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]WotVouchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]WotVouchArg)(nil), args)
@@ -223,11 +223,11 @@ func WotProtocol(i WotInterface) rpc.Protocol {
 				},
 			},
 			"wotVouchCLI": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WotVouchCLIArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]WotVouchCLIArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]WotVouchCLIArg)(nil), args)
@@ -238,11 +238,11 @@ func WotProtocol(i WotInterface) rpc.Protocol {
 				},
 			},
 			"wotReact": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WotReactArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]WotReactArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]WotReactArg)(nil), args)
@@ -253,11 +253,11 @@ func WotProtocol(i WotInterface) rpc.Protocol {
 				},
 			},
 			"dismissWotNotifications": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DismissWotNotificationsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DismissWotNotificationsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DismissWotNotificationsArg)(nil), args)
@@ -268,11 +268,11 @@ func WotProtocol(i WotInterface) rpc.Protocol {
 				},
 			},
 			"wotFetchVouches": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WotFetchVouchesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]WotFetchVouchesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]WotFetchVouchesArg)(nil), args)
@@ -291,26 +291,26 @@ type WotClient struct {
 }
 
 func (c WotClient) WotVouch(ctx context.Context, __arg WotVouchArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.wot.wotVouch", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.wot.wotVouch", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c WotClient) WotVouchCLI(ctx context.Context, __arg WotVouchCLIArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.wot.wotVouchCLI", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.wot.wotVouchCLI", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c WotClient) WotReact(ctx context.Context, __arg WotReactArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.wot.wotReact", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.wot.wotReact", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c WotClient) DismissWotNotifications(ctx context.Context, __arg DismissWotNotificationsArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.wot.dismissWotNotifications", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.wot.dismissWotNotifications", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c WotClient) WotFetchVouches(ctx context.Context, __arg WotFetchVouchesArg) (res []WotVouch, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.wot.wotFetchVouches", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "keybase.1.wot.wotFetchVouches", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -1854,11 +1854,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 		Name: "stellar.1.local",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getWalletAccountsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetWalletAccountsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetWalletAccountsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetWalletAccountsLocalArg)(nil), args)
@@ -1869,11 +1869,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getWalletAccountLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetWalletAccountLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetWalletAccountLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetWalletAccountLocalArg)(nil), args)
@@ -1884,11 +1884,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getAccountAssetsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetAccountAssetsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetAccountAssetsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetAccountAssetsLocalArg)(nil), args)
@@ -1899,11 +1899,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getPaymentsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPaymentsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPaymentsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPaymentsLocalArg)(nil), args)
@@ -1914,11 +1914,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getPendingPaymentsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPendingPaymentsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPendingPaymentsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPendingPaymentsLocalArg)(nil), args)
@@ -1929,11 +1929,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"markAsReadLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MarkAsReadLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MarkAsReadLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MarkAsReadLocalArg)(nil), args)
@@ -1944,11 +1944,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getPaymentDetailsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPaymentDetailsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPaymentDetailsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPaymentDetailsLocalArg)(nil), args)
@@ -1959,11 +1959,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getGenericPaymentDetailsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetGenericPaymentDetailsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetGenericPaymentDetailsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetGenericPaymentDetailsLocalArg)(nil), args)
@@ -1974,11 +1974,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getDisplayCurrenciesLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetDisplayCurrenciesLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetDisplayCurrenciesLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetDisplayCurrenciesLocalArg)(nil), args)
@@ -1989,11 +1989,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"validateAccountIDLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ValidateAccountIDLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ValidateAccountIDLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ValidateAccountIDLocalArg)(nil), args)
@@ -2004,11 +2004,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"validateSecretKeyLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ValidateSecretKeyLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ValidateSecretKeyLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ValidateSecretKeyLocalArg)(nil), args)
@@ -2019,11 +2019,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"validateAccountNameLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ValidateAccountNameLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ValidateAccountNameLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ValidateAccountNameLocalArg)(nil), args)
@@ -2034,11 +2034,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"changeWalletAccountNameLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChangeWalletAccountNameLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChangeWalletAccountNameLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChangeWalletAccountNameLocalArg)(nil), args)
@@ -2049,11 +2049,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setWalletAccountAsDefaultLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetWalletAccountAsDefaultLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetWalletAccountAsDefaultLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetWalletAccountAsDefaultLocalArg)(nil), args)
@@ -2064,11 +2064,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"deleteWalletAccountLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteWalletAccountLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteWalletAccountLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteWalletAccountLocalArg)(nil), args)
@@ -2079,11 +2079,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"linkNewWalletAccountLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LinkNewWalletAccountLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LinkNewWalletAccountLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LinkNewWalletAccountLocalArg)(nil), args)
@@ -2094,11 +2094,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"createWalletAccountLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CreateWalletAccountLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CreateWalletAccountLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CreateWalletAccountLocalArg)(nil), args)
@@ -2109,11 +2109,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"changeDisplayCurrencyLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChangeDisplayCurrencyLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChangeDisplayCurrencyLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChangeDisplayCurrencyLocalArg)(nil), args)
@@ -2124,11 +2124,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getDisplayCurrencyLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetDisplayCurrencyLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetDisplayCurrencyLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetDisplayCurrencyLocalArg)(nil), args)
@@ -2139,11 +2139,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"hasAcceptedDisclaimerLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]HasAcceptedDisclaimerLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]HasAcceptedDisclaimerLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]HasAcceptedDisclaimerLocalArg)(nil), args)
@@ -2154,11 +2154,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"acceptDisclaimerLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AcceptDisclaimerLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AcceptDisclaimerLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AcceptDisclaimerLocalArg)(nil), args)
@@ -2169,11 +2169,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getWalletAccountPublicKeyLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetWalletAccountPublicKeyLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetWalletAccountPublicKeyLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetWalletAccountPublicKeyLocalArg)(nil), args)
@@ -2184,11 +2184,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getWalletAccountSecretKeyLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetWalletAccountSecretKeyLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetWalletAccountSecretKeyLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetWalletAccountSecretKeyLocalArg)(nil), args)
@@ -2199,11 +2199,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getSendAssetChoicesLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetSendAssetChoicesLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetSendAssetChoicesLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetSendAssetChoicesLocalArg)(nil), args)
@@ -2214,11 +2214,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"startBuildPaymentLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StartBuildPaymentLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]StartBuildPaymentLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]StartBuildPaymentLocalArg)(nil), args)
@@ -2229,11 +2229,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"stopBuildPaymentLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]StopBuildPaymentLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]StopBuildPaymentLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]StopBuildPaymentLocalArg)(nil), args)
@@ -2244,11 +2244,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"buildPaymentLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BuildPaymentLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BuildPaymentLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BuildPaymentLocalArg)(nil), args)
@@ -2259,11 +2259,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"reviewPaymentLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ReviewPaymentLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ReviewPaymentLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ReviewPaymentLocalArg)(nil), args)
@@ -2274,11 +2274,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"sendPaymentLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SendPaymentLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SendPaymentLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SendPaymentLocalArg)(nil), args)
@@ -2289,11 +2289,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"sendPathLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SendPathLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SendPathLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SendPathLocalArg)(nil), args)
@@ -2304,11 +2304,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"buildRequestLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BuildRequestLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BuildRequestLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BuildRequestLocalArg)(nil), args)
@@ -2319,11 +2319,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getRequestDetailsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetRequestDetailsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetRequestDetailsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetRequestDetailsLocalArg)(nil), args)
@@ -2334,11 +2334,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"cancelRequestLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CancelRequestLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CancelRequestLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CancelRequestLocalArg)(nil), args)
@@ -2349,11 +2349,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"makeRequestLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MakeRequestLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MakeRequestLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MakeRequestLocalArg)(nil), args)
@@ -2364,11 +2364,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setAccountMobileOnlyLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetAccountMobileOnlyLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetAccountMobileOnlyLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetAccountMobileOnlyLocalArg)(nil), args)
@@ -2379,11 +2379,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setAccountAllDevicesLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetAccountAllDevicesLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetAccountAllDevicesLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetAccountAllDevicesLocalArg)(nil), args)
@@ -2394,11 +2394,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"isAccountMobileOnlyLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]IsAccountMobileOnlyLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]IsAccountMobileOnlyLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]IsAccountMobileOnlyLocalArg)(nil), args)
@@ -2409,11 +2409,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"cancelPaymentLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CancelPaymentLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CancelPaymentLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CancelPaymentLocalArg)(nil), args)
@@ -2424,11 +2424,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getPredefinedInflationDestinationsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPredefinedInflationDestinationsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPredefinedInflationDestinationsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPredefinedInflationDestinationsLocalArg)(nil), args)
@@ -2439,11 +2439,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setInflationDestinationLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetInflationDestinationLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetInflationDestinationLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetInflationDestinationLocalArg)(nil), args)
@@ -2454,11 +2454,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getInflationDestinationLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetInflationDestinationLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetInflationDestinationLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetInflationDestinationLocalArg)(nil), args)
@@ -2469,11 +2469,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"airdropDetailsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AirdropDetailsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AirdropDetailsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AirdropDetailsLocalArg)(nil), args)
@@ -2484,11 +2484,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"airdropStatusLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AirdropStatusLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AirdropStatusLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AirdropStatusLocalArg)(nil), args)
@@ -2499,11 +2499,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"airdropRegisterLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AirdropRegisterLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AirdropRegisterLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AirdropRegisterLocalArg)(nil), args)
@@ -2514,11 +2514,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"fuzzyAssetSearchLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FuzzyAssetSearchLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FuzzyAssetSearchLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FuzzyAssetSearchLocalArg)(nil), args)
@@ -2529,11 +2529,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"listPopularAssetsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListPopularAssetsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ListPopularAssetsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ListPopularAssetsLocalArg)(nil), args)
@@ -2544,11 +2544,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"addTrustlineLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AddTrustlineLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AddTrustlineLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AddTrustlineLocalArg)(nil), args)
@@ -2559,11 +2559,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"deleteTrustlineLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DeleteTrustlineLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DeleteTrustlineLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DeleteTrustlineLocalArg)(nil), args)
@@ -2574,11 +2574,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"changeTrustlineLimitLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChangeTrustlineLimitLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChangeTrustlineLimitLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChangeTrustlineLimitLocalArg)(nil), args)
@@ -2589,11 +2589,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getTrustlinesLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTrustlinesLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTrustlinesLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTrustlinesLocalArg)(nil), args)
@@ -2604,11 +2604,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getTrustlinesForRecipientLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetTrustlinesForRecipientLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetTrustlinesForRecipientLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetTrustlinesForRecipientLocalArg)(nil), args)
@@ -2619,11 +2619,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"findPaymentPathLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FindPaymentPathLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FindPaymentPathLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FindPaymentPathLocalArg)(nil), args)
@@ -2634,11 +2634,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"assetDepositLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AssetDepositLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AssetDepositLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AssetDepositLocalArg)(nil), args)
@@ -2649,11 +2649,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"assetWithdrawLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AssetWithdrawLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AssetWithdrawLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AssetWithdrawLocalArg)(nil), args)
@@ -2664,11 +2664,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"balancesLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BalancesLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BalancesLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BalancesLocalArg)(nil), args)
@@ -2679,11 +2679,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"sendCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SendCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SendCLILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SendCLILocalArg)(nil), args)
@@ -2694,11 +2694,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"sendPathCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SendPathCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SendPathCLILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SendPathCLILocalArg)(nil), args)
@@ -2709,11 +2709,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"accountMergeCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AccountMergeCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AccountMergeCLILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AccountMergeCLILocalArg)(nil), args)
@@ -2724,11 +2724,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"claimCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ClaimCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ClaimCLILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ClaimCLILocalArg)(nil), args)
@@ -2739,11 +2739,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"recentPaymentsCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RecentPaymentsCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RecentPaymentsCLILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RecentPaymentsCLILocalArg)(nil), args)
@@ -2754,11 +2754,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"paymentDetailCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PaymentDetailCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PaymentDetailCLILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PaymentDetailCLILocalArg)(nil), args)
@@ -2769,41 +2769,41 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"walletInitLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WalletInitLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					err = i.WalletInitLocal(ctx)
 					return
 				},
 			},
 			"walletDumpLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WalletDumpLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.WalletDumpLocal(ctx)
 					return
 				},
 			},
 			"walletGetAccountsCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]WalletGetAccountsCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.WalletGetAccountsCLILocal(ctx)
 					return
 				},
 			},
 			"ownAccountLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]OwnAccountLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]OwnAccountLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]OwnAccountLocalArg)(nil), args)
@@ -2814,11 +2814,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"importSecretKeyLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ImportSecretKeyLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ImportSecretKeyLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ImportSecretKeyLocalArg)(nil), args)
@@ -2829,11 +2829,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"exportSecretKeyLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ExportSecretKeyLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ExportSecretKeyLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ExportSecretKeyLocalArg)(nil), args)
@@ -2844,11 +2844,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"setDisplayCurrency": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetDisplayCurrencyArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetDisplayCurrencyArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetDisplayCurrencyArg)(nil), args)
@@ -2859,11 +2859,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"exchangeRateLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ExchangeRateLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ExchangeRateLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ExchangeRateLocalArg)(nil), args)
@@ -2874,21 +2874,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getAvailableLocalCurrencies": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetAvailableLocalCurrenciesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetAvailableLocalCurrencies(ctx)
 					return
 				},
 			},
 			"formatLocalCurrencyString": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FormatLocalCurrencyStringArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FormatLocalCurrencyStringArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FormatLocalCurrencyStringArg)(nil), args)
@@ -2899,11 +2899,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"makeRequestCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MakeRequestCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MakeRequestCLILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MakeRequestCLILocalArg)(nil), args)
@@ -2914,11 +2914,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"lookupCLILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]LookupCLILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]LookupCLILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]LookupCLILocalArg)(nil), args)
@@ -2929,11 +2929,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"batchLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BatchLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BatchLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BatchLocalArg)(nil), args)
@@ -2944,11 +2944,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"validateStellarURILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ValidateStellarURILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ValidateStellarURILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ValidateStellarURILocalArg)(nil), args)
@@ -2959,11 +2959,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"approveTxURILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ApproveTxURILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ApproveTxURILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ApproveTxURILocalArg)(nil), args)
@@ -2974,11 +2974,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"approvePayURILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ApprovePayURILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ApprovePayURILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ApprovePayURILocalArg)(nil), args)
@@ -2989,11 +2989,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"approvePathURILocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ApprovePathURILocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ApprovePathURILocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ApprovePathURILocalArg)(nil), args)
@@ -3004,11 +3004,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getPartnerUrlsLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetPartnerUrlsLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]GetPartnerUrlsLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]GetPartnerUrlsLocalArg)(nil), args)
@@ -3019,11 +3019,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"signTransactionXdrLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SignTransactionXdrLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SignTransactionXdrLocalArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SignTransactionXdrLocalArg)(nil), args)
@@ -3034,11 +3034,11 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 			},
 			"getStaticConfigLocal": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]GetStaticConfigLocalArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.GetStaticConfigLocal(ctx)
 					return
 				},
@@ -3053,422 +3053,422 @@ type LocalClient struct {
 
 func (c LocalClient) GetWalletAccountsLocal(ctx context.Context, sessionID int) (res []WalletAccountLocal, err error) {
 	__arg := GetWalletAccountsLocalArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "stellar.1.local.getWalletAccountsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getWalletAccountsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetWalletAccountLocal(ctx context.Context, __arg GetWalletAccountLocalArg) (res WalletAccountLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getWalletAccountLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getWalletAccountLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetAccountAssetsLocal(ctx context.Context, __arg GetAccountAssetsLocalArg) (res []AccountAssetLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getAccountAssetsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getAccountAssetsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetPaymentsLocal(ctx context.Context, __arg GetPaymentsLocalArg) (res PaymentsPageLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getPaymentsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getPaymentsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetPendingPaymentsLocal(ctx context.Context, __arg GetPendingPaymentsLocalArg) (res []PaymentOrErrorLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getPendingPaymentsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getPendingPaymentsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) MarkAsReadLocal(ctx context.Context, __arg MarkAsReadLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.markAsReadLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.markAsReadLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetPaymentDetailsLocal(ctx context.Context, __arg GetPaymentDetailsLocalArg) (res PaymentDetailsLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getPaymentDetailsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getPaymentDetailsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetGenericPaymentDetailsLocal(ctx context.Context, __arg GetGenericPaymentDetailsLocalArg) (res PaymentDetailsLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getGenericPaymentDetailsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getGenericPaymentDetailsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetDisplayCurrenciesLocal(ctx context.Context, sessionID int) (res []CurrencyLocal, err error) {
 	__arg := GetDisplayCurrenciesLocalArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "stellar.1.local.getDisplayCurrenciesLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getDisplayCurrenciesLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ValidateAccountIDLocal(ctx context.Context, __arg ValidateAccountIDLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.validateAccountIDLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.validateAccountIDLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ValidateSecretKeyLocal(ctx context.Context, __arg ValidateSecretKeyLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.validateSecretKeyLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.validateSecretKeyLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ValidateAccountNameLocal(ctx context.Context, __arg ValidateAccountNameLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.validateAccountNameLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.validateAccountNameLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ChangeWalletAccountNameLocal(ctx context.Context, __arg ChangeWalletAccountNameLocalArg) (res WalletAccountLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.changeWalletAccountNameLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.changeWalletAccountNameLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetWalletAccountAsDefaultLocal(ctx context.Context, __arg SetWalletAccountAsDefaultLocalArg) (res []WalletAccountLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.setWalletAccountAsDefaultLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.setWalletAccountAsDefaultLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) DeleteWalletAccountLocal(ctx context.Context, __arg DeleteWalletAccountLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.deleteWalletAccountLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.deleteWalletAccountLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) LinkNewWalletAccountLocal(ctx context.Context, __arg LinkNewWalletAccountLocalArg) (res AccountID, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.linkNewWalletAccountLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.linkNewWalletAccountLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) CreateWalletAccountLocal(ctx context.Context, __arg CreateWalletAccountLocalArg) (res AccountID, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.createWalletAccountLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.createWalletAccountLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ChangeDisplayCurrencyLocal(ctx context.Context, __arg ChangeDisplayCurrencyLocalArg) (res CurrencyLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.changeDisplayCurrencyLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.changeDisplayCurrencyLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetDisplayCurrencyLocal(ctx context.Context, __arg GetDisplayCurrencyLocalArg) (res CurrencyLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getDisplayCurrencyLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getDisplayCurrencyLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) HasAcceptedDisclaimerLocal(ctx context.Context, sessionID int) (res bool, err error) {
 	__arg := HasAcceptedDisclaimerLocalArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "stellar.1.local.hasAcceptedDisclaimerLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.hasAcceptedDisclaimerLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AcceptDisclaimerLocal(ctx context.Context, sessionID int) (err error) {
 	__arg := AcceptDisclaimerLocalArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "stellar.1.local.acceptDisclaimerLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.acceptDisclaimerLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetWalletAccountPublicKeyLocal(ctx context.Context, __arg GetWalletAccountPublicKeyLocalArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getWalletAccountPublicKeyLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getWalletAccountPublicKeyLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetWalletAccountSecretKeyLocal(ctx context.Context, __arg GetWalletAccountSecretKeyLocalArg) (res SecretKey, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getWalletAccountSecretKeyLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getWalletAccountSecretKeyLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetSendAssetChoicesLocal(ctx context.Context, __arg GetSendAssetChoicesLocalArg) (res []SendAssetChoiceLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getSendAssetChoicesLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getSendAssetChoicesLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) StartBuildPaymentLocal(ctx context.Context, sessionID int) (res BuildPaymentID, err error) {
 	__arg := StartBuildPaymentLocalArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "stellar.1.local.startBuildPaymentLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.startBuildPaymentLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) StopBuildPaymentLocal(ctx context.Context, __arg StopBuildPaymentLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.stopBuildPaymentLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.stopBuildPaymentLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) BuildPaymentLocal(ctx context.Context, __arg BuildPaymentLocalArg) (res BuildPaymentResLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.buildPaymentLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.buildPaymentLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ReviewPaymentLocal(ctx context.Context, __arg ReviewPaymentLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.reviewPaymentLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.reviewPaymentLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SendPaymentLocal(ctx context.Context, __arg SendPaymentLocalArg) (res SendPaymentResLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.sendPaymentLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.sendPaymentLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SendPathLocal(ctx context.Context, __arg SendPathLocalArg) (res SendPaymentResLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.sendPathLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.sendPathLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) BuildRequestLocal(ctx context.Context, __arg BuildRequestLocalArg) (res BuildRequestResLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.buildRequestLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.buildRequestLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetRequestDetailsLocal(ctx context.Context, __arg GetRequestDetailsLocalArg) (res RequestDetailsLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getRequestDetailsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getRequestDetailsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) CancelRequestLocal(ctx context.Context, __arg CancelRequestLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.cancelRequestLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.cancelRequestLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) MakeRequestLocal(ctx context.Context, __arg MakeRequestLocalArg) (res KeybaseRequestID, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.makeRequestLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.makeRequestLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetAccountMobileOnlyLocal(ctx context.Context, __arg SetAccountMobileOnlyLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.setAccountMobileOnlyLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.setAccountMobileOnlyLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetAccountAllDevicesLocal(ctx context.Context, __arg SetAccountAllDevicesLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.setAccountAllDevicesLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.setAccountAllDevicesLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) IsAccountMobileOnlyLocal(ctx context.Context, __arg IsAccountMobileOnlyLocalArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.isAccountMobileOnlyLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.isAccountMobileOnlyLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) CancelPaymentLocal(ctx context.Context, __arg CancelPaymentLocalArg) (res RelayClaimResult, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.cancelPaymentLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.cancelPaymentLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetPredefinedInflationDestinationsLocal(ctx context.Context, sessionID int) (res []PredefinedInflationDestination, err error) {
 	__arg := GetPredefinedInflationDestinationsLocalArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "stellar.1.local.getPredefinedInflationDestinationsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getPredefinedInflationDestinationsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetInflationDestinationLocal(ctx context.Context, __arg SetInflationDestinationLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.setInflationDestinationLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.setInflationDestinationLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetInflationDestinationLocal(ctx context.Context, __arg GetInflationDestinationLocalArg) (res InflationDestinationResultLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getInflationDestinationLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getInflationDestinationLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AirdropDetailsLocal(ctx context.Context, sessionID int) (res AirdropDetails, err error) {
 	__arg := AirdropDetailsLocalArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "stellar.1.local.airdropDetailsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.airdropDetailsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AirdropStatusLocal(ctx context.Context, sessionID int) (res AirdropStatus, err error) {
 	__arg := AirdropStatusLocalArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "stellar.1.local.airdropStatusLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.airdropStatusLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AirdropRegisterLocal(ctx context.Context, __arg AirdropRegisterLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.airdropRegisterLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.airdropRegisterLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) FuzzyAssetSearchLocal(ctx context.Context, __arg FuzzyAssetSearchLocalArg) (res []Asset, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.fuzzyAssetSearchLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.fuzzyAssetSearchLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ListPopularAssetsLocal(ctx context.Context, sessionID int) (res AssetListResult, err error) {
 	__arg := ListPopularAssetsLocalArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "stellar.1.local.listPopularAssetsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.listPopularAssetsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AddTrustlineLocal(ctx context.Context, __arg AddTrustlineLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.addTrustlineLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.addTrustlineLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) DeleteTrustlineLocal(ctx context.Context, __arg DeleteTrustlineLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.deleteTrustlineLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.deleteTrustlineLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ChangeTrustlineLimitLocal(ctx context.Context, __arg ChangeTrustlineLimitLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.changeTrustlineLimitLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.changeTrustlineLimitLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetTrustlinesLocal(ctx context.Context, __arg GetTrustlinesLocalArg) (res []Balance, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getTrustlinesLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getTrustlinesLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetTrustlinesForRecipientLocal(ctx context.Context, __arg GetTrustlinesForRecipientLocalArg) (res RecipientTrustlinesLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getTrustlinesForRecipientLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getTrustlinesForRecipientLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) FindPaymentPathLocal(ctx context.Context, __arg FindPaymentPathLocalArg) (res PaymentPathLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.findPaymentPathLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.findPaymentPathLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AssetDepositLocal(ctx context.Context, __arg AssetDepositLocalArg) (res AssetActionResultLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.assetDepositLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.assetDepositLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AssetWithdrawLocal(ctx context.Context, __arg AssetWithdrawLocalArg) (res AssetActionResultLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.assetWithdrawLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.assetWithdrawLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) BalancesLocal(ctx context.Context, accountID AccountID) (res []Balance, err error) {
 	__arg := BalancesLocalArg{AccountID: accountID}
-	err = c.Cli.Call(ctx, "stellar.1.local.balancesLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.balancesLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SendCLILocal(ctx context.Context, __arg SendCLILocalArg) (res SendResultCLILocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.sendCLILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.sendCLILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SendPathCLILocal(ctx context.Context, __arg SendPathCLILocalArg) (res SendResultCLILocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.sendPathCLILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.sendPathCLILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) AccountMergeCLILocal(ctx context.Context, __arg AccountMergeCLILocalArg) (res TransactionID, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.accountMergeCLILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.accountMergeCLILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ClaimCLILocal(ctx context.Context, __arg ClaimCLILocalArg) (res RelayClaimResult, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.claimCLILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.claimCLILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) RecentPaymentsCLILocal(ctx context.Context, accountID *AccountID) (res []PaymentOrErrorCLILocal, err error) {
 	__arg := RecentPaymentsCLILocalArg{AccountID: accountID}
-	err = c.Cli.Call(ctx, "stellar.1.local.recentPaymentsCLILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.recentPaymentsCLILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PaymentDetailCLILocal(ctx context.Context, txID string) (res PaymentCLILocal, err error) {
 	__arg := PaymentDetailCLILocalArg{TxID: txID}
-	err = c.Cli.Call(ctx, "stellar.1.local.paymentDetailCLILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.paymentDetailCLILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) WalletInitLocal(ctx context.Context) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.walletInitLocal", []interface{}{WalletInitLocalArg{}}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.walletInitLocal", []any{WalletInitLocalArg{}}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) WalletDumpLocal(ctx context.Context) (res Bundle, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.walletDumpLocal", []interface{}{WalletDumpLocalArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.walletDumpLocal", []any{WalletDumpLocalArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) WalletGetAccountsCLILocal(ctx context.Context) (res []OwnAccountCLILocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.walletGetAccountsCLILocal", []interface{}{WalletGetAccountsCLILocalArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.walletGetAccountsCLILocal", []any{WalletGetAccountsCLILocalArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) OwnAccountLocal(ctx context.Context, accountID AccountID) (res bool, err error) {
 	__arg := OwnAccountLocalArg{AccountID: accountID}
-	err = c.Cli.Call(ctx, "stellar.1.local.ownAccountLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.ownAccountLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ImportSecretKeyLocal(ctx context.Context, __arg ImportSecretKeyLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.importSecretKeyLocal", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.importSecretKeyLocal", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ExportSecretKeyLocal(ctx context.Context, accountID AccountID) (res SecretKey, err error) {
 	__arg := ExportSecretKeyLocalArg{AccountID: accountID}
-	err = c.Cli.Call(ctx, "stellar.1.local.exportSecretKeyLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.exportSecretKeyLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SetDisplayCurrency(ctx context.Context, __arg SetDisplayCurrencyArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.setDisplayCurrency", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.setDisplayCurrency", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ExchangeRateLocal(ctx context.Context, currency OutsideCurrencyCode) (res OutsideExchangeRate, err error) {
 	__arg := ExchangeRateLocalArg{Currency: currency}
-	err = c.Cli.Call(ctx, "stellar.1.local.exchangeRateLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.exchangeRateLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetAvailableLocalCurrencies(ctx context.Context) (res map[OutsideCurrencyCode]OutsideCurrencyDefinition, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getAvailableLocalCurrencies", []interface{}{GetAvailableLocalCurrenciesArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getAvailableLocalCurrencies", []any{GetAvailableLocalCurrenciesArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) FormatLocalCurrencyString(ctx context.Context, __arg FormatLocalCurrencyStringArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.formatLocalCurrencyString", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.formatLocalCurrencyString", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) MakeRequestCLILocal(ctx context.Context, __arg MakeRequestCLILocalArg) (res KeybaseRequestID, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.makeRequestCLILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.makeRequestCLILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) LookupCLILocal(ctx context.Context, name string) (res LookupResultCLILocal, err error) {
 	__arg := LookupCLILocalArg{Name: name}
-	err = c.Cli.Call(ctx, "stellar.1.local.lookupCLILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.lookupCLILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) BatchLocal(ctx context.Context, __arg BatchLocalArg) (res BatchResultLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.batchLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.batchLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ValidateStellarURILocal(ctx context.Context, __arg ValidateStellarURILocalArg) (res ValidateStellarURIResultLocal, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.validateStellarURILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.validateStellarURILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ApproveTxURILocal(ctx context.Context, __arg ApproveTxURILocalArg) (res TransactionID, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.approveTxURILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.approveTxURILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ApprovePayURILocal(ctx context.Context, __arg ApprovePayURILocalArg) (res TransactionID, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.approvePayURILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.approvePayURILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) ApprovePathURILocal(ctx context.Context, __arg ApprovePathURILocalArg) (res TransactionID, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.approvePathURILocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.approvePathURILocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetPartnerUrlsLocal(ctx context.Context, sessionID int) (res []PartnerUrl, err error) {
 	__arg := GetPartnerUrlsLocalArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "stellar.1.local.getPartnerUrlsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getPartnerUrlsLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) SignTransactionXdrLocal(ctx context.Context, __arg SignTransactionXdrLocalArg) (res SignXdrResult, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.signTransactionXdrLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.signTransactionXdrLocal", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c LocalClient) GetStaticConfigLocal(ctx context.Context) (res StaticConfig, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.getStaticConfigLocal", []interface{}{GetStaticConfigLocalArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.local.getStaticConfigLocal", []any{GetStaticConfigLocalArg{}}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/stellar1/notify.go
+++ b/go/protocol/stellar1/notify.go
@@ -57,11 +57,11 @@ func NotifyProtocol(i NotifyInterface) rpc.Protocol {
 		Name: "stellar.1.notify",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"paymentNotification": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PaymentNotificationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PaymentNotificationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PaymentNotificationArg)(nil), args)
@@ -72,11 +72,11 @@ func NotifyProtocol(i NotifyInterface) rpc.Protocol {
 				},
 			},
 			"paymentStatusNotification": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PaymentStatusNotificationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PaymentStatusNotificationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PaymentStatusNotificationArg)(nil), args)
@@ -87,11 +87,11 @@ func NotifyProtocol(i NotifyInterface) rpc.Protocol {
 				},
 			},
 			"requestStatusNotification": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RequestStatusNotificationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RequestStatusNotificationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RequestStatusNotificationArg)(nil), args)
@@ -102,11 +102,11 @@ func NotifyProtocol(i NotifyInterface) rpc.Protocol {
 				},
 			},
 			"accountDetailsUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AccountDetailsUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AccountDetailsUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AccountDetailsUpdateArg)(nil), args)
@@ -117,11 +117,11 @@ func NotifyProtocol(i NotifyInterface) rpc.Protocol {
 				},
 			},
 			"accountsUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AccountsUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AccountsUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AccountsUpdateArg)(nil), args)
@@ -132,11 +132,11 @@ func NotifyProtocol(i NotifyInterface) rpc.Protocol {
 				},
 			},
 			"pendingPaymentsUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PendingPaymentsUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PendingPaymentsUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PendingPaymentsUpdateArg)(nil), args)
@@ -147,11 +147,11 @@ func NotifyProtocol(i NotifyInterface) rpc.Protocol {
 				},
 			},
 			"recentPaymentsUpdate": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RecentPaymentsUpdateArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RecentPaymentsUpdateArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RecentPaymentsUpdateArg)(nil), args)
@@ -170,38 +170,38 @@ type NotifyClient struct {
 }
 
 func (c NotifyClient) PaymentNotification(ctx context.Context, __arg PaymentNotificationArg) (err error) {
-	err = c.Cli.Notify(ctx, "stellar.1.notify.paymentNotification", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "stellar.1.notify.paymentNotification", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyClient) PaymentStatusNotification(ctx context.Context, __arg PaymentStatusNotificationArg) (err error) {
-	err = c.Cli.Notify(ctx, "stellar.1.notify.paymentStatusNotification", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "stellar.1.notify.paymentStatusNotification", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyClient) RequestStatusNotification(ctx context.Context, reqID KeybaseRequestID) (err error) {
 	__arg := RequestStatusNotificationArg{ReqID: reqID}
-	err = c.Cli.Notify(ctx, "stellar.1.notify.requestStatusNotification", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "stellar.1.notify.requestStatusNotification", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyClient) AccountDetailsUpdate(ctx context.Context, __arg AccountDetailsUpdateArg) (err error) {
-	err = c.Cli.Notify(ctx, "stellar.1.notify.accountDetailsUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "stellar.1.notify.accountDetailsUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyClient) AccountsUpdate(ctx context.Context, accounts []WalletAccountLocal) (err error) {
 	__arg := AccountsUpdateArg{Accounts: accounts}
-	err = c.Cli.Notify(ctx, "stellar.1.notify.accountsUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "stellar.1.notify.accountsUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyClient) PendingPaymentsUpdate(ctx context.Context, __arg PendingPaymentsUpdateArg) (err error) {
-	err = c.Cli.Notify(ctx, "stellar.1.notify.pendingPaymentsUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "stellar.1.notify.pendingPaymentsUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }
 
 func (c NotifyClient) RecentPaymentsUpdate(ctx context.Context, __arg RecentPaymentsUpdateArg) (err error) {
-	err = c.Cli.Notify(ctx, "stellar.1.notify.recentPaymentsUpdate", []interface{}{__arg}, 0*time.Millisecond)
+	err = c.Cli.Notify(ctx, "stellar.1.notify.recentPaymentsUpdate", []any{__arg}, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/stellar1/remote.go
+++ b/go/protocol/stellar1/remote.go
@@ -1106,11 +1106,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 		Name: "stellar.1.remote",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"balances": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]BalancesArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]BalancesArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]BalancesArg)(nil), args)
@@ -1121,11 +1121,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"details": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DetailsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DetailsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DetailsArg)(nil), args)
@@ -1136,11 +1136,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"recentPayments": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RecentPaymentsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RecentPaymentsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RecentPaymentsArg)(nil), args)
@@ -1151,11 +1151,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"pendingPayments": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PendingPaymentsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PendingPaymentsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PendingPaymentsArg)(nil), args)
@@ -1166,11 +1166,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"markAsRead": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]MarkAsReadArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]MarkAsReadArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]MarkAsReadArg)(nil), args)
@@ -1181,11 +1181,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"paymentDetails": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PaymentDetailsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PaymentDetailsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PaymentDetailsArg)(nil), args)
@@ -1196,11 +1196,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"accountSeqno": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AccountSeqnoArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AccountSeqnoArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AccountSeqnoArg)(nil), args)
@@ -1211,11 +1211,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"submitPayment": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SubmitPaymentArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SubmitPaymentArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SubmitPaymentArg)(nil), args)
@@ -1226,11 +1226,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"submitRelayPayment": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SubmitRelayPaymentArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SubmitRelayPaymentArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SubmitRelayPaymentArg)(nil), args)
@@ -1241,11 +1241,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"submitRelayClaim": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SubmitRelayClaimArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SubmitRelayClaimArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SubmitRelayClaimArg)(nil), args)
@@ -1256,11 +1256,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"submitPathPayment": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SubmitPathPaymentArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SubmitPathPaymentArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SubmitPathPaymentArg)(nil), args)
@@ -1271,11 +1271,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"submitMultiPayment": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SubmitMultiPaymentArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SubmitMultiPaymentArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SubmitMultiPaymentArg)(nil), args)
@@ -1286,11 +1286,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"acquireAutoClaimLock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AcquireAutoClaimLockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AcquireAutoClaimLockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AcquireAutoClaimLockArg)(nil), args)
@@ -1301,11 +1301,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"releaseAutoClaimLock": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ReleaseAutoClaimLockArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ReleaseAutoClaimLockArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ReleaseAutoClaimLockArg)(nil), args)
@@ -1316,11 +1316,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"nextAutoClaim": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NextAutoClaimArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NextAutoClaimArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NextAutoClaimArg)(nil), args)
@@ -1331,11 +1331,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"isMasterKeyActive": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]IsMasterKeyActiveArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]IsMasterKeyActiveArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]IsMasterKeyActiveArg)(nil), args)
@@ -1346,11 +1346,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"submitRequest": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SubmitRequestArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SubmitRequestArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SubmitRequestArg)(nil), args)
@@ -1361,11 +1361,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"requestDetails": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]RequestDetailsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]RequestDetailsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]RequestDetailsArg)(nil), args)
@@ -1376,11 +1376,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"cancelRequest": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]CancelRequestArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]CancelRequestArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]CancelRequestArg)(nil), args)
@@ -1391,11 +1391,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"setInflationDestination": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]SetInflationDestinationArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]SetInflationDestinationArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]SetInflationDestinationArg)(nil), args)
@@ -1406,21 +1406,21 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"ping": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PingArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					ret, err = i.Ping(ctx)
 					return
 				},
 			},
 			"networkOptions": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]NetworkOptionsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]NetworkOptionsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]NetworkOptionsArg)(nil), args)
@@ -1431,11 +1431,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"detailsPlusPayments": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]DetailsPlusPaymentsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]DetailsPlusPaymentsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]DetailsPlusPaymentsArg)(nil), args)
@@ -1446,11 +1446,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"allDetailsPlusPayments": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AllDetailsPlusPaymentsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AllDetailsPlusPaymentsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AllDetailsPlusPaymentsArg)(nil), args)
@@ -1461,11 +1461,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"assetSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]AssetSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]AssetSearchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]AssetSearchArg)(nil), args)
@@ -1476,11 +1476,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"fuzzyAssetSearch": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FuzzyAssetSearchArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FuzzyAssetSearchArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FuzzyAssetSearchArg)(nil), args)
@@ -1491,11 +1491,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"listPopularAssets": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ListPopularAssetsArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ListPopularAssetsArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ListPopularAssetsArg)(nil), args)
@@ -1506,11 +1506,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"changeTrustline": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]ChangeTrustlineArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]ChangeTrustlineArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]ChangeTrustlineArg)(nil), args)
@@ -1521,11 +1521,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"findPaymentPath": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]FindPaymentPathArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]FindPaymentPathArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]FindPaymentPathArg)(nil), args)
@@ -1536,11 +1536,11 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 			},
 			"postAnyTransaction": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PostAnyTransactionArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PostAnyTransactionArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PostAnyTransactionArg)(nil), args)
@@ -1559,156 +1559,156 @@ type RemoteClient struct {
 }
 
 func (c RemoteClient) Balances(ctx context.Context, __arg BalancesArg) (res []Balance, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.balances", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.balances", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) Details(ctx context.Context, __arg DetailsArg) (res AccountDetails, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.details", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.details", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) RecentPayments(ctx context.Context, __arg RecentPaymentsArg) (res PaymentsPage, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.recentPayments", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.recentPayments", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) PendingPayments(ctx context.Context, __arg PendingPaymentsArg) (res []PaymentSummary, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.pendingPayments", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.pendingPayments", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) MarkAsRead(ctx context.Context, __arg MarkAsReadArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.markAsRead", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.markAsRead", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) PaymentDetails(ctx context.Context, __arg PaymentDetailsArg) (res PaymentDetails, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.paymentDetails", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.paymentDetails", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) AccountSeqno(ctx context.Context, __arg AccountSeqnoArg) (res string, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.accountSeqno", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.accountSeqno", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SubmitPayment(ctx context.Context, __arg SubmitPaymentArg) (res PaymentResult, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.submitPayment", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.submitPayment", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SubmitRelayPayment(ctx context.Context, __arg SubmitRelayPaymentArg) (res PaymentResult, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.submitRelayPayment", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.submitRelayPayment", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SubmitRelayClaim(ctx context.Context, __arg SubmitRelayClaimArg) (res RelayClaimResult, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.submitRelayClaim", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.submitRelayClaim", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SubmitPathPayment(ctx context.Context, __arg SubmitPathPaymentArg) (res PaymentResult, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.submitPathPayment", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.submitPathPayment", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SubmitMultiPayment(ctx context.Context, __arg SubmitMultiPaymentArg) (res SubmitMultiRes, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.submitMultiPayment", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.submitMultiPayment", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) AcquireAutoClaimLock(ctx context.Context, caller keybase1.UserVersion) (res string, err error) {
 	__arg := AcquireAutoClaimLockArg{Caller: caller}
-	err = c.Cli.Call(ctx, "stellar.1.remote.acquireAutoClaimLock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.acquireAutoClaimLock", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) ReleaseAutoClaimLock(ctx context.Context, __arg ReleaseAutoClaimLockArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.releaseAutoClaimLock", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.releaseAutoClaimLock", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) NextAutoClaim(ctx context.Context, caller keybase1.UserVersion) (res *AutoClaim, err error) {
 	__arg := NextAutoClaimArg{Caller: caller}
-	err = c.Cli.Call(ctx, "stellar.1.remote.nextAutoClaim", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.nextAutoClaim", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) IsMasterKeyActive(ctx context.Context, __arg IsMasterKeyActiveArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.isMasterKeyActive", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.isMasterKeyActive", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SubmitRequest(ctx context.Context, __arg SubmitRequestArg) (res KeybaseRequestID, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.submitRequest", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.submitRequest", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) RequestDetails(ctx context.Context, __arg RequestDetailsArg) (res RequestDetails, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.requestDetails", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.requestDetails", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) CancelRequest(ctx context.Context, __arg CancelRequestArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.cancelRequest", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.cancelRequest", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) SetInflationDestination(ctx context.Context, __arg SetInflationDestinationArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.setInflationDestination", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.setInflationDestination", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) Ping(ctx context.Context) (res string, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.ping", []interface{}{PingArg{}}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.ping", []any{PingArg{}}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) NetworkOptions(ctx context.Context, caller keybase1.UserVersion) (res NetworkOptions, err error) {
 	__arg := NetworkOptionsArg{Caller: caller}
-	err = c.Cli.Call(ctx, "stellar.1.remote.networkOptions", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.networkOptions", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) DetailsPlusPayments(ctx context.Context, __arg DetailsPlusPaymentsArg) (res DetailsPlusPayments, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.detailsPlusPayments", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.detailsPlusPayments", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) AllDetailsPlusPayments(ctx context.Context, caller keybase1.UserVersion) (res []DetailsPlusPayments, err error) {
 	__arg := AllDetailsPlusPaymentsArg{Caller: caller}
-	err = c.Cli.Call(ctx, "stellar.1.remote.allDetailsPlusPayments", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.allDetailsPlusPayments", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) AssetSearch(ctx context.Context, __arg AssetSearchArg) (res []Asset, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.assetSearch", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.assetSearch", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) FuzzyAssetSearch(ctx context.Context, __arg FuzzyAssetSearchArg) (res []Asset, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.fuzzyAssetSearch", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.fuzzyAssetSearch", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) ListPopularAssets(ctx context.Context, caller keybase1.UserVersion) (res AssetListResult, err error) {
 	__arg := ListPopularAssetsArg{Caller: caller}
-	err = c.Cli.Call(ctx, "stellar.1.remote.listPopularAssets", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.listPopularAssets", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) ChangeTrustline(ctx context.Context, __arg ChangeTrustlineArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.changeTrustline", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.changeTrustline", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) FindPaymentPath(ctx context.Context, __arg FindPaymentPathArg) (res PaymentPath, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.findPaymentPath", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.findPaymentPath", []any{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
 func (c RemoteClient) PostAnyTransaction(ctx context.Context, __arg PostAnyTransactionArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.postAnyTransaction", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.remote.postAnyTransaction", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/stellar1/ui.go
+++ b/go/protocol/stellar1/ui.go
@@ -51,11 +51,11 @@ func UiProtocol(i UiInterface) rpc.Protocol {
 		Name: "stellar.1.ui",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"paymentReviewed": {
-				MakeArg: func() interface{} {
+				MakeArg: func() any {
 					var ret [1]PaymentReviewedArg
 					return &ret
 				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+				Handler: func(ctx context.Context, args any) (ret any, err error) {
 					typedArgs, ok := args.(*[1]PaymentReviewedArg)
 					if !ok {
 						err = rpc.NewTypeError((*[1]PaymentReviewedArg)(nil), args)
@@ -74,6 +74,6 @@ type UiClient struct {
 }
 
 func (c UiClient) PaymentReviewed(ctx context.Context, __arg PaymentReviewedArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.ui.paymentReviewed", []interface{}{__arg}, nil, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "stellar.1.ui.paymentReviewed", []any{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/pvl/debug.go
+++ b/go/pvl/debug.go
@@ -23,7 +23,7 @@ func (m metaContext) getStubDNS() *stubDNSEngine {
 	return m.stubDNS
 }
 
-func debugWithState(m metaContext, state scriptState, format string, arg ...interface{}) {
+func debugWithState(m metaContext, state scriptState, format string, arg ...any) {
 	s := fmt.Sprintf(format, arg...)
 	m.Debug("PVL @(service:%v script:%v pc:%v) %v",
 		debugServiceToString(state.Service), state.WhichScript, state.PC, s)
@@ -34,13 +34,13 @@ func debugWithStateError(m metaContext, state scriptState, err libkb.ProofError)
 		debugServiceToString(state.Service), state.WhichScript, state.PC, err.GetProofStatus(), err.GetDesc())
 }
 
-func debugWithPosition(m metaContext, service keybase1.ProofType, whichscript int, pc int, format string, arg ...interface{}) {
+func debugWithPosition(m metaContext, service keybase1.ProofType, whichscript int, pc int, format string, arg ...any) {
 	s := fmt.Sprintf(format, arg...)
 	m.Debug("PVL @(service:%v script:%v pc:%v) %v",
 		debugServiceToString(service), whichscript, pc, s)
 }
 
-func debug(m metaContext, format string, arg ...interface{}) {
+func debug(m metaContext, format string, arg ...any) {
 	s := fmt.Sprintf(format, arg...)
 	m.Debug("PVL %v", s)
 }

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -326,7 +326,7 @@ func validateScript(m metaContext, script *scriptT, service keybase1.ProofType, 
 	// Does not validate each instruction's format. (That is done when running it)
 	// Validate each instruction's "error" field.
 
-	logerr := func(m metaContext, service keybase1.ProofType, whichscript int, pc int, format string, arg ...interface{}) libkb.ProofError {
+	logerr := func(m metaContext, service keybase1.ProofType, whichscript int, pc int, format string, arg ...any) libkb.ProofError {
 		debugWithPosition(m, service, whichscript, pc, format, arg...)
 		return libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL, format, arg...)
 	}
@@ -1013,7 +1013,7 @@ func runCSSSelectorInner(m metaContext, html *goquery.Selection,
 
 func runSelectorJSONInner(m metaContext, state scriptState, selectedObject *jsonw.Wrapper,
 	selectors []keybase1.SelectorEntry) ([]string, libkb.ProofError) {
-	logger := func(format string, args ...interface{}) {
+	logger := func(format string, args ...any) {
 		debugWithState(m, state, format, args)
 	}
 	jsonResults, perr := jsonhelpers.AtSelectorPath(selectedObject, selectors, logger, libkb.NewInvalidPVLSelectorError)

--- a/go/pvl/interp_test.go
+++ b/go/pvl/interp_test.go
@@ -2038,13 +2038,13 @@ func TestUnits(t *testing.T) {
 	}
 }
 
-type failer func(string, ...interface{})
+type failer func(string, ...any)
 
 func runPvlTest(t *testing.T, unit *interpUnitTest) {
 	tc := libkb.SetupTest(t, unit.name, 1)
 	defer tc.Cleanup()
 
-	fail := func(f string, arg ...interface{}) {
+	fail := func(f string, arg ...any) {
 		f2 := fmt.Sprintf("[%v] ", unit.name) + f
 		t.Fatalf(f2, arg...)
 	}

--- a/go/pvl/registers_test.go
+++ b/go/pvl/registers_test.go
@@ -55,7 +55,7 @@ func TestNamedRegsStore(t *testing.T) {
 		var res string
 		useRes := false
 
-		fail := func(f string, args ...interface{}) {
+		fail := func(f string, args ...any) {
 			prefix := fmt.Sprintf("[%v] ", i)
 			t.Fatalf(prefix+f, args...)
 		}

--- a/go/runtimestats/stats.go
+++ b/go/runtimestats/stats.go
@@ -38,7 +38,7 @@ func NewRunner(g *globals.Context) *Runner {
 	return r
 }
 
-func (r *Runner) debug(ctx context.Context, msg string, args ...interface{}) {
+func (r *Runner) debug(ctx context.Context, msg string, args ...any) {
 	r.G().Log.CDebugf(ctx, "RuntimeStats.Runner: %s", fmt.Sprintf(msg, args...))
 }
 

--- a/go/service/apiserver.go
+++ b/go/service/apiserver.go
@@ -134,7 +134,7 @@ func (a *APIServerHandler) doPostJSON(mctx libkb.MetaContext, rawarg keybase1.Po
 	arg := a.setupArg(rawarg)
 	jsonPayload := make(libkb.JSONPayload)
 	for _, kvpair := range rawarg.JSONPayload {
-		var value interface{}
+		var value any
 		err = jsonw.EnsureMaxDepthBytesDefault([]byte(kvpair.Value))
 		if err != nil {
 			return keybase1.APIRes{}, err

--- a/go/service/canceling.go
+++ b/go/service/canceling.go
@@ -14,7 +14,7 @@ func CancelingProtocol(g *libkb.GlobalContext, prot rpc.Protocol, reason libkb.R
 		var newDesc rpc.ServeHandlerDescription
 		desc := ldesc
 		newDesc.MakeArg = desc.MakeArg
-		newDesc.Handler = func(ctx context.Context, arg interface{}) (interface{}, error) {
+		newDesc.Handler = func(ctx context.Context, arg any) (any, error) {
 			var ctxID libkb.RPCCancelerKey
 			ctx, ctxID = g.RPCCanceler.RegisterContext(ctx, reason)
 			defer g.RPCCanceler.UnregisterContext(ctxID)

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -56,7 +56,7 @@ func (h ConfigHandler) GetValue(ctx context.Context, path string) (ret keybase1.
 }
 
 func (h ConfigHandler) getValue(_ context.Context, path string, reader libkb.JSONReader) (ret keybase1.ConfigValue, err error) {
-	var i interface{}
+	var i any
 	i, err = reader.GetInterfaceAtPath(path)
 	if err != nil {
 		return ret, err

--- a/go/service/debugging.go
+++ b/go/service/debugging.go
@@ -37,7 +37,7 @@ func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (
 	m := libkb.NewMetaContext(ctx, t.G())
 	defer m.Trace(fmt.Sprintf("Script(%s)", arg.Script), &err)()
 	args := arg.Args
-	log := func(format string, args ...interface{}) {
+	log := func(format string, args ...any) {
 		t.G().Log.CInfof(ctx, format, args...)
 	}
 	defer time.Sleep(100 * time.Millisecond) // Without this CInfof often doesn't reach the CLI
@@ -93,7 +93,7 @@ func (t *DebuggingHandler) FirstStep(ctx context.Context, arg keybase1.FirstStep
 	client := t.rpcClient()
 	cbArg := keybase1.SecondStepArg{Val: arg.Val + 1, SessionID: arg.SessionID}
 	var cbReply int
-	err = client.Call(ctx, "keybase.1.debugging.secondStep", []interface{}{cbArg}, &cbReply, 0)
+	err = client.Call(ctx, "keybase.1.debugging.secondStep", []any{cbArg}, &cbReply, 0)
 	if err != nil {
 		return
 	}

--- a/go/service/debugging_devel.go
+++ b/go/service/debugging_devel.go
@@ -33,7 +33,7 @@ func (t *DebuggingHandler) scriptExtras(ctx context.Context, arg keybase1.Script
 	ctx = libkb.WithLogTag(ctx, "DG")
 	m := libkb.NewMetaContext(ctx, t.G())
 	args := arg.Args
-	log := func(format string, args ...interface{}) {
+	log := func(format string, args ...any) {
 		t.G().Log.CInfof(ctx, format, args...)
 	}
 	defer time.Sleep(100 * time.Millisecond) // Without this CInfof often doesn't reach the CLI

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -410,15 +410,15 @@ func (g *gregorHandler) getRPCCli() rpc.GenericClient {
 	return g.cli
 }
 
-func (g *gregorHandler) Debug(ctx context.Context, s string, args ...interface{}) {
+func (g *gregorHandler) Debug(ctx context.Context, s string, args ...any) {
 	g.G().Log.CloneWithAddedDepth(1).CDebugf(ctx, "PushHandler: "+s, args...)
 }
 
-func (g *gregorHandler) Warning(ctx context.Context, s string, args ...interface{}) {
+func (g *gregorHandler) Warning(ctx context.Context, s string, args ...any) {
 	g.G().Log.CloneWithAddedDepth(1).CWarningf(ctx, "PushHandler: "+s, args...)
 }
 
-func (g *gregorHandler) Errorf(ctx context.Context, s string, args ...interface{}) {
+func (g *gregorHandler) Errorf(ctx context.Context, s string, args ...any) {
 	g.G().Log.CloneWithAddedDepth(1).CErrorf(ctx, "PushHandler: "+s, args...)
 }
 
@@ -1901,8 +1901,8 @@ type timeoutClient struct {
 
 var _ rpc.GenericClient = (*timeoutClient)(nil)
 
-func (t *timeoutClient) Call(ctx context.Context, method string, arg interface{},
-	res interface{}, timeout time.Duration) error {
+func (t *timeoutClient) Call(ctx context.Context, method string, arg any,
+	res any, timeout time.Duration) error {
 	if timeout == 0 {
 		timeout = t.timeout
 	}
@@ -1913,8 +1913,8 @@ func (t *timeoutClient) Call(ctx context.Context, method string, arg interface{}
 	return err
 }
 
-func (t *timeoutClient) CallCompressed(ctx context.Context, method string, arg interface{},
-	res interface{}, ctype rpc.CompressionType, timeout time.Duration) error {
+func (t *timeoutClient) CallCompressed(ctx context.Context, method string, arg any,
+	res any, ctype rpc.CompressionType, timeout time.Duration) error {
 	if timeout == 0 {
 		timeout = t.timeout
 	}
@@ -1925,7 +1925,7 @@ func (t *timeoutClient) CallCompressed(ctx context.Context, method string, arg i
 	return err
 }
 
-func (t *timeoutClient) Notify(ctx context.Context, method string, arg interface{}, timeout time.Duration) error {
+func (t *timeoutClient) Notify(ctx context.Context, method string, arg any, timeout time.Duration) error {
 	if timeout == 0 {
 		timeout = t.timeout
 	}

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -75,7 +75,7 @@ func (h *IdentifyHandler) Identify2(netCtx context.Context, arg keybase1.Identif
 func (h *IdentifyHandler) IdentifyLite(netCtx context.Context, arg keybase1.IdentifyLiteArg) (ret keybase1.IdentifyLiteRes, err error) {
 	mctx := libkb.NewMetaContext(netCtx, h.G()).WithLogTag("IDL")
 	defer mctx.Trace("IdentifyHandler#IdentifyLite", &err)()
-	loader := func(mctx libkb.MetaContext) (interface{}, error) {
+	loader := func(mctx libkb.MetaContext) (any, error) {
 		return h.identifyLite(mctx, arg)
 	}
 	cacheArg := keybase1.IdentifyLiteArg{
@@ -175,7 +175,7 @@ func (h *IdentifyHandler) identifyLiteUser(netCtx context.Context, arg keybase1.
 func (h *IdentifyHandler) Resolve3(ctx context.Context, arg keybase1.Resolve3Arg) (ret keybase1.UserOrTeamLite, err error) {
 	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("RSLV")
 	defer mctx.Trace(fmt.Sprintf("IdentifyHandler#Resolve3(%+v)", arg), &err)()
-	servedRet, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.resolve3", false, arg, &ret, func(mctx libkb.MetaContext) (interface{}, error) {
+	servedRet, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.resolve3", false, arg, &ret, func(mctx libkb.MetaContext) (any, error) {
 		return h.resolveUserOrTeam(mctx.Ctx(), arg.Assertion)
 	})
 	if err != nil {
@@ -212,7 +212,7 @@ func (h *IdentifyHandler) ResolveIdentifyImplicitTeam(ctx context.Context, arg k
 		IsPublic:   arg.IsPublic,
 	}
 
-	servedRes, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.resolveIdentifyImplicitTeam", false, cacheArg, &res, func(mctx libkb.MetaContext) (interface{}, error) {
+	servedRes, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.resolveIdentifyImplicitTeam", false, cacheArg, &res, func(mctx libkb.MetaContext) (any, error) {
 		return h.resolveIdentifyImplicitTeamHelper(mctx.Ctx(), arg, writerAssertions, readerAssertions)
 	})
 

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -149,7 +149,7 @@ func (h *KBFSHandler) CreateTLF(ctx context.Context, arg keybase1.CreateTLFArg) 
 
 func (h *KBFSHandler) GetKBFSTeamSettings(ctx context.Context, arg keybase1.GetKBFSTeamSettingsArg) (ret keybase1.KBFSTeamSettings, err error) {
 	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("SETTINGS")
-	loader := func(mctx libkb.MetaContext) (interface{}, error) {
+	loader := func(mctx libkb.MetaContext) (any, error) {
 		return teams.GetKBFSTeamSettings(mctx.Ctx(), mctx.G(), arg.TeamID.IsPublic(), arg.TeamID)
 	}
 	servedRet, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "kbfs.getKBFSTeamSettings", false, arg, &ret, loader)

--- a/go/service/kvstore_test.go
+++ b/go/service/kvstore_test.go
@@ -150,7 +150,7 @@ func TestKvStoreMultiUserTeam(t *testing.T) {
 	// Alice puts a secret
 	namespace := "myapp"
 	entryKey := "asdfasfeasef"
-	secretData := map[string]interface{}{
+	secretData := map[string]any{
 		"username":      "hunter2",
 		"email":         "thereal@example.com",
 		"password":      "super random password",

--- a/go/service/log_fwd.go
+++ b/go/service/log_fwd.go
@@ -8,7 +8,7 @@ import keybase1 "github.com/keybase/client/go/protocol/keybase1"
 type logEntry struct {
 	level  keybase1.LogLevel
 	format string
-	args   []interface{}
+	args   []any
 }
 
 type extLogger interface {
@@ -50,7 +50,7 @@ func (f *logFwd) Remove(x extLogger) {
 	f.removeCh <- x
 }
 
-func (f *logFwd) Log(level keybase1.LogLevel, format string, args []interface{}) {
+func (f *logFwd) Log(level keybase1.LogLevel, format string, args []any) {
 	f.logCh <- &logEntry{level: level, format: format, args: args}
 }
 

--- a/go/service/log_ui.go
+++ b/go/service/log_ui.go
@@ -24,7 +24,7 @@ func NewLogUI(sessionID int, c *rpc.Client) *LogUI {
 	}
 }
 
-func (l *LogUI) Log(level keybase1.LogLevel, format string, args []interface{}) {
+func (l *LogUI) Log(level keybase1.LogLevel, format string, args []any) {
 	msg := fmt.Sprintf(format, args...)
 	_ = l.cli.Log(context.TODO(), keybase1.LogArg{
 		SessionID: l.sessionID,
@@ -36,21 +36,21 @@ func (l *LogUI) Log(level keybase1.LogLevel, format string, args []interface{}) 
 	})
 }
 
-func (l *LogUI) Debug(format string, args ...interface{}) {
+func (l *LogUI) Debug(format string, args ...any) {
 	l.Log(keybase1.LogLevel_DEBUG, format, args)
 }
-func (l *LogUI) Info(format string, args ...interface{}) {
+func (l *LogUI) Info(format string, args ...any) {
 	l.Log(keybase1.LogLevel_INFO, format, args)
 }
-func (l *LogUI) Critical(format string, args ...interface{}) {
+func (l *LogUI) Critical(format string, args ...any) {
 	l.Log(keybase1.LogLevel_CRITICAL, format, args)
 }
-func (l *LogUI) Warning(format string, args ...interface{}) {
+func (l *LogUI) Warning(format string, args ...any) {
 	l.Log(keybase1.LogLevel_WARN, format, args)
 }
-func (l *LogUI) Errorf(format string, args ...interface{}) {
+func (l *LogUI) Errorf(format string, args ...any) {
 	l.Log(keybase1.LogLevel_ERROR, format, args)
 }
-func (l *LogUI) Notice(format string, args ...interface{}) {
+func (l *LogUI) Notice(format string, args ...any) {
 	l.Log(keybase1.LogLevel_NOTICE, format, args)
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -659,7 +659,7 @@ func (h *TeamsHandler) LoadTeamPlusApplicationKeys(ctx context.Context, arg keyb
 	defer h.G().CTrace(ctx, fmt.Sprintf("LoadTeamPlusApplicationKeys(%s)", arg.Id), &err)()
 
 	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
-	loader := func(mctx libkb.MetaContext) (interface{}, error) {
+	loader := func(mctx libkb.MetaContext) (any, error) {
 		return teams.LoadTeamPlusApplicationKeys(ctx, h.G().ExternalG(), arg.Id, arg.Application, arg.Refreshers,
 			arg.IncludeKBFSKeys)
 	}

--- a/go/service/test_handler.go
+++ b/go/service/test_handler.go
@@ -27,7 +27,7 @@ func (t TestHandler) Test(ctx context.Context, arg keybase1.TestArg) (test keyba
 	client := t.rpcClient()
 	cbArg := keybase1.TestCallbackArg(arg)
 	var cbReply string
-	err = client.Call(ctx, "keybase.1.test.testCallback", []interface{}{cbArg}, &cbReply, 0)
+	err = client.Call(ctx, "keybase.1.test.testCallback", []any{cbArg}, &cbReply, 0)
 	if err != nil {
 		return
 	}

--- a/go/service/tracker_loader.go
+++ b/go/service/tracker_loader.go
@@ -39,7 +39,7 @@ func NewTrackerLoader(g *libkb.GlobalContext) *TrackerLoader {
 	return l
 }
 
-func (l *TrackerLoader) debug(ctx context.Context, msg string, args ...interface{}) {
+func (l *TrackerLoader) debug(ctx context.Context, msg string, args ...any) {
 	l.G().Log.CDebugf(ctx, "TrackerLoader: %s", fmt.Sprintf(msg, args...))
 }
 

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -121,7 +121,7 @@ func (h *UserHandler) LoadUserPlusKeysV2(ctx context.Context, arg keybase1.LoadU
 	}
 
 	retp := &ret
-	servedRet, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "user.loadUserPlusKeysV2", false, cacheArg, &retp, func(mctx libkb.MetaContext) (interface{}, error) {
+	servedRet, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "user.loadUserPlusKeysV2", false, cacheArg, &retp, func(mctx libkb.MetaContext) (any, error) {
 		return h.G().GetUPAKLoader().LoadV2WithKID(mctx.Ctx(), arg.Uid, arg.PollForKID)
 	})
 	if s, ok := servedRet.(*keybase1.UserPlusKeysV2AllIncarnations); ok && s != nil {

--- a/go/sig3/errors.go
+++ b/go/sig3/errors.go
@@ -12,7 +12,7 @@ func (e ParseError) Error() string {
 	return fmt.Sprintf("parse error: %s", e.m)
 }
 
-func newParseError(f string, a ...interface{}) error {
+func newParseError(f string, a ...any) error {
 	return ParseError{m: fmt.Sprintf(f, a...)}
 }
 
@@ -24,7 +24,7 @@ func (e Sig3Error) Error() string {
 	return fmt.Sprintf("sig3 error: %s", e.m)
 }
 
-func newSig3Error(f string, a ...interface{}) error {
+func newSig3Error(f string, a ...any) error {
 	return Sig3Error{m: fmt.Sprintf(f, a...)}
 }
 
@@ -32,7 +32,7 @@ type SequenceError struct {
 	m string
 }
 
-func newSequenceError(f string, a ...interface{}) error {
+func newSequenceError(f string, a ...any) error {
 	return SequenceError{m: fmt.Sprintf(f, a...)}
 }
 

--- a/go/sig3/prot.go
+++ b/go/sig3/prot.go
@@ -58,7 +58,7 @@ type OuterLink struct {
 }
 
 type InnerLink struct {
-	Body        interface{} `codec:"b"`           // The actual body, which varies based on the type in the outer link
+	Body        any         `codec:"b"`           // The actual body, which varies based on the type in the outer link
 	Ctime       TimeSec     `codec:"c"`           // Seconds since 1970 UTC.
 	Entropy     Entropy     `codec:"e"`           // entropy for hiding the value of the inner link
 	ClientInfo  *ClientInfo `codec:"i,omitempty"` // Optional client type making sig

--- a/go/sig3/sig3.go
+++ b/go/sig3/sig3.go
@@ -156,7 +156,7 @@ func (i InnerLink) hash() (LinkID, error) {
 	return hashInterface(i)
 }
 
-func hashInterface(i interface{}) (LinkID, error) {
+func hashInterface(i any) (LinkID, error) {
 	b, err := msgpack.Encode(i)
 	if err != nil {
 		return LinkID{}, err
@@ -471,7 +471,7 @@ func signGeneric(g Generic, privkey kbcrypto.NaclSigningKeyPrivate) (ret *Sig3Bu
 
 // Export a sig3 up to the server in base64'ed JSON format, as in a POST request.
 func (s Sig3Bundle) Export() (ret ExportJSON, err error) {
-	enc := func(i interface{}) (string, error) {
+	enc := func(i any) (string, error) {
 		b, err := msgpack.Encode(i)
 		if err != nil {
 			return "", err

--- a/go/status/status_test.go
+++ b/go/status/status_test.go
@@ -32,7 +32,7 @@ func TestMergeExtendedStatus(t *testing.T) {
 	err := jsonw.EnsureMaxDepthBytesDefault([]byte(fullStatus))
 	require.NoError(t, err)
 
-	fullStatusMap := map[string]interface{}{}
+	fullStatusMap := map[string]any{}
 	err = json.Unmarshal([]byte(fullStatus), &fullStatusMap)
 	require.NoError(t, err)
 	_, ok := fullStatusMap["status"]

--- a/go/status/utils.go
+++ b/go/status/utils.go
@@ -33,17 +33,17 @@ import (
 // MergeStatusJSON merges the given `obj` into the given `status` JSON blob.
 // If any errors occur the original `status` is returned. Otherwise a new JSON
 // blob is created of the form {"status": status, key: obj}
-func MergeStatusJSON(obj interface{}, key, status string) string {
+func MergeStatusJSON(obj any, key, status string) string {
 	if err := jsonw.EnsureMaxDepthBytesDefault([]byte(status)); err != nil {
 		return status
 	}
 
-	var statusObj map[string]interface{}
+	var statusObj map[string]any
 	if err := json.Unmarshal([]byte(status), &statusObj); err != nil {
 		return status
 	}
 
-	statusMap := make(map[string]interface{})
+	statusMap := make(map[string]any)
 	statusMap["status"] = statusObj
 	statusMap[key] = obj
 
@@ -273,7 +273,7 @@ func findFirstNewline(b []byte) []byte {
 	return b[(index + 1):]
 }
 
-func appendError(log logger.Logger, collected []byte, format string, args ...interface{}) []byte {
+func appendError(log logger.Logger, collected []byte, format string, args ...any) []byte {
 	msg := "Error reading logs: " + fmt.Sprintf(format, args...)
 	log.Errorf(msg)
 	return append(collected, []byte("\n"+msg+"\n")...)

--- a/go/stellar/autoclaim.go
+++ b/go/stellar/autoclaim.go
@@ -65,7 +65,7 @@ func (r *AutoClaimRunner) loop(mctx libkb.MetaContext, trigger gregor.MsgID) {
 	for {
 		i++
 		mctx := mctx.WithLogTag("ACR") // shadow mctx for this round with a log tag
-		log := func(format string, args ...interface{}) {
+		log := func(format string, args ...any) {
 			mctx.Debug(fmt.Sprintf("AutoClaimRunnner round[%v] ", i) + fmt.Sprintf(format, args...))
 		}
 		action, err := r.step(mctx, i, trigger)
@@ -99,7 +99,7 @@ func (r *AutoClaimRunner) loop(mctx libkb.MetaContext, trigger gregor.MsgID) {
 
 // `trigger` is optional
 func (r *AutoClaimRunner) step(mctx libkb.MetaContext, i int, trigger gregor.MsgID) (action autoClaimLoopAction, err error) {
-	log := func(format string, args ...interface{}) {
+	log := func(format string, args ...any) {
 		mctx.Debug(fmt.Sprintf("AutoClaimRunnner round[%v] ", i) + fmt.Sprintf(format, args...))
 	}
 	log("step begin")

--- a/go/stellar/bpc.go
+++ b/go/stellar/bpc.go
@@ -65,7 +65,7 @@ func (c *buildPaymentCache) AccountSeqno(mctx libkb.MetaContext,
 
 func (c *buildPaymentCache) IsAccountFunded(mctx libkb.MetaContext,
 	accountID stellar1.AccountID, bid stellar1.BuildPaymentID) (res bool, err error) {
-	fill := func() (interface{}, error) {
+	fill := func() (any, error) {
 		funded, err := isAccountFunded(mctx.Ctx(), c.remoter, accountID)
 		res = funded
 		return funded, err
@@ -81,7 +81,7 @@ func (c *buildPaymentCache) IsAccountFunded(mctx libkb.MetaContext,
 
 func (c *buildPaymentCache) LookupRecipient(mctx libkb.MetaContext,
 	to stellarcommon.RecipientInput) (res stellarcommon.Recipient, err error) {
-	fill := func() (interface{}, error) {
+	fill := func() (any, error) {
 		return LookupRecipient(mctx, to, false /* isCLI */)
 	}
 	err = c.lookupRecipientCache.GetWithFill(mctx, string(to), &res, fill)
@@ -90,7 +90,7 @@ func (c *buildPaymentCache) LookupRecipient(mctx libkb.MetaContext,
 
 func (c *buildPaymentCache) ShouldOfferAdvancedSend(mctx libkb.MetaContext, from, to stellar1.AccountID) (res stellar1.AdvancedBanner, err error) {
 	key := from.String() + ":" + to.String()
-	fill := func() (interface{}, error) {
+	fill := func() (any, error) {
 		return ShouldOfferAdvancedSend(mctx, c.remoter, from, to)
 	}
 	err = c.shouldOfferAdvancedSendCache.GetWithFill(mctx, key, &res, fill)
@@ -116,11 +116,11 @@ func (c *buildPaymentCache) AvailableXLMToSend(mctx libkb.MetaContext,
 
 func (c *buildPaymentCache) GetOutsideCurrencyPreference(mctx libkb.MetaContext,
 	accountID stellar1.AccountID, bid stellar1.BuildPaymentID) (res stellar1.OutsideCurrencyCode, err error) {
-	fillInner := func() (interface{}, error) {
+	fillInner := func() (any, error) {
 		cr, err := GetCurrencySetting(mctx, accountID)
 		return cr.Code, err
 	}
-	fillOuter := func() (interface{}, error) {
+	fillOuter := func() (any, error) {
 		err := c.currencyPreferenceCache.GetWithFill(mctx, accountID.String(), &res, fillInner)
 		return res, err
 	}

--- a/go/stellar/build.go
+++ b/go/stellar/build.go
@@ -156,7 +156,7 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 		secretNote bool
 		publicMemo bool
 	}{}
-	log := func(format string, args ...interface{}) {
+	log := func(format string, args ...any) {
 		mctx.Debug("bpl: "+format, args...)
 	}
 
@@ -771,7 +771,7 @@ func BuildRequestLocal(mctx libkb.MetaContext, arg stellar1.BuildRequestLocalArg
 		amount     bool
 		secretNote bool
 	}{}
-	log := func(format string, args ...interface{}) {
+	log := func(format string, args ...any) {
 		mctx.Debug("brl: "+format, args...)
 	}
 
@@ -872,7 +872,7 @@ type buildPaymentAmountResult struct {
 var zeroOrNoAmountRE = regexp.MustCompile(`^0*\.?0*$`)
 
 func buildPaymentAmountHelper(mctx libkb.MetaContext, bpc BuildPaymentCache, arg buildPaymentAmountArg) (res buildPaymentAmountResult) {
-	log := func(format string, args ...interface{}) {
+	log := func(format string, args ...any) {
 		mctx.Debug("bpl: "+format, args...)
 	}
 	res.asset = stellar1.AssetNative()

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -442,7 +442,7 @@ type hasAcceptedDisclaimerDBEntry struct {
 // For a UV, accepted starts out false and transitions to true. It never becomes false again.
 // A cached true is returned, but a false always hits the server.
 func (s *Stellar) hasAcceptedDisclaimer(ctx context.Context) (bool, error) {
-	log := func(format string, args ...interface{}) {
+	log := func(format string, args ...any) {
 		s.G().Log.CDebugf(ctx, "Stellar.hasAcceptedDisclaimer "+format, args...)
 	}
 	uv, err := s.G().GetMeUV(ctx)

--- a/go/stellar/stellarsvc/anchor.go
+++ b/go/stellar/stellarsvc/anchor.go
@@ -231,13 +231,13 @@ func (a *anchorInteractor) checkURL(mctx libkb.MetaContext, action string) (*url
 }
 
 type okDepositResponse struct {
-	How        string      `json:"how"`
-	ETA        int         `json:"int"`
-	MinAmount  float64     `json:"min_amount"`
-	MaxAmount  float64     `json:"max_amount"`
-	FeeFixed   float64     `json:"fee_fixed"`
-	FeePercent float64     `json:"fee_percent"`
-	ExtraInfo  interface{} `json:"extra_info"`
+	How        string  `json:"how"`
+	ETA        int     `json:"int"`
+	MinAmount  float64 `json:"min_amount"`
+	MaxAmount  float64 `json:"max_amount"`
+	FeeFixed   float64 `json:"fee_fixed"`
+	FeePercent float64 `json:"fee_percent"`
+	ExtraInfo  any     `json:"extra_info"`
 }
 
 // this will never happen, but:

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -636,7 +636,7 @@ func NewBackendMock(t testing.TB) *BackendMock {
 	}
 }
 
-func (r *BackendMock) trace(err *error, name string, format string, args ...interface{}) func() {
+func (r *BackendMock) trace(err *error, name string, format string, args ...any) func() {
 	r.T.Logf("+ %s %s", name, fmt.Sprintf(format, args...))
 	return func() {
 		errStr := "?"

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -65,9 +65,10 @@ type preambleArg struct {
 
 // Preamble
 // Example usage:
-//   ctx, err, fin := c.Preamble(...)
-//   defer fin()
-//   if err != nil { return err }
+//
+//	ctx, err, fin := c.Preamble(...)
+//	defer fin()
+//	if err != nil { return err }
 func (s *Server) Preamble(inCtx context.Context, opts preambleArg) (mctx libkb.MetaContext, fin func(), err error) {
 	mctx = libkb.NewMetaContext(s.logTag(inCtx), s.G())
 	fin = mctx.Trace("LRPC "+opts.RPCName, opts.Err)
@@ -956,7 +957,7 @@ func (s *Server) GetPartnerUrlsLocal(ctx context.Context, sessionID int) (res []
 	if err != nil {
 		return nil, err
 	}
-	var externalURLs map[string]map[string][]interface{}
+	var externalURLs map[string]map[string][]any
 	if err := json.Unmarshal([]byte(entry.Entry), &externalURLs); err != nil {
 		return nil, err
 	}

--- a/go/stellar/time_cache_test.go
+++ b/go/stellar/time_cache_test.go
@@ -20,10 +20,10 @@ func TestTimeCache(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, 1, a)
 
-	fill2 := func() (interface{}, error) {
+	fill2 := func() (any, error) {
 		return 2, nil
 	}
-	fillErr := func() (interface{}, error) {
+	fillErr := func() (any, error) {
 		return 3, fmt.Errorf("eek")
 	}
 	err := c.GetWithFill(tc.MetaContext(), "l", &a, fill2)

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -258,7 +258,7 @@ func (w *WalletState) UpdateAccountEntriesWithBundle(mctx libkb.MetaContext, rea
 
 // RefreshAll refreshes all the accounts.
 func (w *WalletState) RefreshAll(mctx libkb.MetaContext, reason string) error {
-	_, err := w.refreshGroup.Do("RefreshAll", func() (interface{}, error) {
+	_, err := w.refreshGroup.Do("RefreshAll", func() (any, error) {
 		doErr := w.refreshAll(mctx, reason)
 		return nil, doErr
 	})
@@ -587,7 +587,7 @@ func (w *WalletState) ExchangeRate(ctx context.Context, currency string) (stella
 	}
 	w.G().Log.CDebugf(ctx, "ExchangeRate(%s) using remote", currency)
 
-	rateRes, err := w.rateGroup.Do(currency, func() (interface{}, error) {
+	rateRes, err := w.rateGroup.Do(currency, func() (any, error) {
 		return w.Remoter.ExchangeRate(ctx, currency)
 	})
 	rate, ok := rateRes.(stellar1.OutsideExchangeRate)
@@ -688,7 +688,7 @@ func newAccountState(accountID stellar1.AccountID, r remote.Remoter, reqsCh chan
 
 // Refresh updates all the data for this account from the server.
 func (a *AccountState) Refresh(mctx libkb.MetaContext, router *libkb.NotifyRouter, reason string) error {
-	_, err := a.refreshGroup.Do("Refresh", func() (interface{}, error) {
+	_, err := a.refreshGroup.Do("Refresh", func() (any, error) {
 		doErr := a.refresh(mctx, router, reason)
 		return nil, doErr
 	})
@@ -697,7 +697,7 @@ func (a *AccountState) Refresh(mctx libkb.MetaContext, router *libkb.NotifyRoute
 
 // RefreshWithDetails updates all the data for this account with the provided details data.
 func (a *AccountState) RefreshWithDetails(mctx libkb.MetaContext, router *libkb.NotifyRouter, reason string, details *stellar1.DetailsPlusPayments) error {
-	_, err := a.refreshGroup.Do("Refresh", func() (interface{}, error) {
+	_, err := a.refreshGroup.Do("Refresh", func() (any, error) {
 		var doErr error
 		if details != nil {
 			doErr = a.refreshWithDetails(mctx, router, reason, details)

--- a/go/systests/common_test.go
+++ b/go/systests/common_test.go
@@ -55,13 +55,13 @@ type baseNullUI struct {
 
 type dumbUI struct{}
 
-func (d dumbUI) Printf(format string, args ...interface{}) (int, error) {
+func (d dumbUI) Printf(format string, args ...any) (int, error) {
 	return 0, nil
 }
-func (d dumbUI) PrintfStderr(format string, args ...interface{}) (int, error) {
+func (d dumbUI) PrintfStderr(format string, args ...any) (int, error) {
 	return 0, nil
 }
-func (d dumbUI) PrintfUnescaped(format string, args ...interface{}) (int, error) {
+func (d dumbUI) PrintfUnescaped(format string, args ...any) (int, error) {
 	return 0, nil
 }
 

--- a/go/systests/config_test.go
+++ b/go/systests/config_test.go
@@ -55,17 +55,17 @@ func (c *configTestUI) GetDumbOutputUI() libkb.DumbOutputUI {
 	return c
 }
 
-func (c *configTestUI) Printf(fmtString string, args ...interface{}) (int, error) {
+func (c *configTestUI) Printf(fmtString string, args ...any) (int, error) {
 	return c.PrintfUnescaped(fmtString, args...)
 }
 
-func (c *configTestUI) PrintfUnescaped(fmtString string, args ...interface{}) (int, error) {
+func (c *configTestUI) PrintfUnescaped(fmtString string, args ...any) (int, error) {
 	s := fmt.Sprintf(fmtString, args...)
 	c.stdout = append(c.stdout, s)
 	return 0, nil
 }
 
-func (c *configTestUI) PrintfStderr(fmtString string, args ...interface{}) (int, error) {
+func (c *configTestUI) PrintfStderr(fmtString string, args ...any) (int, error) {
 	s := fmt.Sprintf(fmtString, args...)
 	c.stderr = append(c.stderr, s)
 	return 0, nil

--- a/go/systests/ctl_test.go
+++ b/go/systests/ctl_test.go
@@ -19,16 +19,16 @@ func (v *versionUI) GetDumbOutputUI() libkb.DumbOutputUI {
 	return v
 }
 
-func (v *versionUI) Printf(format string, args ...interface{}) (n int, err error) {
+func (v *versionUI) Printf(format string, args ...any) (n int, err error) {
 	return v.PrintfUnescaped(format, args...)
 }
 
-func (v *versionUI) PrintfUnescaped(format string, args ...interface{}) (n int, err error) {
+func (v *versionUI) PrintfUnescaped(format string, args ...any) (n int, err error) {
 	v.outbuf = append(v.outbuf, fmt.Sprintf(format, args...))
 	return 0, nil
 }
 
-func (v *versionUI) PrintfStderr(format string, args ...interface{}) (n int, err error) {
+func (v *versionUI) PrintfStderr(format string, args ...any) (n int, err error) {
 	return 0, nil
 }
 

--- a/go/systests/device_common_test.go
+++ b/go/systests/device_common_test.go
@@ -75,11 +75,11 @@ func (t *testUI) UnescapedOutputWriter() io.Writer {
 	return t
 }
 
-func (t *testUI) Printf(f string, args ...interface{}) (int, error) {
+func (t *testUI) Printf(f string, args ...any) (int, error) {
 	return t.PrintfUnescaped(f, args...)
 }
 
-func (t *testUI) PrintfUnescaped(f string, args ...interface{}) (int, error) {
+func (t *testUI) PrintfUnescaped(f string, args ...any) (int, error) {
 	s := fmt.Sprintf(f, args...)
 	t.G().Log.Debug("Terminal Printf: %s", s)
 	return len(s), nil

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -126,8 +126,8 @@ func (t smuTerminalUI) Output(string) error                                     
 func (t smuTerminalUI) OutputDesc(libkb.OutputDescriptor, string) error               { return nil }
 func (t smuTerminalUI) OutputWriter() io.Writer                                       { return nil }
 func (t smuTerminalUI) UnescapedOutputWriter() io.Writer                              { return nil }
-func (t smuTerminalUI) Printf(fmt string, args ...interface{}) (int, error)           { return 0, nil }
-func (t smuTerminalUI) PrintfUnescaped(fmt string, args ...interface{}) (int, error)  { return 0, nil }
+func (t smuTerminalUI) Printf(fmt string, args ...any) (int, error)                   { return 0, nil }
+func (t smuTerminalUI) PrintfUnescaped(fmt string, args ...any) (int, error)          { return 0, nil }
 func (t smuTerminalUI) Prompt(libkb.PromptDescriptor, string) (string, error)         { return "", nil }
 func (t smuTerminalUI) PromptForConfirmation(prompt string) error                     { return nil }
 func (t smuTerminalUI) PromptPassword(libkb.PromptDescriptor, string) (string, error) { return "", nil }

--- a/go/systests/passphrase_test.go
+++ b/go/systests/passphrase_test.go
@@ -343,12 +343,12 @@ func (n *testRecoverUIRecover) OutputDesc(od libkb.OutputDescriptor, s string) e
 	n.G().Log.Debug("Terminal Output %d: %s", od, s)
 	return nil
 }
-func (n *testRecoverUIRecover) Printf(f string, args ...interface{}) (int, error) {
+func (n *testRecoverUIRecover) Printf(f string, args ...any) (int, error) {
 	s := fmt.Sprintf(f, args...)
 	n.G().Log.Debug("Terminal Printf: %s", s)
 	return len(s), nil
 }
-func (n *testRecoverUIRecover) PrintfUnescaped(f string, args ...interface{}) (int, error) {
+func (n *testRecoverUIRecover) PrintfUnescaped(f string, args ...any) (int, error) {
 	s := fmt.Sprintf(f, args...)
 	n.G().Log.Debug("Terminal PrintfUnescaped: %s", s)
 	return len(s), nil

--- a/go/systests/retry_test.go
+++ b/go/systests/retry_test.go
@@ -14,11 +14,11 @@ type testAttempt struct {
 	failed bool
 }
 
-func (t *testAttempt) Error(args ...interface{}) {
+func (t *testAttempt) Error(args ...any) {
 	t.Log(args...)
 }
 
-func (t *testAttempt) Errorf(format string, args ...interface{}) {
+func (t *testAttempt) Errorf(format string, args ...any) {
 	t.Logf(format, args...)
 }
 
@@ -41,7 +41,7 @@ func (t *testAttempt) Failed() bool {
 	return t.failed
 }
 
-func (t *testAttempt) Fatal(args ...interface{}) {
+func (t *testAttempt) Fatal(args ...any) {
 	t.Log(args...)
 	t.Lock()
 	t.failed = true
@@ -49,7 +49,7 @@ func (t *testAttempt) Fatal(args ...interface{}) {
 	panic("Fatal call")
 }
 
-func (t *testAttempt) Fatalf(format string, args ...interface{}) {
+func (t *testAttempt) Fatalf(format string, args ...any) {
 	t.Logf(format, args...)
 	t.Lock()
 	t.failed = true
@@ -57,11 +57,11 @@ func (t *testAttempt) Fatalf(format string, args ...interface{}) {
 	panic("Fatalf call")
 }
 
-func (t *testAttempt) Log(args ...interface{}) {
+func (t *testAttempt) Log(args ...any) {
 	t.t.Log(args...)
 }
 
-func (t *testAttempt) Logf(format string, args ...interface{}) {
+func (t *testAttempt) Logf(format string, args ...any) {
 	t.t.Logf(format, args...)
 }
 
@@ -69,14 +69,14 @@ func (t *testAttempt) Name() string {
 	return t.t.Name()
 }
 
-func (t *testAttempt) Skip(args ...interface{}) {
+func (t *testAttempt) Skip(args ...any) {
 	t.t.Skip(args...)
 }
 
 func (t *testAttempt) SkipNow() {
 	t.t.SkipNow()
 }
-func (t *testAttempt) Skipf(format string, args ...interface{}) {
+func (t *testAttempt) Skipf(format string, args ...any) {
 	t.t.Skipf(format, args...)
 }
 func (t *testAttempt) Skipped() bool {

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func divDebug(ctx *smuContext, fmt string, arg ...interface{}) {
+func divDebug(ctx *smuContext, fmt string, arg ...any) {
 	div := "------------"
 	ctx.log.Debug(div+" "+fmt+" "+div, arg...)
 }

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -142,12 +142,12 @@ func (n *signupTerminalUI) OutputDesc(od libkb.OutputDescriptor, s string) error
 	n.G().Log.Debug("Terminal Output %d: %s", od, s)
 	return nil
 }
-func (n *signupTerminalUI) Printf(f string, args ...interface{}) (int, error) {
+func (n *signupTerminalUI) Printf(f string, args ...any) (int, error) {
 	s := fmt.Sprintf(f, args...)
 	n.G().Log.Debug("Terminal Printf: %s", s)
 	return len(s), nil
 }
-func (n *signupTerminalUI) PrintfUnescaped(f string, args ...interface{}) (int, error) {
+func (n *signupTerminalUI) PrintfUnescaped(f string, args ...any) (int, error) {
 	s := fmt.Sprintf(f, args...)
 	n.G().Log.Debug("Terminal PrintfUnescaped: %s", s)
 	return len(s), nil

--- a/go/teambot/featuredbot.go
+++ b/go/teambot/featuredbot.go
@@ -37,7 +37,7 @@ func NewFeaturedBotLoader(g *libkb.GlobalContext) *FeaturedBotLoader {
 	}
 }
 
-func (l *FeaturedBotLoader) debug(mctx libkb.MetaContext, msg string, args ...interface{}) {
+func (l *FeaturedBotLoader) debug(mctx libkb.MetaContext, msg string, args ...any) {
 	l.G().Log.CDebugf(mctx.Ctx(), "FeaturedBotLoader: %s", fmt.Sprintf(msg, args...))
 }
 

--- a/go/teams/box_audit.go
+++ b/go/teams/box_audit.go
@@ -1141,7 +1141,7 @@ func putJailToDisk(mctx libkb.MetaContext, jail *BoxAuditJail) error {
 	return putToDisk(mctx, BoxAuditJailDbKey(mctx), jail)
 }
 
-func putToDisk(mctx libkb.MetaContext, dbKey libkb.DbKey, i interface{}) error {
+func putToDisk(mctx libkb.MetaContext, dbKey libkb.DbKey, i any) error {
 	return mctx.G().LocalDb.PutObj(dbKey, nil, i)
 }
 

--- a/go/teams/box_audit_test.go
+++ b/go/teams/box_audit_test.go
@@ -133,12 +133,12 @@ func TestBoxAuditAttempt(t *testing.T) {
 	require.NoError(t, toErr(attempt), "attempt OK after rotate")
 }
 
-func requireFatalError(t *testing.T, err error, args ...interface{}) {
+func requireFatalError(t *testing.T, err error, args ...any) {
 	_, ok := err.(FatalBoxAuditError)
 	require.True(t, ok, args...)
 }
 
-func requireNonfatalError(t *testing.T, err error, args ...interface{}) {
+func requireNonfatalError(t *testing.T, err error, args ...any) {
 	_, ok := err.(NonfatalBoxAuditError)
 	require.True(t, ok, args...)
 }

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -264,7 +264,7 @@ func findRoleDowngrade(points []keybase1.UserLogPoint, role keybase1.TeamRole) *
 // If there was, return a PermissionError. If no adminship was found at all, return a PermissionError.
 func (t TeamSigChainState) AssertWasRoleOrAboveAt(uv keybase1.UserVersion,
 	role keybase1.TeamRole, scl keybase1.SigChainLocation) (err error) {
-	mkErr := func(format string, args ...interface{}) error {
+	mkErr := func(format string, args ...any) error {
 		msg := fmt.Sprintf(format, args...)
 		if role.IsOrAbove(keybase1.TeamRole_ADMIN) {
 			return NewAdminPermissionError(t.GetID(), uv, msg)
@@ -1893,12 +1893,13 @@ var hardcodedInviteRuleExceptionSigIDs = map[keybase1.SigIDMapKey]bool{
 
 // sanityCheckInvites sanity checks a raw SCTeamInvites section and coerces it into a
 // format that we can use. It checks:
-//  - inviting owners is sometimes banned
-//  - invite IDs aren't repeated
-//  - <name,type> pairs aren't reused
-//  - IDs parse into proper keybase1.TeamInviteIDs
-//  - the invite type parses into proper TeamInviteType, or that it's an unknown
-//    invite that we're OK to not act upon.
+//   - inviting owners is sometimes banned
+//   - invite IDs aren't repeated
+//   - <name,type> pairs aren't reused
+//   - IDs parse into proper keybase1.TeamInviteIDs
+//   - the invite type parses into proper TeamInviteType, or that it's an unknown
+//     invite that we're OK to not act upon.
+//
 // Implicit teams are different:
 // - owners and readers are the only allowed roles
 func (t *teamSigchainPlayer) sanityCheckInvites(mctx libkb.MetaContext,

--- a/go/teams/chain_test.go
+++ b/go/teams/chain_test.go
@@ -360,7 +360,7 @@ func TestTeamSigChainPlay2(t *testing.T) {
 	}
 }
 
-func encode(input interface{}) ([]byte, error) {
+func encode(input any) ([]byte, error) {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	var data []byte
 	enc := codec.NewEncoderBytes(&data, &mh)
@@ -370,7 +370,7 @@ func encode(input interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func decode(data []byte, res interface{}) error {
+func decode(data []byte, res any) error {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	dec := codec.NewDecoderBytes(data, &mh)
 	err := dec.Decode(res)

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -264,7 +264,7 @@ func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me libk
 
 	mctx.Debug("makeSigAndPostRootTeam post sigs")
 	payload := make(libkb.JSONPayload)
-	payload["sigs"] = []interface{}{sigMultiItem}
+	payload["sigs"] = []any{sigMultiItem}
 	payload["per_team_key"] = secretboxes
 
 	_, err = mctx.G().API.PostJSON(mctx, libkb.APIArg{
@@ -420,7 +420,7 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 	}
 
 	payload := make(libkb.JSONPayload)
-	payload["sigs"] = []interface{}{newSubteamSig, subteamHeadSig}
+	payload["sigs"] = []any{newSubteamSig, subteamHeadSig}
 	payload["per_team_key"] = secretboxes
 	ratchet.AddToJSONPayload(payload)
 

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -39,7 +39,7 @@ func (e InvalidLink) Error() string {
 	return fmt.Sprintf("invalid link (seqno %d): %s", e.l.Seqno(), e.note)
 }
 
-func NewInvalidLink(l *ChainLinkUnpacked, format string, args ...interface{}) InvalidLink {
+func NewInvalidLink(l *ChainLinkUnpacked, format string, args ...any) InvalidLink {
 	return InvalidLink{l, fmt.Sprintf(format, args...)}
 }
 
@@ -152,7 +152,7 @@ type PrevError struct {
 	Msg string
 }
 
-func NewPrevError(format string, args ...interface{}) error {
+func NewPrevError(format string, args ...any) error {
 	return PrevError{fmt.Sprintf(format, args...)}
 }
 
@@ -214,7 +214,7 @@ func (e TeamDoesNotExistError) Error() string {
 	return fmt.Sprintf("Team %q does not exist", e.descriptor)
 }
 
-func NewTeamDoesNotExistError(public bool, format string, args ...interface{}) error {
+func NewTeamDoesNotExistError(public bool, format string, args ...any) error {
 	return TeamDoesNotExistError{
 		descriptor: fmt.Sprintf(format, args...),
 		public:     public,
@@ -237,7 +237,7 @@ func (e ExplicitTeamOperationError) Error() string {
 	return fmt.Sprintf("Operation only allowed on implicit teams: %s", e.msg)
 }
 
-func NewImplicitTeamOperationError(format string, args ...interface{}) error {
+func NewImplicitTeamOperationError(format string, args ...any) error {
 	return &ImplicitTeamOperationError{msg: fmt.Sprintf(format, args...)}
 }
 
@@ -413,7 +413,7 @@ func (e AttemptedInviteSocialOwnerError) Error() string { return e.Msg }
 
 type UserHasNotResetError struct{ Msg string }
 
-func NewUserHasNotResetError(format string, args ...interface{}) error {
+func NewUserHasNotResetError(format string, args ...any) error {
 	return UserHasNotResetError{Msg: fmt.Sprintf(format, args...)}
 }
 
@@ -459,7 +459,7 @@ func (f FastLoadError) Error() string {
 	return fmt.Sprintf("fast load error: %s", f.Msg)
 }
 
-func NewFastLoadError(format string, args ...interface{}) error {
+func NewFastLoadError(format string, args ...any) error {
 	return FastLoadError{Msg: fmt.Sprintf(format, args...)}
 }
 
@@ -480,7 +480,7 @@ type AuditError struct {
 	Msg string
 }
 
-func NewAuditError(format string, args ...interface{}) error {
+func NewAuditError(format string, args ...any) error {
 	return AuditError{Msg: fmt.Sprintf(format, args...)}
 }
 
@@ -628,6 +628,6 @@ func (e InviteLinkAcceptanceError) Error() string {
 	return fmt.Sprintf("InviteLinkAcceptanceError: %s", e.Cause)
 }
 
-func NewInviteLinkAcceptanceError(format string, args ...interface{}) InviteLinkAcceptanceError {
+func NewInviteLinkAcceptanceError(format string, args ...any) InviteLinkAcceptanceError {
 	return InviteLinkAcceptanceError{fmt.Errorf(format, args...)}
 }

--- a/go/teams/hidden/errors.go
+++ b/go/teams/hidden/errors.go
@@ -14,7 +14,7 @@ func (e ManagerError) Error() string {
 	return fmt.Sprintf("hidden team manager error: %s", e.note)
 }
 
-func NewManagerError(format string, args ...interface{}) ManagerError {
+func NewManagerError(format string, args ...any) ManagerError {
 	return ManagerError{fmt.Sprintf(format, args...)}
 }
 
@@ -28,7 +28,7 @@ func (e LoaderError) Error() string {
 	return fmt.Sprintf("hidden team loader error: %s", e.note)
 }
 
-func NewLoaderError(format string, args ...interface{}) LoaderError {
+func NewLoaderError(format string, args ...any) LoaderError {
 	return LoaderError{fmt.Sprintf(format, args...)}
 }
 
@@ -42,7 +42,7 @@ func (e GenerateError) Error() string {
 	return fmt.Sprintf("hidden team generate error: %s", e.note)
 }
 
-func NewGenerateError(format string, args ...interface{}) GenerateError {
+func NewGenerateError(format string, args ...any) GenerateError {
 	return GenerateError{fmt.Sprintf(format, args...)}
 }
 
@@ -56,7 +56,7 @@ func (e RatchetError) Error() string {
 	return fmt.Sprintf("hidden team ratchet error: %s", e.note)
 }
 
-func newRatchetError(format string, args ...interface{}) RatchetError {
+func newRatchetError(format string, args ...any) RatchetError {
 	return RatchetError{fmt.Sprintf(format, args...)}
 }
 
@@ -106,7 +106,7 @@ func (e TombstonedError) Error() string {
 	return fmt.Sprintf("hidden team tombstoned error: %s", e.note)
 }
 
-func NewTombstonedError(format string, args ...interface{}) TombstonedError {
+func NewTombstonedError(format string, args ...any) TombstonedError {
 	return TombstonedError{fmt.Sprintf(format, args...)}
 }
 

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -396,11 +396,11 @@ func newImplicitTeamCache(g *libkb.GlobalContext) *implicitTeamCache {
 	}
 }
 
-func (i *implicitTeamCache) Get(key interface{}) (interface{}, bool) {
+func (i *implicitTeamCache) Get(key any) (any, bool) {
 	return i.cache.Get(key)
 }
 
-func (i *implicitTeamCache) Put(key, value interface{}) bool {
+func (i *implicitTeamCache) Put(key, value any) bool {
 	return i.cache.Add(key, value)
 }
 

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -228,7 +228,7 @@ func (l *TeamLoader) ResolveNameToIDUntrusted(ctx context.Context, teamName keyb
 		return resolveNameToIDUntrustedAPICall(ctx, l.G(), teamName, public)
 	}
 
-	var idVoidPointer interface{}
+	var idVoidPointer any
 	key := nameLookupBurstCacheKey{teamName, public}
 	idVoidPointer, err = l.nameLookupBurstCache.Load(ctx, key, l.makeNameLookupBurstCacheLoader(ctx, l.G(), key))
 	if err != nil {
@@ -264,7 +264,7 @@ func resolveNameToIDUntrustedAPICall(ctx context.Context, g *libkb.GlobalContext
 }
 
 func (l *TeamLoader) makeNameLookupBurstCacheLoader(ctx context.Context, g *libkb.GlobalContext, key nameLookupBurstCacheKey) libkb.BurstCacheLoader {
-	return func() (obj interface{}, err error) {
+	return func() (obj any, err error) {
 		id, err := resolveNameToIDUntrustedAPICall(ctx, g, key.teamName, key.public)
 		if err != nil {
 			return nil, err
@@ -1300,16 +1300,16 @@ func (l *TeamLoader) userPreload(ctx context.Context, links []*ChainLinkUnpacked
 // discardCache - the caller should throw out their cached copy and repoll.
 // repoll - hit up merkle for the latest tail
 // Considers:
-// - NeedAdmin
-// - NeedKeyGeneration
-// - NeedApplicationsAtGenerations
-// - WantMembers
-// - ForceRepoll
-// - Cache freshness / StaleOK
-// - NeedSeqnos
-// - JustUpdated
-// - If this user is in global "force repoll" mode, where it would be too spammy to
-//   push out individual team changed notifications, so all team loads need a repoll.
+//   - NeedAdmin
+//   - NeedKeyGeneration
+//   - NeedApplicationsAtGenerations
+//   - WantMembers
+//   - ForceRepoll
+//   - Cache freshness / StaleOK
+//   - NeedSeqnos
+//   - JustUpdated
+//   - If this user is in global "force repoll" mode, where it would be too spammy to
+//     push out individual team changed notifications, so all team loads need a repoll.
 func (l *TeamLoader) load2DecideRepoll(mctx libkb.MetaContext, arg load2ArgT, fromCache Teamer, cachedPolledAt *keybase1.Time) (discardCache bool, repoll bool) {
 	var reason string
 	defer func() {

--- a/go/teams/loader_chain_test.go
+++ b/go/teams/loader_chain_test.go
@@ -192,7 +192,7 @@ func runUnit(t *testing.T, unit TestCase) (lastLoadRet *Team, didRun bool) {
 			}
 			err := json.Unmarshal(link, &outer)
 			require.NoError(t, err)
-			var inner interface{}
+			var inner any
 
 			err = jsonw.EnsureMaxDepthBytesDefault([]byte(outer.PayloadJSON))
 			if err != nil {

--- a/go/teams/loader_ctx_test.go
+++ b/go/teams/loader_ctx_test.go
@@ -338,13 +338,13 @@ func (e *mockError) Error() string {
 	return fmt.Sprintf("error in mock: %s", e.Msg)
 }
 
-func NewMockError(format string, args ...interface{}) error {
+func NewMockError(format string, args ...any) error {
 	return &mockError{
 		Msg: fmt.Sprintf(format, args...),
 	}
 }
 
-func NewMockBoundsError(caller string, keydesc string, key interface{}) error {
+func NewMockBoundsError(caller string, keydesc string, key any) error {
 	return &mockError{
 		Msg: fmt.Sprintf("in %s: key not found (%s) %+v", caller, keydesc, key),
 	}

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -113,7 +113,9 @@ func TestLoaderByName(t *testing.T) {
 // Test loading a team with NeedKeyGeneration set.
 // User A creates a team and rotate the key several times.
 // User B caches the team at generation 1, and then loads with NeedKeyGeneration later.
-//   which should get the latest generation that exists.
+//
+//	which should get the latest generation that exists.
+//
 // User C is a bot and never has access to keys.
 func TestLoaderKeyGen(t *testing.T) {
 	fus, tcs, cleanup := setupNTests(t, 4)
@@ -368,7 +370,7 @@ func TestLoaderWantMembers(t *testing.T) {
 	defer cleanup()
 
 	// Require that a team is at this seqno
-	requireSeqno := func(team *keybase1.TeamData, seqno int, dots ...interface{}) {
+	requireSeqno := func(team *keybase1.TeamData, seqno int, dots ...any) {
 		require.NotNil(t, team, dots...)
 		require.Equal(t, keybase1.Seqno(seqno), TeamSigChainState{inner: team.Chain}.GetLatestSeqno(), dots...)
 	}
@@ -592,7 +594,7 @@ func TestLoaderInferWantMembers(t *testing.T) {
 	defer cleanup()
 
 	// Require that a team is at this seqno
-	requireSeqno := func(team *keybase1.TeamData, seqno int, dots ...interface{}) {
+	requireSeqno := func(team *keybase1.TeamData, seqno int, dots ...any) {
 		require.NotNil(t, team, dots...)
 		require.Equal(t, keybase1.Seqno(seqno), TeamSigChainState{inner: team.Chain}.GetLatestSeqno(), dots...)
 	}

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -1411,7 +1411,7 @@ func TestMemberAddRace(t *testing.T) {
 		return errCh
 	}
 
-	assertNoErr := func(errCh <-chan error, msgAndArgs ...interface{}) {
+	assertNoErr := func(errCh <-chan error, msgAndArgs ...any) {
 		select {
 		case err := <-errCh:
 			require.NoError(t, err, msgAndArgs...)
@@ -1483,7 +1483,7 @@ func TestMemberAddRaceConflict(t *testing.T) {
 		return errCh
 	}
 
-	assertNoErr := func(errCh <-chan error, msgAndArgs ...interface{}) {
+	assertNoErr := func(errCh <-chan error, msgAndArgs ...any) {
 		select {
 		case err := <-errCh:
 			require.NoError(t, err, msgAndArgs...)
@@ -1493,7 +1493,7 @@ func TestMemberAddRaceConflict(t *testing.T) {
 	}
 
 	// Exactly one error comes from the list of channels
-	assertOneErr := func(errChs []<-chan error, msgAndArgs ...interface{}) (retErr error) {
+	assertOneErr := func(errChs []<-chan error, msgAndArgs ...any) (retErr error) {
 		for i, errCh := range errChs {
 			select {
 			case err := <-errCh:

--- a/go/teams/rename.go
+++ b/go/teams/rename.go
@@ -103,7 +103,7 @@ func RenameSubteam(ctx context.Context, g *libkb.GlobalContext, prevName keybase
 		}
 
 		payload := make(libkb.JSONPayload)
-		payload["sigs"] = []interface{}{renameSubteamSig, renameUpPointerSig}
+		payload["sigs"] = []any{renameSubteamSig, renameUpPointerSig}
 		err = ratchetBlindingKeys.AddToJSONPayload(payload)
 		if err != nil {
 			return err

--- a/go/teams/rotate_test.go
+++ b/go/teams/rotate_test.go
@@ -329,7 +329,7 @@ func TestRotateRace(t *testing.T) {
 		return errCh
 	}
 
-	assertNoErr := func(errCh <-chan error, msgAndArgs ...interface{}) {
+	assertNoErr := func(errCh <-chan error, msgAndArgs ...any) {
 		select {
 		case err := <-errCh:
 			require.NoError(t, err, msgAndArgs...)

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1222,7 +1222,7 @@ func (t *Team) deleteSubteam(ctx context.Context) error {
 	}
 
 	payload := make(libkb.JSONPayload)
-	payload["sigs"] = []interface{}{sigParent, sigSub}
+	payload["sigs"] = []any{sigParent, sigSub}
 
 	var ratchetSet hidden.RatchetBlindingKeySet
 	if parentRatchet != nil {
@@ -2495,7 +2495,7 @@ func isTeamBadGenerationError(err error) bool {
 	return libkb.IsAppStatusCode(err, keybase1.StatusCode_SCTeamBadGeneration)
 }
 
-func (t *Team) marshal(incoming interface{}) ([]byte, error) {
+func (t *Team) marshal(incoming any) ([]byte, error) {
 	var data []byte
 	mh := codec.MsgpackHandle{WriteExt: true}
 	enc := codec.NewEncoderBytes(&data, &mh)

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -110,7 +110,7 @@ type txPayload struct {
 	Tag txPayloadTag
 	// txPayload holds either of: *SCTeamInvites or
 	// *keybase1.TeamChangeReq.
-	Val interface{}
+	Val any
 }
 
 func CreateAddMemberTx(t *Team) *AddMemberTx {
@@ -122,7 +122,7 @@ func CreateAddMemberTx(t *Team) *AddMemberTx {
 	}
 }
 
-func (tx *AddMemberTx) DebugPayloads() (res []interface{}) {
+func (tx *AddMemberTx) DebugPayloads() (res []any) {
 	for _, v := range tx.payloads {
 		res = append(res, v.Val)
 	}
@@ -137,7 +137,7 @@ func (tx *AddMemberTx) IsEmpty() bool {
 // of AddMemberTx API. Users of this API should avoid lowercase
 // methods and fields at all cost, even from same package.
 
-func (tx *AddMemberTx) findPayload(tag txPayloadTag, forUID keybase1.UID) interface{} {
+func (tx *AddMemberTx) findPayload(tag txPayloadTag, forUID keybase1.UID) any {
 	minSeqno := 0
 	hasUID := !forUID.IsNil()
 	if hasUID {
@@ -619,10 +619,11 @@ func (a AddMemberCandidate) DebugString() string {
 // ResolveUPKV2FromAssertion itself does not modify the transaction.
 //
 // If your use case is:
-// - you have an assertion,
-// - that should be resolved,
-// - and based on the resolution it should either add it to the transaction or
-//   not,
+//   - you have an assertion,
+//   - that should be resolved,
+//   - and based on the resolution it should either add it to the transaction or
+//     not,
+//
 // this is the way to go.
 //
 // See documentation of AddOrInviteMemberByAssertion to find out what assertion
@@ -832,11 +833,11 @@ func (tx *AddMemberTx) ConsumeInviteByID(ctx context.Context, inviteID keybase1.
 // being added outside of SBS handling. There are two cases in which this
 // function completes an invite:
 //
-// 1) An admin is racing SBS handler by adding a user after they add a proof but
-//    before server sends out SBS notifications.
-// 2) There was more than one social invite that resolved to the same user
-// 3) ...or other cases (or bugs) when there are outstanding invites that
-//    resolve to a user but they were not added through SBS handler.
+//  1. An admin is racing SBS handler by adding a user after they add a proof but
+//     before server sends out SBS notifications.
+//  2. There was more than one social invite that resolved to the same user
+//  3. ...or other cases (or bugs) when there are outstanding invites that
+//     resolve to a user but they were not added through SBS handler.
 //
 // Note that (2) is likely still not handled correctly if there are social
 // invites that someone who is already in the team adds proofs for.

--- a/go/tlfupgrade/tlfupgrade.go
+++ b/go/tlfupgrade/tlfupgrade.go
@@ -44,7 +44,7 @@ func NewBackgroundTLFUpdater(g *libkb.GlobalContext) *BackgroundTLFUpdater {
 	return b
 }
 
-func (b *BackgroundTLFUpdater) debug(ctx context.Context, msg string, args ...interface{}) {
+func (b *BackgroundTLFUpdater) debug(ctx context.Context, msg string, args ...any) {
 	b.G().Log.CDebugf(ctx, "BackgroundTLFUpdater: %s", fmt.Sprintf(msg, args...))
 }
 

--- a/packaging/linux/tuxbot/bot/chatbot/chatbot.go
+++ b/packaging/linux/tuxbot/bot/chatbot/chatbot.go
@@ -105,7 +105,7 @@ type ChatLogger struct {
 
 var _ Logger = (*ChatLogger)(nil)
 
-func (l ChatLogger) msg(format string, args ...interface{}) string {
+func (l ChatLogger) msg(format string, args ...any) string {
 	m := fmt.Sprintf(format, args...)
 	if l.Name == "" {
 		return m
@@ -113,12 +113,12 @@ func (l ChatLogger) msg(format string, args ...interface{}) string {
 	return fmt.Sprintf("`(%s)` %s", l.Name, m)
 }
 
-func (l ChatLogger) VDebug(format string, args ...interface{}) {
+func (l ChatLogger) VDebug(format string, args ...any) {
 	msg := l.msg(format, args...)
 	fmt.Println(msg)
 }
 
-func (l ChatLogger) Debug(format string, args ...interface{}) {
+func (l ChatLogger) Debug(format string, args ...any) {
 	msg := l.msg(format, args...)
 	fmt.Println(msg)
 	if _, err := l.API.SendMessage(l.DebugChannel, msg); err != nil {
@@ -126,7 +126,7 @@ func (l ChatLogger) Debug(format string, args ...interface{}) {
 	}
 }
 
-func (l ChatLogger) Info(format string, args ...interface{}) {
+func (l ChatLogger) Info(format string, args ...any) {
 	if _, err := l.API.SendMessage(l.InfoChannel, l.msg(format, args...)); err != nil {
 		fmt.Printf("unable to SendMessage: %v", err)
 	}

--- a/packaging/linux/tuxbot/bot/chatbot/logger.go
+++ b/packaging/linux/tuxbot/bot/chatbot/logger.go
@@ -5,16 +5,16 @@ import (
 )
 
 type Logger interface {
-	Debug(format string, args ...interface{})
-	Info(format string, args ...interface{})
-	VDebug(format string, args ...interface{})
+	Debug(format string, args ...any)
+	Info(format string, args ...any)
+	VDebug(format string, args ...any)
 	Alert()
 	AlertWith(string)
 }
 
-type LogFn func(format string, args ...interface{})
+type LogFn func(format string, args ...any)
 
-func GenericTraceVerbose(l Logger, s string, f func() (interface{}, error), okLog LogFn, errLog LogFn) func() {
+func GenericTraceVerbose(l Logger, s string, f func() (any, error), okLog LogFn, errLog LogFn) func() {
 	pc, _, _, ok := runtime.Caller(2)
 	details := runtime.FuncForPC(pc)
 	name := "unknown function"
@@ -32,22 +32,22 @@ func GenericTraceVerbose(l Logger, s string, f func() (interface{}, error), okLo
 	}
 }
 
-func InfoTraceVerbose(l Logger, s string, f func() (interface{}, error)) func() {
+func InfoTraceVerbose(l Logger, s string, f func() (any, error)) func() {
 	return GenericTraceVerbose(l, s, f, l.Info, l.Info)
 }
 
-func DebugTraceResult(l Logger, f func() (interface{}, error)) func() {
+func DebugTraceResult(l Logger, f func() (any, error)) func() {
 	return GenericTraceVerbose(l, "", f, l.Debug, l.Debug)
 }
 
 func DebugTrace(l Logger, f func() error) func() {
-	return GenericTraceVerbose(l, "", func() (interface{}, error) { return nil, f() }, l.Debug, l.Debug)
+	return GenericTraceVerbose(l, "", func() (any, error) { return nil, f() }, l.Debug, l.Debug)
 }
 
-func DebugTraceVerbose(l Logger, s string, f func() (interface{}, error)) func() {
+func DebugTraceVerbose(l Logger, s string, f func() (any, error)) func() {
 	return GenericTraceVerbose(l, s, f, l.Debug, l.Debug)
 }
 
-func FunctionTraceVerbose(l Logger, s string, f func() (interface{}, error)) func() {
+func FunctionTraceVerbose(l Logger, s string, f func() (any, error)) func() {
 	return GenericTraceVerbose(l, s, f, l.Debug, l.Info)
 }

--- a/packaging/linux/tuxbot/bot/docker-cleanup/main.go
+++ b/packaging/linux/tuxbot/bot/docker-cleanup/main.go
@@ -117,7 +117,7 @@ func main2() error {
 		return err
 	}
 	var cfg struct {
-		Variants map[string]interface{} `json:"variants"`
+		Variants map[string]any `json:"variants"`
 	}
 	if err := json.NewDecoder(configRes.Body).Decode(&cfg); err != nil {
 		return err
@@ -133,7 +133,7 @@ func main2() error {
 		Client: &http.Client{
 			Transport: registry.WrapTransport(http.DefaultTransport, "https://registry-1.docker.io", *username, *password),
 		},
-		Logf: func(format string, args ...interface{}) {},
+		Logf: func(format string, args ...any) {},
 	}
 	if err := hub.Ping(); err != nil {
 		return err

--- a/packaging/linux/tuxbot/bot/tuxbot/tuxbot.go
+++ b/packaging/linux/tuxbot/bot/tuxbot/tuxbot.go
@@ -78,7 +78,7 @@ func (c Tuxbot) Dispatch(msg chat1.MsgSummary, args []string) (err error) {
 
 	// Defer deferment so we don't spam logs with non-commands
 	cmd := fmt.Sprintf("%s(%s)", command, strings.Join(args, ", "))
-	defer chatbot.InfoTraceVerbose(c, cmd, func() (interface{}, error) { return nil, err })()
+	defer chatbot.InfoTraceVerbose(c, cmd, func() (any, error) { return nil, err })()
 
 	currentUser, err := user.Current()
 	if err != nil {


### PR DESCRIPTION
Rewrites `interface{}` to `any` using `gofmt`

[_Created by Sourcegraph batch change `christine/Go-upgrade-type`._](https://demo.sourcegraph.com/users/christine/batch-changes/Go-upgrade-type)